### PR TITLE
维护：增加自动管理 issue 的工作流

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: retorquere/label-gun@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          label.awaiting: "waiting-for-response-from-contributor"
+          label.awaiting: "等待贡献者回复"
 
   stable:
     if: github.event_name == 'schedule'
@@ -31,11 +31,11 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 60
+          days-before-issue-stale: 360
           days-before-issue-close: 7
-          stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          stale-issue-label: "过期"
+          stale-issue-message: "该 issue 已被标记为「过期」，因为已经超过 360 天没有活动。"
+          close-issue-message: "该 issue 已关闭，因为它被标记为「过期」后 7 天内仍一直处于非活动状态。"
           exempt-issue-labels: "help wanted"
           days-before-pr-stale: -1
           days-before-pr-close: -1

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -1,0 +1,42 @@
+name: issue-bot
+
+on:
+  issues:
+    types: [opened, edited, closed]
+  issue_comment:
+    types: [created, edited]
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions: {}
+
+jobs:
+  label:
+    permissions:
+      issues: write # to add label to an issues (retorquere/label-gun)
+      pull-requests: write # to add label, comment on pull request (retorquere/label-gun)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: retorquere/label-gun@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          label.awaiting: "waiting-for-response-from-contributor"
+
+  stable:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          exempt-issue-labels: "help wanted"
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
1. 类似 csl 官方仓库，当维护者回复后，自动添加“waiting-for-response-from-contributor”标签，得到回复后，移除该标签。
2. issue 无活动超过 60 天时，标记为 “stable”，再之后 7 天仍无活动的自动关闭。

这可能有助于减轻一些管理维护负担。