### PR TITLE
Update acta-horticulturae-sinica.csl

### DIFF
--- a/src/acta-horticulturae-sinica/acta-horticulturae-sinica.csl
+++ b/src/acta-horticulturae-sinica/acta-horticulturae-sinica.csl
@@ -126,7 +126,7 @@
   </macro>
   <macro name="author-sort">
     <choose>
-      <if type="original-author">
+      <if variable="original-author">
         <text macro="author-ZHtoEN"/>
       </if>
       <else>
@@ -175,13 +175,13 @@
       </choose>
     </group>
     <choose>
-      <if type="thesis" prefix="[" suffix="]">
+      <if type="thesis">
         <choose>
           <if variable="genre">
-            <text variable="genre" text-case="capitalize-first"/>
+            <text variable="genre" text-case="capitalize-first"  prefix="[" suffix="]"/>
           </if>
           <else>
-            <text term="thesis" text-case="capitalize-first"/>
+            <text term="thesis" text-case="capitalize-first"  prefix="[" suffix="]"/>
           </else>
         </choose>
       </if>
@@ -224,13 +224,13 @@
       </choose>
     </group>
     <choose>
-      <if type="thesis" prefix="[" suffix="]">
+      <if type="thesis">
         <choose>
           <if variable="genre">
-            <text variable="genre" text-case="capitalize-first"/>
+            <text variable="genre" text-case="capitalize-first" prefix="[" suffix="]"/>
           </if>
           <else>
-            <text term="thesis" text-case="capitalize-first"/>
+            <text term="thesis" text-case="capitalize-first" prefix="[" suffix="]"/>
           </else>
         </choose>
       </if>


### PR DESCRIPTION
# 找到了2个问题 #444 

1. 书目不能按照作者的姓按字母排序，排查发现是if条件写错了，已修改。

2. 硕士/博士学位论文的前/后置方括号不能正确显示，已经补充在了text标签上

# 一个问题

此外想请教一下csl文件能否识别gener具体的值来生成不同的文字，根据代码

```xml
<locale xml:lang="en">
    <terms>
      <term name="thesis">Ph. D. Dissertation</term>
    </terms>
  </locale>
  <locale xml:lang="zh">
    <terms>
      <term name="thesis">博士论文</term>
    </terms>
  </locale>

...

<choose>
      <if type="thesis">
        <choose>
          <if variable="genre">
            <text variable="genre" text-case="capitalize-first" prefix="[" suffix="]"/>
          </if>
          <else>
            <text term="thesis" text-case="capitalize-first" prefix="[" suffix="]"/>
          </else>
        </choose>
      </if>
    </choose>
```

只能为博士论文自动添加[博士论文]和[Ph. D. Dissertation]

但是我希望能够根据gener的值自动填写内容，如果是“博士学位论文”，则为中文书目增加[博士论文]，英文书目增加[Ph. D. Dissertation]；如果是“硕士学位论文”，则为中文书目增加[硕士论文]，英文书目增加[M. D. Dissertation]。