### PR TITLE
更正连接号的格式 (issue#12)

### DIFF
--- a/10economic-research-journal.csl
+++ b/10economic-research-journal.csl
@@ -16,7 +16,7 @@
     <contributor>
         <name>牛耕田</name>
         <email>buffalo_d@163.com</email>
-    </contributor>   
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Economic Research Journal author-date style</summary>
@@ -31,16 +31,16 @@
         <single>p.</single>
         <multiple>pp.</multiple>
       </term>
-       <term name="page-range-delimiter">—</term>
+       <term name="page-range-delimiter">&#x2014;</term>
     </terms>
   </locale>
   <locale xml:lang="en">
     <terms>
-      <term name="page-range-delimiter">—</term>
+      <term name="page-range-delimiter">&#x2014;</term>
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -134,7 +134,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -168,7 +168,7 @@
       </if>
     </choose>
   </macro>
-<!-- 中文出版社 --> 
+<!-- 中文出版社 -->
 <macro name="publishing-cn">
     <choose>
       <if variable="publisher">
@@ -178,7 +178,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-     <!--   <text variable="page" prefix=": "/>--> 
+     <!--   <text variable="page" prefix=": "/>-->
       <text macro="issue-date-year" prefix="，" suffix="年"/>
       </if>
     </choose>
@@ -188,20 +188,20 @@
         <text variable="volume" prefix=""/>
         <text variable="issue" prefix="(" suffix=")"/>
     </group>
-    <text variable="page" prefix=", "/><!--  期不显示--> 
-    
+    <text variable="page" prefix=", "/><!--  期不显示-->
+
   </macro>
-  
+
  <macro name="serial-information-cn">
     <group delimiter="">
         <!--<text macro="issue-date-year" suffix="年"/>-->
        <!-- <text variable="volume" prefix=""/> -->
        <text variable="issue" prefix="第" suffix="期"/>
     </group>
-    
+
     <!--  <text variable="page" prefix=": "/>-->
   </macro>
-  
+
   <macro name="title">
     <text variable="title" text-case="" prefix="“" suffix="”"/>
     <!-- comment <text variable="number" prefix=": "/> -->
@@ -344,7 +344,7 @@
   </citation>
   <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" line-spacing="1" hanging-indent="true">
     <sort>
-        <key variable="language" sort="ascending"/> 
+        <key variable="language" sort="ascending"/>
         <key macro="author-intext"/>
         <key macro="issue-date-year" sort="ascending"/>
     </sort>

--- a/11yuzuc-at-title-at-author-at-year.csl
+++ b/11yuzuc-at-title-at-author-at-year.csl
@@ -32,7 +32,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -83,7 +83,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>

--- a/12financial-research-journal.csl
+++ b/12financial-research-journal.csl
@@ -30,16 +30,16 @@
         <single>p.</single>
         <multiple>pp.</multiple>
       </term>
-      <term name="page-range-delimiter">—</term>
+      <term name="page-range-delimiter">&#x2014;</term>
     </terms>
   </locale>
   <locale xml:lang="en">
     <terms>
-      <term name="page-range-delimiter">—</term>
+      <term name="page-range-delimiter">&#x2014;</term>
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -133,7 +133,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>

--- a/13gb-t-7714-2015-author-date-ynu.csl
+++ b/13gb-t-7714-2015-author-date-ynu.csl
@@ -38,7 +38,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -117,7 +117,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>

--- a/14tcsae.csl
+++ b/14tcsae.csl
@@ -28,7 +28,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -79,7 +79,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -192,7 +192,7 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="article-journal article-magazine article-newspaper" match="any">
           <group prefix=". ">
             <choose>
@@ -235,7 +235,7 @@
      <text macro="bib-entry"/>
     </layout>
     <layout suffix=".">
-     <text variable="citation-number" prefix="[" suffix="] "/> 
+     <text variable="citation-number" prefix="[" suffix="] "/>
      <text macro="bib-entry"/>
      <text variable="title-short" display="block"  prefix="."/>
     </layout>

--- a/15bmj.csl
+++ b/15bmj.csl
@@ -37,7 +37,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -132,7 +132,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -228,7 +228,7 @@
     </group>
   </macro>
   <macro name="bib-entry-cn" >
-  <text variable="citation-number" prefix="[" suffix="] "/> 
+  <text variable="citation-number" prefix="[" suffix="] "/>
       <text macro="author-cn" suffix=". "/>
       <text macro="title" text-case=""/>
       <choose>
@@ -247,7 +247,7 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="article-journal article-magazine article-newspaper" match="any">
           <group prefix=". ">
             <choose>
@@ -262,7 +262,7 @@
                 </choose>
                 <text macro="serial-information" prefix=", "/>
               </if>
-               
+
               <else>
                 <text macro="serial-information" suffix=". "/>
                 <text macro="publishing"/>
@@ -281,7 +281,7 @@
       <text macro="accessed-date"/>
   </macro>
   <macro name="bib-entry-en" >
-  <text variable="citation-number" prefix="[" suffix="] "/> 
+  <text variable="citation-number" prefix="[" suffix="] "/>
       <text macro="author-en" suffix=". "/>
       <text macro="title" text-case="title"/>
       <choose>
@@ -300,7 +300,7 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="article-journal article-magazine article-newspaper" match="any">
           <group prefix=". ">
             <choose>
@@ -362,7 +362,7 @@
         </group>
 <!--       <group vertical-align="sup">
           <text  variable="citation-number" prefix="[" suffix="]"/>
-        </group>--> 
+        </group>-->
       </group>
     </layout>
   </citation>

--- a/1gb-t-7714-2015-numeric-no-date-url.csl
+++ b/1gb-t-7714-2015-numeric-no-date-url.csl
@@ -33,8 +33,13 @@
       </term>
     </terms>
   </locale>
+  <locale>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -85,7 +90,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -154,7 +159,7 @@
       <else-if type="patent">
         <text value="P"/>
       </else-if>
-      <else-if type="post-weblog webpage" match="any"> 
+      <else-if type="post-weblog webpage" match="any">
         <text value="OL"/><!-- 网页改为OL-->
       </else-if>
       <else-if type="report">
@@ -173,7 +178,7 @@
     <text variable="number" prefix=": "/>
     <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-code"/>
-      <!-- 
+      <!--
       <choose>
         <if variable="URL">
           <text value="OL"/>
@@ -254,13 +259,13 @@
             <text macro="publishing" prefix=". "/>
             <text macro="issued-date" prefix=".(" suffix=")"/>
             <text variable="URL"  prefix=". "/>
-          </else-if> 
+          </else-if>
           <else>
             <text macro="publishing" prefix=". "/>
             <text macro="issued-date" prefix="(" suffix=")"/>
           </else>
         </choose>
-       <!-- 
+       <!--
         <text macro="accessed-date"/>
         <group delimiter=". " prefix=". ">
           <text variable="URL"/>

--- a/3cas-like-thesis-zotero-ask.csl
+++ b/3cas-like-thesis-zotero-ask.csl
@@ -31,7 +31,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -110,7 +110,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -197,7 +197,7 @@
     <text variable="title" text-case=""/>
 
     <!--  <text variable="number" prefix=": "/> -->
-    
+
     <!-- <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-code"/>
       <choose>
@@ -208,7 +208,7 @@
     </group>-->
   </macro>
   <macro name="bib-entry-cn" >
-   <text variable="citation-number" prefix="" suffix=". "/> 
+   <text variable="citation-number" prefix="" suffix=". "/>
       <text macro="author" suffix=". "/>
       <text macro="title" text-case=""/>
       <choose>
@@ -226,10 +226,10 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="thesis"><!--学位论文-->
               <group prefix=". ">
-                
+
                    <!-- <text macro="serial-information" suffix=". "/>-->
                    <group delimiter="">
                       <text variable="genre" prefix="[" suffix="学位论文]. "/>
@@ -284,7 +284,7 @@
   </citation>
   <bibliography entry-spacing="0" et-al-min="3" et-al-use-first="3" line-spacing="1" second-field-align="flush">
    <sort>
-     <key variable="language" sort="ascending"/> 
+     <key variable="language" sort="ascending"/>
     </sort>
    <layout>
     <text macro="bib-entry-cn" suffix=""/>

--- a/3cas-like-thesis.csl
+++ b/3cas-like-thesis.csl
@@ -34,7 +34,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -113,7 +113,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -200,7 +200,7 @@
     <text variable="title" text-case=""/>
 
     <!--  <text variable="number" prefix=": "/> -->
-    
+
     <!-- <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-code"/>
       <choose>
@@ -211,7 +211,7 @@
     </group>-->
   </macro>
   <macro name="bib-entry-cn" >
-   <text variable="citation-number" prefix="" suffix=". "/> 
+   <text variable="citation-number" prefix="" suffix=". "/>
       <text macro="author" suffix=". "/>
       <text macro="title" text-case=""/>
       <choose>
@@ -229,10 +229,10 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="thesis"><!--学位论文-->
               <group prefix=". ">
-                
+
                    <!-- <text macro="serial-information" suffix=". "/>-->
                    <group delimiter="">
                       <text variable="genre" prefix="[" suffix="学位论文]. "/>
@@ -269,7 +269,7 @@
       <!--<text macro="accessed-date"/> 访问日期-->
   </macro>
    <macro name="bib-entry-en" >
-   <text variable="citation-number" prefix="" suffix=". "/> 
+   <text variable="citation-number" prefix="" suffix=". "/>
       <text macro="author" suffix=". "/>
       <text macro="title" text-case=""/>
       <choose>
@@ -287,10 +287,10 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="thesis"><!--学位论文-->
               <group prefix=". ">
-                
+
                    <!-- <text macro="serial-information" suffix=". "/>-->
                    <group delimiter="">
                       <text variable="genre" prefix="(" suffix="dissertation). "/>
@@ -304,11 +304,11 @@
             </else-if><!--学位论文-->
         <else-if type="article-journal article-magazine article-newspaper" match="any">
           <group prefix=". ">
-           
+
                 <text variable="container-title" font-weight="bold" suffix=". " text-case="title"/>
                 <text macro="serial-information" suffix=". "/>
                 <text macro="publishing"/>
-           
+
           </group>
         </else-if>
         <else-if type="patent">
@@ -349,7 +349,7 @@
   </citation>
   <bibliography entry-spacing="0" et-al-min="3" et-al-use-first="3" line-spacing="1" second-field-align="flush">
    <sort>
-     <key variable="language" sort="ascending"/> 
+     <key variable="language" sort="ascending"/>
     </sort>
     <layout locale="en">
     <text macro="bib-entry-en" suffix=""/>

--- a/4zuel-thesis.csl
+++ b/4zuel-thesis.csl
@@ -36,7 +36,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -115,7 +115,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>

--- a/5swu-thesis.csl
+++ b/5swu-thesis.csl
@@ -48,7 +48,7 @@
   </locale>
 
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -127,7 +127,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -223,7 +223,7 @@
     </group>
   </macro>
   <macro name="bib-full">
-  <text variable="citation-number" prefix="[" suffix="] "/> 
+  <text variable="citation-number" prefix="[" suffix="] "/>
     <text macro="author" suffix=". "/>
     <text macro="title"/>
     <choose>

--- a/6cma.csl
+++ b/6cma.csl
@@ -31,7 +31,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="&#8211;" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -82,7 +82,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="&#8211;">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>

--- a/7comparative-economic-and-social-systems.csl
+++ b/7comparative-economic-and-social-systems.csl
@@ -15,7 +15,7 @@
     <contributor>
         <name>牛耕田</name>
         <email>buffalo_d@163.com</email>
-    </contributor>   
+    </contributor>
     <contributor>
       <name>Raymond</name>
     </contributor>
@@ -36,7 +36,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -130,7 +130,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -164,7 +164,7 @@
       </if>
     </choose>
   </macro>
-  
+
   <macro name="serial-information">
     <group delimiter=", " prefix=". ">
       <text variable="volume"/>
@@ -172,17 +172,17 @@
     <text variable="issue" prefix="(" suffix=")"/>
     <text variable="page" prefix=": "/>
   </macro>
-  
+
  <macro name="serial-information-cn">
     <group delimiter=", ">
         <text macro="issue-date-year" suffix=""/>
        <!-- <text variable="volume" prefix=""/> -->
        <text variable="issue" prefix="" suffix=""/>
     </group>
-    
+
     <text variable="page" prefix=": "/>
   </macro>
-  
+
   <macro name="title">
     <text variable="title" text-case="" prefix="“" suffix=".”"/>
     <!-- comment <text variable="number" prefix=": "/> -->
@@ -309,7 +309,7 @@
   </citation>
   <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" line-spacing="1" hanging-indent="true">
     <sort>
-        <key variable="language" sort="ascending"/> 
+        <key variable="language" sort="ascending"/>
         <key macro="author-intext"/>
         <key macro="issue-date-year" sort="ascending"/>
     </sort>

--- a/9journal-of-management-world.csl
+++ b/9journal-of-management-world.csl
@@ -15,7 +15,7 @@
     <contributor>
         <name>牛耕田</name>
         <email>buffalo_d@163.com</email>
-    </contributor>   
+    </contributor>
     <contributor>
       <name>Raymond</name>
     </contributor>
@@ -42,7 +42,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -136,7 +136,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -170,7 +170,7 @@
       </if>
     </choose>
   </macro>
-<!-- 中文出版社 --> 
+<!-- 中文出版社 -->
 <macro name="publishing-cn">
     <choose>
       <if variable="publisher">
@@ -180,7 +180,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-     <!--   <text variable="page" prefix=": "/>--> 
+     <!--   <text variable="page" prefix=": "/>-->
       <text macro="issue-date-year" prefix="，" suffix="年"/>
       </if>
     </choose>
@@ -190,20 +190,20 @@
         <text variable="volume" prefix=""/>
         <text variable="issue" prefix="(" suffix=")"/>
     </group>
-    <text variable="page" prefix=", pp. "/><!--  期不显示--> 
-    
+    <text variable="page" prefix=", pp. "/><!--  期不显示-->
+
   </macro>
-  
+
  <macro name="serial-information-cn">
     <group delimiter="">
         <text macro="issue-date-year" suffix="年"/>
        <!-- <text variable="volume" prefix=""/> -->
        <text variable="issue" prefix="第" suffix="期"/>
     </group>
-    
+
     <!--  <text variable="page" prefix=": "/>-->
   </macro>
-  
+
   <macro name="title">
     <text variable="title" text-case="" prefix="“" suffix="”"/>
     <!-- comment <text variable="number" prefix=": "/> -->
@@ -281,7 +281,7 @@
   <!-- 中文文末显示设置-->
   <macro name="bib-full" suffix="。">
     <text macro="author-cn" suffix="："/>
-   
+
     <text macro="title-cn"/>
     <choose>
       <if type="book bill chapter legislation paper-conference report" match="any">
@@ -359,7 +359,7 @@
   </citation>
   <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" line-spacing="1" hanging-indent="true">
     <sort>
-        <key variable="language" sort="ascending"/> 
+        <key variable="language" sort="ascending"/>
         <key macro="author-intext"/>
         <key macro="issue-date-year" sort="ascending"/>
     </sort>

--- a/china-national-standard-gb-t-7714-2015-author-date-aulower-bilan.csl
+++ b/china-national-standard-gb-t-7714-2015-author-date-aulower-bilan.csl
@@ -32,8 +32,13 @@
       </term>
     </terms>
   </locale>
+  <locale>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -112,7 +117,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>

--- a/china-national-standard-gb-t-7714-2015-note-noibid.csl
+++ b/china-national-standard-gb-t-7714-2015-note-noibid.csl
@@ -32,8 +32,13 @@
       <!-- <term name="container-author" form="verb-short">著</term> -->
     </terms>
   </locale>
+  <locale>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="&#8211;" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -85,7 +90,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="&#8211;">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -234,7 +239,7 @@
             <text variable="DOI" prefix="DOI:"/>
           </group>
   </macro>
-  
+
   <citation et-al-min="4" et-al-use-first="3" disambiguate-add-names="true">
     <layout locale="en" suffix="." delimiter="; ">
     <!---->

--- a/china-national-standard-gb-t-7714-2015-numeric-aulower-bilan-nodoi.csl
+++ b/china-national-standard-gb-t-7714-2015-numeric-aulower-bilan-nodoi.csl
@@ -27,8 +27,13 @@
       </term>
     </terms>
   </locale>
+  <locale>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -79,7 +84,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -175,7 +180,7 @@
     </group>
   </macro>
   <macro name="bib-entry" >
-  <text variable="citation-number" prefix="[" suffix="] "/> 
+  <text variable="citation-number" prefix="[" suffix="] "/>
       <text macro="author" suffix=". "/>
       <text macro="title" text-case=""/>
       <choose>
@@ -194,7 +199,7 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="article-journal article-magazine article-newspaper" match="any">
           <group prefix=". ">
             <choose>

--- a/china-national-standard-gb-t-7714-2015-numeric-aulower-bilan.csl
+++ b/china-national-standard-gb-t-7714-2015-numeric-aulower-bilan.csl
@@ -27,8 +27,13 @@
       </term>
     </terms>
   </locale>
+  <locale>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -79,7 +84,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>

--- a/china-national-standard-gb-t-7714-2015-numeric-pageout.csl
+++ b/china-national-standard-gb-t-7714-2015-numeric-pageout.csl
@@ -32,8 +32,13 @@
       </term>
     </terms>
   </locale>
+  <locale>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -84,7 +89,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>

--- a/china-national-standard-gb-t-7714-2015-numeric.csl
+++ b/china-national-standard-gb-t-7714-2015-numeric.csl
@@ -26,8 +26,13 @@
       </term>
     </terms>
   </locale>
+  <locale>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="&#8211;" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -78,7 +83,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="&#8211;">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>

--- a/gb-t-7714-2015-author-date-aulower-bilan-nodoi.csl
+++ b/gb-t-7714-2015-author-date-aulower-bilan-nodoi.csl
@@ -15,7 +15,7 @@
     <contributor>
       <name>韩小土</name>
       <email>redleafnew@163.com</email>
-    </contributor>   
+    </contributor>
     <contributor>
       <name>Raymond</name>
     </contributor>
@@ -35,8 +35,13 @@
       </term>
     </terms>
   </locale>
+  <locale>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -115,7 +120,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>

--- a/gb-t-7714-2015-numeric-aulower-bilan-ce.csl
+++ b/gb-t-7714-2015-numeric-aulower-bilan-ce.csl
@@ -27,8 +27,13 @@
       </term>
     </terms>
   </locale>
+  <locale>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -79,7 +84,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -192,7 +197,7 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="article-journal article-magazine article-newspaper" match="any">
           <group prefix=". ">
             <choose>
@@ -235,7 +240,7 @@
      <text macro="bib-entry"/>
     </layout>
     <layout suffix=".">
-     <text variable="citation-number" prefix="[" suffix="] "/> 
+     <text variable="citation-number" prefix="[" suffix="] "/>
      <text macro="bib-entry"/>
      <text variable="title-short" display="block"  prefix="."/>
     </layout>

--- a/gb-t-7714-2015-numeric-aulower-bilan.csl
+++ b/gb-t-7714-2015-numeric-aulower-bilan.csl
@@ -31,8 +31,13 @@
       </term>
     </terms>
   </locale>
+  <locale>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -83,7 +88,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -179,7 +184,7 @@
     </group>
   </macro>
   <macro name="bib-entry" >
-  <text variable="citation-number" prefix="[" suffix="] "/> 
+  <text variable="citation-number" prefix="[" suffix="] "/>
       <text macro="author" suffix=". "/>
       <text macro="title" text-case=""/>
       <choose>
@@ -197,7 +202,7 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="article-journal article-magazine article-newspaper" match="any">
           <group prefix=". ">
             <choose>

--- a/gb-t-7714-2015-numeric-auup-bilan-ce.csl
+++ b/gb-t-7714-2015-numeric-auup-bilan-ce.csl
@@ -27,8 +27,13 @@
       </term>
     </terms>
   </locale>
+  <locale>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -79,7 +84,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -192,7 +197,7 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="article-journal article-magazine article-newspaper" match="any">
           <group prefix=". ">
             <choose>
@@ -235,7 +240,7 @@
      <text macro="bib-entry"/>
     </layout>
     <layout suffix=".">
-     <text variable="citation-number" prefix="[" suffix="] "/> 
+     <text variable="citation-number" prefix="[" suffix="] "/>
      <text macro="bib-entry"/>
      <text variable="title-short" display="block"  prefix="."/>
     </layout>

--- a/hzau-thesis.csl
+++ b/hzau-thesis.csl
@@ -32,7 +32,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -111,7 +111,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -198,7 +198,7 @@
     <text variable="title" text-case=""/>
 
     <!--  <text variable="number" prefix=": "/> -->
-    <!-- 
+    <!--
     <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-code"/>
       <choose>
@@ -209,7 +209,7 @@
     </group>-->
   </macro>
   <macro name="bib-entry-cn" >
-   <text variable="citation-number" prefix="" suffix=". "/> 
+   <text variable="citation-number" prefix="" suffix=". "/>
       <text macro="author" suffix=". "/>
       <text macro="title" text-case=""/>
       <choose>
@@ -227,10 +227,10 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="thesis"><!--学位论文-->
               <group prefix=". ">
-                
+
                    <!-- <text macro="serial-information" suffix=". "/>-->
                    <group delimiter="">
                       <text variable="genre" prefix="[" suffix="学位论文]. "/>
@@ -267,7 +267,7 @@
       <!--<text macro="accessed-date"/> 访问日期-->
   </macro>
    <macro name="bib-entry-en" >
-   <text variable="citation-number" prefix="" suffix=". "/> 
+   <text variable="citation-number" prefix="" suffix=". "/>
       <text macro="author" suffix=". "/>
       <text macro="title" text-case=""/>
       <choose>
@@ -285,10 +285,10 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="thesis"><!--学位论文-->
               <group prefix=". ">
-                
+
                    <!-- <text macro="serial-information" suffix=". "/>-->
                    <group delimiter="">
                       <text variable="genre" prefix="(" suffix="dissertation). "/>
@@ -353,7 +353,7 @@
   </citation>
   <bibliography entry-spacing="0" et-al-min="21" et-al-use-first="20" line-spacing="1" second-field-align="flush">
    <sort>
-     <key variable="language" sort="ascending"/> 
+     <key variable="language" sort="ascending"/>
     </sort>
     <layout locale="en">
     <text macro="bib-entry-en" suffix=""/>

--- a/njau-thesis.csl
+++ b/njau-thesis.csl
@@ -32,7 +32,7 @@
     </terms>
   </locale>
   <macro name="accessed-date">
-    <date variable="accessed" delimiter="–" prefix="[" suffix="]">
+    <date variable="accessed" delimiter="-" prefix="[" suffix="]">
       <date-part name="year"/>
       <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="day" form="numeric-leading-zeros"/>
@@ -83,7 +83,7 @@
   <macro name="issued-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" delimiter="–">
+        <date variable="issued" delimiter="-">
           <date-part name="year"/>
           <date-part name="month" form="numeric-leading-zeros"/>
           <date-part name="day" form="numeric-leading-zeros"/>
@@ -171,7 +171,7 @@
     <text variable="number" prefix=": "/>
     <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-code"/>
-     <!-- 
+     <!--
        <choose>
         <if variable="URL">
           <text value="OL"/>
@@ -181,7 +181,7 @@
     </group>
   </macro>
   <macro name="bib-entry" >
-  <!--  <text variable="citation-number" prefix="[" suffix="]"/> --> 
+  <!--  <text variable="citation-number" prefix="[" suffix="]"/> -->
       <text macro="author" suffix=". "/>
       <text macro="title" text-case=""/>
       <choose>
@@ -199,7 +199,7 @@
           </choose>
           <text macro="edition" suffix=". "/>
           <text macro="publishing"/>
-        </if> 
+        </if>
         <else-if type="paper-conference" match="any"><!-- 会议论文-->
             <text macro="editor" prefix=". "/>
             <choose>
@@ -233,7 +233,7 @@
         <else-if type="patent">
           <text macro="issued-date" prefix=". "/>
         </else-if>
-        <else-if type="post-weblog webpage" match="any"> <!--webpage添加访问日期显示--> 
+        <else-if type="post-weblog webpage" match="any"> <!--webpage添加访问日期显示-->
           <group prefix=". ">
             <text macro="container-title" prefix=". " suffix=". "/>
             <text macro="issued-date" prefix="(" suffix=")"/>
@@ -246,9 +246,9 @@
           <text macro="issued-date" prefix="(" suffix=")"/>
         </else>
       </choose>
-     <!-- 
+     <!--
       <text macro="accessed-date"/>
-     --> <!--删除访问日期显示--> 
+     --> <!--删除访问日期显示-->
   </macro>
   <citation collapse="citation-number" after-collapse-delimiter=",">
     <sort>


### PR DESCRIPTION
1. 全部 `macro[name="accessed-date"]` 和 `macro[name="issued-date"]` 中 date 的 delimiter 设成了 en dash。
2. `china-national-standard-gb-t-7714-2015-*.csl` 和 `gb-t-7714-2015-*.csl` 中添加了 `<term name="page-range-delimiter">-</term>`，其余的未改。
3. 全部的 em dash 改成了 `&#x2014;` 的形式。