### PR TITLE
添加Schema以验证CSL；按CSL规范修改数字变量的标签

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/locales"]
 	path = lib/locales
 	url = https://github.com/citation-style-language/locales.git
+[submodule "lib/schema"]
+	path = lib/schema
+	url = https://github.com/zotero-chinese/csl-m-schema-rng

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,8 +29,8 @@
   "xml.preferences.quoteStyle": "double",
   "xml.fileAssociations": [
     {
-      "systemId": "https://github.com/citation-style-language/schema/blob/master/schemas/styles/csl.rnc",
-      "pattern": "**/*.csl"
+      "pattern": "**/*.csl",
+      "systemId": "${workspaceFolder}/lib/schema/generated-schemas/merged/csl-mlz.rng"
     }
   ],
 
@@ -40,5 +40,7 @@
   "files.exclude": {
     // "node_modules":true,
     // "**/LICENSE": true
-  }
+  },
+
+  "git.autofetch": true
 }

--- a/src/GB-T-7714—1987（顺序编码，双语）/GB-T-7714—1987（顺序编码，双语）.csl
+++ b/src/GB-T-7714—1987（顺序编码，双语）/GB-T-7714—1987（顺序编码，双语）.csl
@@ -106,7 +106,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -142,11 +142,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -258,7 +258,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <date variable="issued" form="numeric"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -267,11 +267,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <date variable="issued" form="numeric" date-parts="year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -286,7 +286,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -294,9 +294,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <date variable="issued" form="numeric" date-parts="year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -307,7 +307,7 @@
           <group delimiter=", ">
             <text macro="patent-country"/>
             <text variable="genre"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <date variable="issued" form="numeric"/>
         </group>
@@ -426,7 +426,7 @@
           <text macro="container-booklike-en"/>
           <text macro="edition"/>
           <text macro="publisher"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </else-if>
         <else>
           <!-- 3.1 专著 -->
@@ -443,7 +443,7 @@
               <text macro="series"/>
               <text macro="notes"/>
               <text macro="document-standard-number"/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </group>
         </else>
@@ -489,7 +489,7 @@
           <text macro="container-booklike-zh"/>
           <text macro="edition"/>
           <text macro="publisher"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </else-if>
         <else>
           <!-- 3.1 专著 -->
@@ -506,7 +506,7 @@
               <text macro="series"/>
               <text macro="notes"/>
               <text macro="document-standard-number"/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </group>
         </else>

--- a/src/GB-T-7714—2005（著者-出版年，双语）/GB-T-7714—2005（著者-出版年，双语）.csl
+++ b/src/GB-T-7714—2005（著者-出版年，双语）/GB-T-7714—2005（著者-出版年，双语）.csl
@@ -117,7 +117,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -138,7 +138,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -174,11 +174,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -312,7 +312,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -320,11 +320,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -340,7 +340,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -348,9 +348,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -376,7 +376,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/GB-T-7714—2005（著者-出版年，双语，姓名不大写，无URL）/GB-T-7714—2005（著者-出版年，双语，姓名不大写，无URL）.csl
+++ b/src/GB-T-7714—2005（著者-出版年，双语，姓名不大写，无URL）/GB-T-7714—2005（著者-出版年，双语，姓名不大写，无URL）.csl
@@ -114,7 +114,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -135,7 +135,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -171,11 +171,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -308,7 +308,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -316,11 +316,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -335,7 +335,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -343,9 +343,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -370,7 +370,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/GB-T-7714—2005（顺序编码，双语）/GB-T-7714—2005（顺序编码，双语）.csl
+++ b/src/GB-T-7714—2005（顺序编码，双语）/GB-T-7714—2005（顺序编码，双语）.csl
@@ -71,7 +71,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -92,7 +92,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -128,11 +128,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -266,7 +266,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -275,11 +275,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -295,7 +295,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -303,9 +303,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -334,7 +334,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/GB-T-7714—2005（顺序编码，双语，姓名不大写，无URL）/GB-T-7714—2005（顺序编码，双语，姓名不大写，无URL）.csl
+++ b/src/GB-T-7714—2005（顺序编码，双语，姓名不大写，无URL）/GB-T-7714—2005（顺序编码，双语，姓名不大写，无URL）.csl
@@ -68,7 +68,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -89,7 +89,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -125,11 +125,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -262,7 +262,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -271,11 +271,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -290,7 +290,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -298,9 +298,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -328,7 +328,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/GB-T-7714—2015（注释，双语）/GB-T-7714—2015（注释，双语）.csl
+++ b/src/GB-T-7714—2015（注释，双语）/GB-T-7714—2015（注释，双语）.csl
@@ -79,7 +79,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -114,11 +114,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -254,9 +254,9 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -274,7 +274,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -282,9 +282,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -367,7 +367,7 @@
         <text variable="locator"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/GB-T-7714—2015（注释，双语，全角标点）/GB-T-7714—2015（注释，双语，全角标点）.csl
+++ b/src/GB-T-7714—2015（注释，双语，全角标点）/GB-T-7714—2015（注释，双语，全角标点）.csl
@@ -95,7 +95,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -136,7 +136,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -171,11 +171,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -360,9 +360,9 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -386,9 +386,9 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -406,7 +406,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -414,16 +414,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -557,7 +557,7 @@
         <text variable="locator"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/GB-T-7714—2015（注释，双语，姓名不大写，无-URL、DOI）/GB-T-7714—2015（注释，双语，姓名不大写，无-URL、DOI）.csl
+++ b/src/GB-T-7714—2015（注释，双语，姓名不大写，无-URL、DOI）/GB-T-7714—2015（注释，双语，姓名不大写，无-URL、DOI）.csl
@@ -76,7 +76,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -111,11 +111,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -250,9 +250,9 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -269,7 +269,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -277,9 +277,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -368,7 +368,7 @@
         <text variable="locator"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/GB-T-7714—2015（注释，双语，姓名不大写，无URL、DOI）/GB-T-7714—2015（注释，双语，姓名不大写，无URL、DOI）.csl
+++ b/src/GB-T-7714—2015（注释，双语，姓名不大写，无URL、DOI）/GB-T-7714—2015（注释，双语，姓名不大写，无URL、DOI）.csl
@@ -76,7 +76,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -111,11 +111,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -250,9 +250,9 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -269,7 +269,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -277,9 +277,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -368,7 +368,7 @@
         <text variable="locator"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/GB-T-7714—2015（注释，双语，姓名不大写，无URL、DOI，重复引用不省略）/GB-T-7714—2015（注释，双语，姓名不大写，无URL、DOI，重复引用不省略）.csl
+++ b/src/GB-T-7714—2015（注释，双语，姓名不大写，无URL、DOI，重复引用不省略）/GB-T-7714—2015（注释，双语，姓名不大写，无URL、DOI，重复引用不省略）.csl
@@ -76,7 +76,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -111,11 +111,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -250,9 +250,9 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -269,7 +269,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -277,9 +277,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -368,7 +368,7 @@
         <text variable="locator"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/GB-T-7714—2015（注释，双语，重复引用不省略）/GB-T-7714—2015（注释，双语，重复引用不省略）.csl
+++ b/src/GB-T-7714—2015（注释，双语，重复引用不省略）/GB-T-7714—2015（注释，双语，重复引用不省略）.csl
@@ -78,7 +78,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -113,11 +113,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -253,9 +253,9 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -273,7 +273,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -281,9 +281,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -366,7 +366,7 @@
         <text variable="locator"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/GB-T-7714—2015（著者-出版年，双语）/GB-T-7714—2015（著者-出版年，双语）.csl
+++ b/src/GB-T-7714—2015（著者-出版年，双语）/GB-T-7714—2015（著者-出版年，双语）.csl
@@ -121,7 +121,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -156,11 +156,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -288,7 +288,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -296,11 +296,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -316,7 +316,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -324,9 +324,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -352,7 +352,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/GB-T-7714—2015（著者-出版年，双语，全角标点）/GB-T-7714—2015（著者-出版年，双语，全角标点）.csl
+++ b/src/GB-T-7714—2015（著者-出版年，双语，全角标点）/GB-T-7714—2015（著者-出版年，双语，全角标点）.csl
@@ -140,7 +140,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -181,7 +181,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -216,11 +216,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -397,7 +397,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -405,11 +405,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -423,7 +423,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，卷（期）：页码［引用日期］” -->
@@ -431,11 +431,11 @@
           <group>
             <group delimiter="，">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -451,7 +451,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -459,16 +459,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -494,7 +494,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -525,7 +525,7 @@
             <text variable="publisher-place"/>
             <text variable="publisher"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/GB-T-7714—2015（著者-出版年，双语，姓名不大写）/GB-T-7714—2015（著者-出版年，双语，姓名不大写）.csl
+++ b/src/GB-T-7714—2015（著者-出版年，双语，姓名不大写）/GB-T-7714—2015（著者-出版年，双语，姓名不大写）.csl
@@ -121,7 +121,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -156,11 +156,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -282,7 +282,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -290,11 +290,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -310,7 +310,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -318,9 +318,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -346,7 +346,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/GB-T-7714—2015（著者-出版年，双语，姓名不大写，无URL、DOI）/GB-T-7714—2015（著者-出版年，双语，姓名不大写，无URL、DOI）.csl
+++ b/src/GB-T-7714—2015（著者-出版年，双语，姓名不大写，无URL、DOI）/GB-T-7714—2015（著者-出版年，双语，姓名不大写，无URL、DOI）.csl
@@ -118,7 +118,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -153,11 +153,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -284,7 +284,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -292,11 +292,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -311,7 +311,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -319,9 +319,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -346,7 +346,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/GB-T-7714—2015（著者-出版年，双语，姓名不大写，无URL、DOI，全角括号）/GB-T-7714—2015（著者-出版年，双语，姓名不大写，无URL、DOI，全角括号）.csl
+++ b/src/GB-T-7714—2015（著者-出版年，双语，姓名不大写，无URL、DOI，全角括号）/GB-T-7714—2015（著者-出版年，双语，姓名不大写，无URL、DOI，全角括号）.csl
@@ -125,7 +125,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -160,11 +160,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -291,7 +291,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -299,11 +299,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -318,7 +318,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -326,9 +326,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -353,7 +353,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/GB-T-7714—2015（著者-出版年，双语，无URL、DOI）/GB-T-7714—2015（著者-出版年，双语，无URL、DOI）.csl
+++ b/src/GB-T-7714—2015（著者-出版年，双语，无URL、DOI）/GB-T-7714—2015（著者-出版年，双语，无URL、DOI）.csl
@@ -121,7 +121,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -156,11 +156,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -293,7 +293,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -301,11 +301,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -320,7 +320,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -328,9 +328,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -355,7 +355,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/GB-T-7714—2015（顺序编码，双语）/GB-T-7714—2015（顺序编码，双语）.csl
+++ b/src/GB-T-7714—2015（顺序编码，双语）/GB-T-7714—2015（顺序编码，双语）.csl
@@ -79,7 +79,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -114,11 +114,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -246,7 +246,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -255,11 +255,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -275,7 +275,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -283,9 +283,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -314,7 +314,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/GB-T-7714—2015（顺序编码，双语，全角标点）/GB-T-7714—2015（顺序编码，双语，全角标点）.csl
+++ b/src/GB-T-7714—2015（顺序编码，双语，全角标点）/GB-T-7714—2015（顺序编码，双语，全角标点）.csl
@@ -98,7 +98,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -139,7 +139,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -174,11 +174,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -355,7 +355,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -364,11 +364,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -382,7 +382,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -391,11 +391,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -411,7 +411,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -419,16 +419,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -457,7 +457,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -497,7 +497,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/GB-T-7714—2015（顺序编码，双语，姓名不大写）/GB-T-7714—2015（顺序编码，双语，姓名不大写）.csl
+++ b/src/GB-T-7714—2015（顺序编码，双语，姓名不大写）/GB-T-7714—2015（顺序编码，双语，姓名不大写）.csl
@@ -80,7 +80,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -115,11 +115,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -241,7 +241,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -250,11 +250,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -270,7 +270,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -278,9 +278,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -309,7 +309,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，全部作者）/GB-T-7714—2015（顺序编码，双语，姓名不大写，全部作者）.csl
+++ b/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，全部作者）/GB-T-7714—2015（顺序编码，双语，姓名不大写，全部作者）.csl
@@ -80,7 +80,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -115,11 +115,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -241,7 +241,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -250,11 +250,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -270,7 +270,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -278,9 +278,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -309,7 +309,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，全部作者，姓名不缩写）/GB-T-7714—2015（顺序编码，双语，姓名不大写，全部作者，姓名不缩写）.csl
+++ b/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，全部作者，姓名不缩写）/GB-T-7714—2015（顺序编码，双语，姓名不大写，全部作者，姓名不缩写）.csl
@@ -80,7 +80,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -115,11 +115,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -241,7 +241,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -250,11 +250,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -270,7 +270,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -278,9 +278,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -309,7 +309,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，引注有页码）/GB-T-7714—2015（顺序编码，双语，姓名不大写，引注有页码）.csl
+++ b/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，引注有页码）/GB-T-7714—2015（顺序编码，双语，姓名不大写，引注有页码）.csl
@@ -80,7 +80,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -115,11 +115,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -241,7 +241,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -250,11 +250,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -270,7 +270,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -278,9 +278,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -309,7 +309,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI）/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI）.csl
+++ b/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI）/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI）.csl
@@ -80,7 +80,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -115,11 +115,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -246,7 +246,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -255,11 +255,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -274,7 +274,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -282,9 +282,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -312,7 +312,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI，引注有页码）/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI，引注有页码）.csl
+++ b/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI，引注有页码）/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI，引注有页码）.csl
@@ -80,7 +80,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -115,11 +115,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -246,7 +246,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -255,11 +255,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -274,7 +274,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -282,9 +282,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -312,7 +312,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI，网络首发文献除外）/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI，网络首发文献除外）.csl
+++ b/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI，网络首发文献除外）/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL、DOI，网络首发文献除外）.csl
@@ -80,7 +80,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -115,11 +115,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -258,7 +258,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -267,11 +267,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -286,7 +286,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -294,9 +294,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -324,7 +324,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL）/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL）.csl
+++ b/src/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL）/GB-T-7714—2015（顺序编码，双语，姓名不大写，无URL）.csl
@@ -80,7 +80,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -115,11 +115,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -246,7 +246,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -255,11 +255,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -274,7 +274,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -282,9 +282,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -312,7 +312,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/GB-T-7714—2015（顺序编码，双语，无URL、DOI）/GB-T-7714—2015（顺序编码，双语，无URL、DOI）.csl
+++ b/src/GB-T-7714—2015（顺序编码，双语，无URL、DOI）/GB-T-7714—2015（顺序编码，双语，无URL、DOI）.csl
@@ -79,7 +79,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -114,11 +114,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -251,7 +251,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -260,11 +260,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -279,7 +279,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -287,9 +287,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -317,7 +317,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/GB-T-7714—2025（征求意见稿，顺序编码，双语）/GB-T-7714—2025（征求意见稿，顺序编码，双语）.csl
+++ b/src/GB-T-7714—2025（征求意见稿，顺序编码，双语）/GB-T-7714—2025（征求意见稿，顺序编码，双语）.csl
@@ -104,10 +104,10 @@
         <choose>
           <if is-numeric="volume">
             <label variable="volume" form="short"/>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -121,7 +121,7 @@
         <text variable="call-number"/>
       </if>
       <else-if variable="number">
-        <text variable="number"/>
+        <number variable="number"/>
       </else-if>
       <else-if type="collection manuscript personal_communication" variable="archive" match="any">
         <!-- 档案的档号 -->
@@ -248,7 +248,7 @@
           <text variable="container-title"/>
           <text macro="date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码” -->
@@ -257,16 +257,16 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="date"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
           <choose>
             <if variable="page">
-              <text variable="page"/>
+              <number variable="page"/>
             </if>
             <else>
-              <text variable="number"/>
+              <number variable="number"/>
             </else>
           </choose>
         </group>
@@ -283,7 +283,7 @@
         </group>
       </if>
       <else-if variable="edition">
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else-if>
       <else-if variable="version">
         <label variable="version" form="short" text-case="capitalize-first" strip-periods="true"/>
@@ -306,13 +306,13 @@
                 </group>
                 <text macro="date"/>
               </group>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </if>
           <else>
             <group delimiter="：">
               <text macro="date"/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -328,7 +328,7 @@
                 </group>
                 <text macro="date"/>
               </group>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </if>
           <else>
@@ -363,7 +363,7 @@
             </group>
             <text macro="date"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -445,7 +445,7 @@
         <if type="periodical">
           <!-- 4.3 连续出版物 -->
           <text macro="title"/>
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text macro="publisher"/>
         </if>
         <else-if type="article-journal article-magazine article-newspaper" match="any">
@@ -493,7 +493,7 @@
               </group>
               <text macro="date"/>
             </group>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else>

--- a/src/IEEE（双语）/IEEE（双语）.csl
+++ b/src/IEEE（双语）/IEEE（双语）.csl
@@ -85,7 +85,7 @@
             </group>
           </if>
           <else>
-            <text variable="edition" text-case="capitalize-first" suffix="."/>
+            <number variable="edition" text-case="capitalize-first" suffix="."/>
           </else>
         </choose>
       </if>
@@ -274,13 +274,13 @@
         <group delimiter=" ">
           <text value="Art."/>
           <text term="issue" form="short"/>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </if>
       <else>
         <group delimiter=" ">
           <label variable="page" form="short"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -368,7 +368,7 @@
             <text macro="publisher"/>
             <group delimiter=" ">
               <text variable="genre"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
             <text macro="issued"/>
           </group>
@@ -394,7 +394,7 @@
         <else-if type="patent">
           <group delimiter=", ">
             <text macro="title"/>
-            <text variable="number"/>
+            <number variable="number"/>
             <text macro="issued"/>
           </group>
           <text macro="access"/>
@@ -508,7 +508,7 @@
             <text macro="publisher"/>
             <group delimiter=" ">
               <text variable="genre"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
             <text macro="issued"/>
           </group>
@@ -534,7 +534,7 @@
         <else-if type="patent">
           <group delimiter=", ">
             <text macro="title"/>
-            <text variable="number"/>
+            <number variable="number"/>
             <text macro="issued"/>
           </group>
           <text macro="access"/>

--- a/src/food-materials-research/food-materials-research.csl
+++ b/src/food-materials-research/food-materials-research.csl
@@ -71,7 +71,7 @@
           <text variable="title" font-style="italic"/>
           <group>
             <label variable="volume" form="short" suffix=" " text-case="capitalize-first"/>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </group>
         </group>
       </else-if>
@@ -109,10 +109,10 @@
           <if variable="volume">
             <group prefix=". ">
               <group suffix=": ">
-                <text variable="volume"/>
-                <text variable="issue" prefix="(" suffix=")"/>
+                <number variable="volume"/>
+                <number variable="issue" prefix="(" suffix=")"/>
               </group>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </if>
           <else>
@@ -120,11 +120,11 @@
               <if is-numeric="page">
                 <group prefix=", ">
                   <label variable="page" form="short" suffix=" "/>
-                  <text variable="page"/>
+                  <number variable="page"/>
                 </group>
               </if>
               <else>
-                <text variable="page" prefix=". "/>
+                <number variable="page" prefix=". "/>
               </else>
             </choose>
           </else>
@@ -135,12 +135,12 @@
           <text macro="date-m-d"/>
           <group>
             <label variable="page" form="short" suffix=" "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </group>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -169,7 +169,7 @@
           <text macro="publisher"/>
           <group prefix=" ">
             <label variable="page" form="short" suffix=" "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
           <!-- <group delimiter=" ">
             <label variable="number-of-pages" form="short"/>
@@ -203,14 +203,14 @@
       </else-if>
       <else-if type="patent">
         <group font-style="italic">
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </else-if>
       <else-if type="report">
         <group delimiter=". ">
           <text macro="container-booklike"/>
           <group delimiter=", ">
-            <text variable="number" font-style="italic"/>
+            <number variable="number" font-style="italic"/>
             <text variable="publisher"/>
             <text variable="publisher-place"/>
           </group>

--- a/src/journal-of-meteorological-research/journal-of-meteorological-research.csl
+++ b/src/journal-of-meteorological-research/journal-of-meteorological-research.csl
@@ -117,7 +117,7 @@
   </macro>
   <macro name="page">
     <label variable="page" suffix=" " form="short"/>
-    <text variable="page"/>
+    <number variable="page"/>
   </macro>
   <macro name="edition">
     <choose>
@@ -128,7 +128,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition" suffix="."/>
+        <number variable="edition" suffix="."/>
       </else>
     </choose>
   </macro>
@@ -170,7 +170,7 @@
           <group prefix=" " delimiter=", ">
             <text variable="container-title" font-style="italic"/>
             <text macro="day-month"/>
-            <text variable="edition"/>
+            <number variable="edition"/>
           </group>
         </if>
         <else-if type="thesis">
@@ -196,14 +196,14 @@
                 <text macro="editor"/>
               </group>
               <group delimiter=" ">
-                <text variable="volume" prefix="Vol. " suffix=" of"/>
+                <number variable="volume" prefix="Vol. " suffix=" of"/>
                 <text variable="collection-title" font-style="italic"/>
                 <text macro="series-editor"/>
               </group>
               <text variable="event"/>
               <text variable="publisher-place"/>
               <text variable="publisher"/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </group>
         </else-if>
@@ -216,7 +216,7 @@
                 <text macro="editor"/>
               </group>
               <group delimiter=" ">
-                <text variable="volume" prefix="Vol. " suffix=" of"/>
+                <number variable="volume" prefix="Vol. " suffix=" of"/>
                 <text variable="collection-title" font-style="italic"/>
                 <text macro="series-editor"/>
               </group>
@@ -232,8 +232,8 @@
           <group prefix=" " suffix="." delimiter=" ">
             <text variable="container-title" form="short" font-style="italic" suffix=","/>
             <group delimiter=", ">
-              <text variable="volume" font-weight="bold"/>
-              <text variable="page"/>
+              <number variable="volume" font-weight="bold"/>
+              <number variable="page"/>
               <text variable="DOI" prefix="https://doi.org/"/>
             </group>
           </group>

--- a/src/journal-of-modern-power-systems-and-clean-energy/journal-of-modern-power-systems-and-clean-energy.csl
+++ b/src/journal-of-modern-power-systems-and-clean-energy/journal-of-modern-power-systems-and-clean-energy.csl
@@ -48,7 +48,7 @@
             </group>
           </if>
           <else>
-            <text variable="edition" text-case="capitalize-first" suffix="."/>
+            <number variable="edition" text-case="capitalize-first" suffix="."/>
           </else>
         </choose>
       </if>
@@ -226,13 +226,13 @@
         <group delimiter=" ">
           <text value="Art."/>
           <text term="issue" form="short"/>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </if>
       <else>
         <group delimiter=" ">
           <label variable="page" form="short"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -271,7 +271,7 @@
           <group delimiter=", " suffix=". ">
             <text variable="collection-title"/>
             <text variable="collection-number" prefix="no. "/>
-            <text variable="volume" prefix="vol. "/>
+            <number variable="volume" prefix="vol. "/>
           </group>
         </group>
       </if>
@@ -355,7 +355,7 @@
             <text macro="publisher"/>
             <group delimiter=" ">
               <text variable="genre"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
             <text macro="issued"/>
           </group>
@@ -380,7 +380,7 @@
         <else-if type="patent">
           <group delimiter=", ">
             <text macro="title"/>
-            <text variable="number"/>
+            <number variable="number"/>
             <text macro="issued"/>
           </group>
           <text macro="access"/>

--- a/src/transactions-of-nonferrous-metals-society-of-china/transactions-of-nonferrous-metals-society-of-china.csl
+++ b/src/transactions-of-nonferrous-metals-society-of-china/transactions-of-nonferrous-metals-society-of-china.csl
@@ -82,7 +82,7 @@
               <choose>
                 <if type="article article-journal" match="none">
                   <!-- 预印本和期刊文章的编号用于其他位置 -->
-                  <text variable="number"/>
+                  <number variable="number"/>
                 </if>
               </choose>
             </group>
@@ -119,11 +119,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -256,7 +256,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -265,11 +265,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -284,7 +284,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -292,9 +292,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -322,7 +322,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/上海交通大学/上海交通大学.csl
+++ b/src/上海交通大学/上海交通大学.csl
@@ -78,7 +78,7 @@
           </choose>
           <choose>
             <if type="bill legal_case legislation patent report standard" match="any">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -113,11 +113,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -246,11 +246,11 @@
               <text macro="issued-year"/>
             </else>
           </choose>
-          <text variable="volume"/>
+          <number variable="volume"/>
         </group>
-        <text variable="issue" prefix="(" suffix=")"/>
+        <number variable="issue" prefix="(" suffix=")"/>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
   </macro>
   <!-- 版本项 -->
@@ -263,7 +263,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -271,9 +271,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -301,7 +301,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL DOI" match="any">

--- a/src/上海大学/上海大学.csl
+++ b/src/上海大学/上海大学.csl
@@ -93,7 +93,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -128,11 +128,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -232,7 +232,7 @@
           <text variable="container-title" text-case="title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <group delimiter=":">
@@ -240,11 +240,11 @@
             <group delimiter=", ">
               <text variable="container-title" text-case="title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -275,7 +275,7 @@
         </choose>
         <text macro="issued-year"/>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
   </macro>
   <!-- 出版年 -->

--- a/src/上海对外经贸大学学报/上海对外经贸大学学报.csl
+++ b/src/上海对外经贸大学学报/上海对外经贸大学学报.csl
@@ -120,7 +120,7 @@
         <group delimiter=", ">
           <text variable="title" text-case="title"/>
           <text macro="volume"/>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </else>
     </choose>
@@ -138,7 +138,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -172,11 +172,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -268,7 +268,7 @@
           <text variable="container-title" text-case="title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <group delimiter=":">
@@ -276,11 +276,11 @@
             <group delimiter=", ">
               <text variable="container-title" text-case="title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -310,7 +310,7 @@
         </choose>
         <text macro="issued-year"/>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
   </macro>
   <macro name="issued-year">

--- a/src/上海工程技术大学/上海工程技术大学.csl
+++ b/src/上海工程技术大学/上海工程技术大学.csl
@@ -65,7 +65,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -86,7 +86,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -122,11 +122,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -272,7 +272,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -281,11 +281,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -300,7 +300,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -308,9 +308,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -338,7 +338,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/上海财经大学（本科）/上海财经大学（本科）.csl
+++ b/src/上海财经大学（本科）/上海财经大学（本科）.csl
@@ -113,7 +113,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -148,11 +148,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -289,7 +289,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -298,11 +298,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -317,7 +317,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -325,9 +325,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -355,7 +355,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/世界历史/世界历史.csl
+++ b/src/世界历史/世界历史.csl
@@ -169,7 +169,7 @@
             <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
             <group>
               <label variable="page" form="short"/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -212,7 +212,7 @@
             </group>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -238,8 +238,8 @@
             <group prefix=" " delimiter=", ">
               <text variable="title" quotes="true"/>
               <text variable="container-title" font-style="italic"/>
-              <text variable="volume" prefix="vol. "/>
-              <text variable="issue" prefix="no. " suffix=" "/>
+              <number variable="volume" prefix="vol. "/>
+              <number variable="issue" prefix="no. " suffix=" "/>
             </group>
             <date date-parts="year-month" form="text" variable="issued" prefix="(" suffix=")"/>
             <group>
@@ -252,13 +252,13 @@
             <group prefix=" " delimiter=", ">
               <text variable="title" quotes="true"/>
               <text variable="container-title" font-style="italic"/>
-              <text variable="volume" prefix="vol. "/>
-              <text variable="issue" prefix="no. " suffix=" "/>
+              <number variable="volume" prefix="vol. "/>
+              <number variable="issue" prefix="no. " suffix=" "/>
             </group>
             <date date-parts="year-month" form="text" variable="issued" prefix="(" suffix=")"/>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -303,7 +303,7 @@
             <date date-parts="year" form="numeric" variable="issued"/>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -327,7 +327,7 @@
             <text variable="publisher-place" prefix="（" suffix="）"/>
             <date date-parts="year" form="text" variable="issued"/>
             <group delimiter="，">
-              <text variable="issue" prefix="第" suffix="期"/>
+              <number variable="issue" prefix="第" suffix="期"/>
             </group>
             <text macro="locators-zh"/>
             <text variable="locator" prefix="，第" suffix="页"/>
@@ -343,9 +343,9 @@
             <text variable="publisher-place" prefix="（" suffix="）"/>
             <date date-parts="year" form="text" variable="issued"/>
             <group delimiter="，">
-              <text variable="issue" prefix="第" suffix="期"/>
+              <number variable="issue" prefix="第" suffix="期"/>
             </group>
-            <text variable="page" prefix="，第" suffix="页"/>
+            <number variable="page" prefix="，第" suffix="页"/>
           </else>
         </choose>
       </if>
@@ -358,7 +358,7 @@
           <text variable="container-title" prefix="《" suffix="》，"/>
         </group>
         <date form="text" variable="issued"/>
-        <text variable="edition" prefix="，第" suffix="版"/>
+        <number variable="edition" prefix="，第" suffix="版"/>
       </else-if>
       <else-if type="chapter">
         <!-- 中文章节 -->
@@ -376,8 +376,8 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text variable="publisher"/>
                 </group>
@@ -394,13 +394,13 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text variable="publisher"/>
                 </group>
                 <text macro="date" suffix="版"/>
-                <text variable="page" prefix="，第" suffix="页"/>
+                <number variable="page" prefix="，第" suffix="页"/>
               </else>
             </choose>
           </if>
@@ -416,8 +416,8 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text variable="publisher"/>
                   <text macro="date" suffix="版"/>
@@ -433,13 +433,13 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text variable="publisher"/>
                   <text macro="date" suffix="版"/>
                 </group>
-                <text variable="page" prefix="，第" suffix="页"/>
+                <number variable="page" prefix="，第" suffix="页"/>
               </else>
             </choose>
           </else>
@@ -479,7 +479,7 @@
               <text variable="event-place"/>
               <date date-parts="year-month-day" form="text" variable="issued"/>
             </group>
-            <text variable="page" prefix="，第" suffix="页"/>
+            <number variable="page" prefix="，第" suffix="页"/>
           </else>
         </choose>
       </else-if>
@@ -509,8 +509,8 @@
               <group>
                 <text variable="title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
               <text variable="publisher"/>
             </group>
@@ -526,8 +526,8 @@
               <group>
                 <text variable="title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
               <text variable="publisher"/>
             </group>
@@ -544,8 +544,8 @@
         <text variable="title" prefix="《" suffix="》"/>
         <group delimiter="，">
           <text variable="collection-number" prefix="第" suffix="册"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
         </group>
         <text macro="secondAuthor" prefix="，"/>
         <group delimiter="：">
@@ -646,7 +646,7 @@
           <text variable="title" quotes="true" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if position="subsequent" type="chapter" match="all">
@@ -656,7 +656,7 @@
           <text variable="title" quotes="true" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else>

--- a/src/世界经济/世界经济.csl
+++ b/src/世界经济/世界经济.csl
@@ -168,7 +168,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -188,7 +188,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -198,7 +198,7 @@
         <number variable="number" prefix="No."/>
       </if>
       <else>
-        <text variable="number"/>
+        <number variable="number"/>
       </else>
     </choose>
   </macro>

--- a/src/世界经济与政治/世界经济与政治.csl
+++ b/src/世界经济与政治/世界经济与政治.csl
@@ -122,7 +122,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -134,7 +134,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -146,7 +146,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -175,12 +175,12 @@
           <choose>
             <if is-numeric="number">
               <text variable="genre"/>
-              <text variable="number" prefix="No."/>
+              <number variable="number" prefix="No."/>
             </if>
             <else>
               <group delimiter=" ">
                 <text variable="genre"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -257,7 +257,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -480,7 +480,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -499,7 +499,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/世界经济与政治论坛/世界经济与政治论坛.csl
+++ b/src/世界经济与政治论坛/世界经济与政治论坛.csl
@@ -92,7 +92,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -132,7 +132,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -171,7 +171,7 @@
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -187,7 +187,7 @@
             <label variable="volume" form="short"/>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -367,9 +367,9 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -393,9 +393,9 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -413,7 +413,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -421,9 +421,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -548,7 +548,7 @@
         <text variable="locator"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/东北大学/东北大学.csl
+++ b/src/东北大学/东北大学.csl
@@ -88,7 +88,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -130,7 +130,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -165,11 +165,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -339,7 +339,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -348,11 +348,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -365,7 +365,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -374,11 +374,11 @@
             <group delimiter="，">
               <text variable="container-title" form="short" strip-periods="true"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -393,7 +393,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -401,16 +401,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -436,7 +436,7 @@
             </choose>
           </group>
           <text macro="issued-year-en"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -489,7 +489,7 @@
             </choose>
           </group>
           <text macro="issued-year-zh"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/东北林业大学/东北林业大学.csl
+++ b/src/东北林业大学/东北林业大学.csl
@@ -78,7 +78,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -109,11 +109,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -174,7 +174,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -183,11 +183,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -202,7 +202,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -210,9 +210,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -237,7 +237,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if type="book chapter paper-conference periodical thesis" variable="archive archive-place publisher publisher-place page" match="any">
@@ -259,7 +259,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -311,7 +311,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if type="book chapter paper-conference periodical thesis" variable="archive archive-place publisher publisher-place page" match="any">
@@ -333,7 +333,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/东南大学/东南大学.csl
+++ b/src/东南大学/东南大学.csl
@@ -82,7 +82,7 @@
       <group delimiter=" ">
         <choose>
           <if type="standard">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
         <group delimiter=", ">
@@ -98,7 +98,7 @@
               <choose>
                 <if type="article article-journal patent standard" match="none">
                   <!-- 预印本和期刊文章的编号用于其他位置 -->
-                  <text variable="number"/>
+                  <number variable="number"/>
                 </if>
               </choose>
               <choose>
@@ -145,7 +145,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <group delimiter="，">
@@ -161,7 +161,7 @@
                 <choose>
                   <if type="article article-journal patent standard" match="none">
                     <!-- 预印本和期刊文章的编号用于其他位置 -->
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </if>
                 </choose>
                 <choose>
@@ -211,11 +211,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -393,7 +393,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -402,11 +402,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -419,7 +419,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -428,11 +428,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -447,7 +447,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -455,16 +455,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -476,7 +476,7 @@
               <text macro="patent-country"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -500,7 +500,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -540,7 +540,7 @@
               <text macro="patent-country"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -564,7 +564,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/中华医学会/中华医学会.csl
+++ b/src/中华医学会/中华医学会.csl
@@ -77,7 +77,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -112,11 +112,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -243,7 +243,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -252,11 +252,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -271,7 +271,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -279,9 +279,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -309,7 +309,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中华心血管病杂志/中华心血管病杂志.csl
+++ b/src/中华心血管病杂志/中华心血管病杂志.csl
@@ -64,7 +64,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -85,7 +85,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -121,11 +121,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -268,7 +268,7 @@
             <text variable="container-title" form="short" strip-periods="true" text-case="title"/>
             <text macro="issued-date"/>
           </group>
-          <text variable="page" prefix="(" suffix=")"/>
+          <number variable="page" prefix="(" suffix=")"/>
         </group>
       </if>
       <else>
@@ -277,11 +277,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true" text-case="title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -296,7 +296,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -304,9 +304,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -333,7 +333,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else>

--- a/src/中华炎性肠病杂志/中华炎性肠病杂志.csl
+++ b/src/中华炎性肠病杂志/中华炎性肠病杂志.csl
@@ -83,7 +83,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -118,7 +118,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -143,11 +143,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -291,7 +291,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -300,11 +300,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -324,7 +324,7 @@
           </choose>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -340,11 +340,11 @@
                 </else>
               </choose>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -359,7 +359,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -367,9 +367,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -397,7 +397,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -443,7 +443,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中南大学/中南大学.csl
+++ b/src/中南大学/中南大学.csl
@@ -75,7 +75,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -110,11 +110,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -242,7 +242,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -251,11 +251,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -271,7 +271,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -279,9 +279,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -310,7 +310,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/中南林业科技大学/中南林业科技大学.csl
+++ b/src/中南林业科技大学/中南林业科技大学.csl
@@ -69,7 +69,7 @@
     <group delimiter=" ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=": ">
@@ -84,7 +84,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -112,11 +112,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -299,7 +299,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -308,11 +308,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -327,7 +327,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -335,9 +335,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -347,7 +347,7 @@
         <group delimiter=", ">
           <group delimiter=": ">
             <text macro="patent-country-en"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -371,7 +371,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -408,7 +408,7 @@
         <group delimiter=", ">
           <group delimiter=": ">
             <text macro="patent-country-zh"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -432,7 +432,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中南民族大学-生命科学学院/中南民族大学-生命科学学院.csl
+++ b/src/中南民族大学-生命科学学院/中南民族大学-生命科学学院.csl
@@ -103,7 +103,7 @@
       <group delimiter=": ">
         <choose>
           <if type="standard">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
         <text variable="title"/>
@@ -117,7 +117,7 @@
           <choose>
             <if type="article article-journal patent standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -152,11 +152,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -286,7 +286,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -295,11 +295,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -314,7 +314,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -322,9 +322,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -341,7 +341,7 @@
                 <text variable="publisher-place"/>
               </else>
             </choose>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -365,7 +365,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中南财经政法大学/中南财经政法大学.csl
+++ b/src/中南财经政法大学/中南财经政法大学.csl
@@ -74,7 +74,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation patent report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -133,7 +133,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -142,10 +142,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -157,7 +157,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/中国人民大学/中国人民大学.csl
+++ b/src/中国人民大学/中国人民大学.csl
@@ -114,7 +114,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -195,7 +195,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -207,7 +207,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -362,7 +362,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -374,13 +374,13 @@
         <if type="article-journal article-magazine article-newspaper" match="any">
           <text macro="container-periodical-en"/>
           <text macro="date-en"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <text macro="container-booklike-en"/>
           <text macro="publisher-en"/>
           <text macro="date-en"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </else-if>
         <else-if type="collection manuscript personal_communication" match="any">
           <text macro="date-en"/>

--- a/src/中国人民大学（本科）/中国人民大学（本科）.csl
+++ b/src/中国人民大学（本科）/中国人民大学（本科）.csl
@@ -134,7 +134,7 @@
     <group delimiter=", ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=": ">
@@ -149,7 +149,7 @@
           <choose>
             <if type="article article-journal regulation standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -187,7 +187,7 @@
             <label variable="volume" form="short"/>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -313,7 +313,7 @@
           <text variable="container-title"/>
           <text macro="issued-date-zh"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -322,11 +322,11 @@
             <text variable="container-title"/>
             <group>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -341,7 +341,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -349,9 +349,9 @@
   <macro name="year-volume-issue-zh">
     <group delimiter=", ">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-zh">
@@ -370,7 +370,7 @@
       <else-if type="regulation">
         <!-- 专利的出版项格式“公告日期[引用日期]” -->
         <group delimiter=". ">
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-date-zh"/>
         </group>
       </else-if>
@@ -393,7 +393,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>
@@ -703,7 +703,7 @@
                     <if is-numeric="volume" match="none">
                       <group delimiter=" ">
                         <label variable="volume" form="short" text-case="capitalize-first"/>
-                        <text variable="volume"/>
+                        <number variable="volume"/>
                       </group>
                     </if>
                   </choose>
@@ -722,7 +722,7 @@
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
                     <label variable="volume" form="short" text-case="capitalize-first"/>
-                    <text variable="volume"/>
+                    <number variable="volume"/>
                   </group>
                 </if>
               </choose>
@@ -751,7 +751,7 @@
             </choose>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </if>
@@ -1201,7 +1201,7 @@
             <text variable="genre" text-case="title"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <choose>
@@ -1264,7 +1264,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1304,11 +1304,11 @@
       </choose>
       <group delimiter=" ">
         <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -1394,12 +1394,12 @@
         <choose>
           <if variable="volume">
             <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
+              <number variable="volume" font-style="italic"/>
+              <number variable="issue" prefix="(" suffix=")"/>
             </group>
           </if>
           <else>
-            <text variable="issue" font-style="italic"/>
+            <number variable="issue" font-style="italic"/>
           </else>
         </choose>
         <choose>
@@ -1408,11 +1408,11 @@
             <!-- This should be localized -->
             <group delimiter=" ">
               <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </group>
@@ -1452,7 +1452,7 @@
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
                     <label variable="volume" form="short" text-case="capitalize-first"/>
-                    <text variable="volume"/>
+                    <number variable="volume"/>
                   </group>
                 </if>
               </choose>
@@ -1665,7 +1665,7 @@
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
                 <text term="on"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
@@ -1735,12 +1735,12 @@
           <text variable="container-title"/>
           <choose>
             <if variable="page page-first" match="any">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -1751,7 +1751,7 @@
           <choose>
             <if variable="container-title">
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
                 <group delimiter=" ">
                   <label variable="section" form="symbol"/>
@@ -1759,7 +1759,7 @@
                 </group>
                 <choose>
                   <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
+                    <number variable="page-first"/>
                   </if>
                   <else>
                     <text value="___"/>
@@ -1770,7 +1770,7 @@
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -1789,7 +1789,7 @@
                   <label variable="number" form="short" text-case="capitalize-first"/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
@@ -1798,9 +1798,9 @@
             <text variable="chapter-number"/>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </group>
         </group>
       </else-if>
@@ -1816,17 +1816,17 @@
           <if variable="number">
             <!-- There's a public law number. -->
             <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
+              <number variable="number" prefix="Pub. L. No. "/>
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </group>
             </group>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title"/>
               <choose>
                 <if variable="section">
@@ -1836,7 +1836,7 @@
                   </group>
                 </if>
                 <else>
-                  <text variable="page-first"/>
+                  <number variable="page-first"/>
                 </else>
               </choose>
             </group>
@@ -1849,11 +1849,11 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
             <choose>
               <if variable="section">
@@ -1863,7 +1863,7 @@
                 </group>
               </if>
               <else>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </else>
             </choose>
           </group>

--- a/src/中国公路学报/中国公路学报.csl
+++ b/src/中国公路学报/中国公路学报.csl
@@ -87,7 +87,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -128,7 +128,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -163,11 +163,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -326,7 +326,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -335,11 +335,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -352,7 +352,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -361,11 +361,11 @@
             <group delimiter=", ">
               <text variable="original-container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -380,7 +380,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -388,9 +388,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -418,7 +418,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -473,7 +473,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中国农业大学-人文与发展学院/中国农业大学-人文与发展学院.csl
+++ b/src/中国农业大学-人文与发展学院/中国农业大学-人文与发展学院.csl
@@ -139,7 +139,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -174,11 +174,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -351,7 +351,7 @@
           <text variable="container-title" font-style="italic"/>
           <text macro="month-day-en"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -360,12 +360,12 @@
             <group delimiter=", ">
               <text variable="container-title" font-style="italic"/>
               <group>
-                <text variable="volume"/>
-                <text variable="issue" prefix="(" suffix=")"/>
+                <number variable="volume"/>
+                <number variable="issue" prefix="(" suffix=")"/>
               </group>
             </group>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -378,7 +378,7 @@
           <text variable="container-title"/>
           <text macro="month-day-zh"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -387,12 +387,12 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <group>
-                <text variable="volume"/>
-                <text variable="issue" prefix="(" suffix=")"/>
+                <number variable="volume"/>
+                <number variable="issue" prefix="(" suffix=")"/>
               </group>
             </group>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -407,7 +407,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -415,9 +415,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -480,7 +480,7 @@
               <text variable="archive"/>
             </else>
           </choose>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -545,7 +545,7 @@
               <text variable="archive"/>
             </else>
           </choose>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>

--- a/src/中国农业大学学报/中国农业大学学报.csl
+++ b/src/中国农业大学学报/中国农业大学学报.csl
@@ -94,7 +94,7 @@
           <choose>
             <if type="article article-journal patent standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -109,7 +109,7 @@
         <if type="patent">
           <group delimiter=", ">
             <text macro="patent-country-en"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </if>
       </choose>
@@ -132,7 +132,7 @@
         </choose>
         <choose>
           <if type="bill legal_case legislation regulation report" match="any">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
       </group>
@@ -140,7 +140,7 @@
         <if type="patent">
           <group delimiter=", ">
             <text macro="patent-country-ZHtoEN"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </if>
       </choose>
@@ -164,7 +164,7 @@
           <choose>
             <if type="article article-journal patent standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -179,7 +179,7 @@
         <if type="patent">
           <group delimiter=", ">
             <text macro="patent-country-zh"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </if>
       </choose>
@@ -197,11 +197,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -433,7 +433,7 @@
           <text variable="container-title" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -442,11 +442,11 @@
             <group delimiter=", ">
               <text variable="container-title" font-style="italic"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -459,7 +459,7 @@
           <text variable="original-container-title" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -468,11 +468,11 @@
             <group delimiter=", ">
               <text variable="original-container-title" font-style="italic"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -485,7 +485,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -494,11 +494,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -513,7 +513,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -521,9 +521,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -550,7 +550,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -595,7 +595,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -712,7 +712,7 @@
           <text macro="publisher"/>
         </else-if>
         <else-if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="title-en"/>
           <text macro="publisher"/>
         </else-if>
@@ -768,7 +768,7 @@
           <text macro="publisher-ZHtoEN"/>
         </else-if>
         <else-if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="title-ZHtoEN"/>
           <text macro="publisher-ZHtoEN"/>
         </else-if>
@@ -825,7 +825,7 @@
           <text macro="publisher"/>
         </else-if>
         <else-if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="title-zh"/>
           <text macro="publisher"/>
         </else-if>

--- a/src/中国农业大学（自然科学）/中国农业大学（自然科学）.csl
+++ b/src/中国农业大学（自然科学）/中国农业大学（自然科学）.csl
@@ -63,7 +63,7 @@
     <group delimiter=", ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=": ">
@@ -78,7 +78,7 @@
           <choose>
             <if type="article article-journal patent standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -117,11 +117,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -248,7 +248,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -257,11 +257,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -276,7 +276,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -284,9 +284,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -297,7 +297,7 @@
             <text macro="patent-country"/>
             <text term="patent"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-date"/>
         </group>
       </if>
@@ -320,7 +320,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -358,7 +358,7 @@
             <text macro="patent-country"/>
             <text term="patent"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-date"/>
         </group>
       </if>
@@ -381,7 +381,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中国农业科学/中国农业科学.csl
+++ b/src/中国农业科学/中国农业科学.csl
@@ -89,7 +89,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -133,7 +133,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -164,11 +164,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -260,7 +260,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <group delimiter=": ">
@@ -268,11 +268,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" form="short" prefix="(" suffix=")"/>
+            <number variable="issue" form="short" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -293,7 +293,7 @@
           </choose>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <group delimiter=": ">
@@ -308,11 +308,11 @@
                 </else>
               </choose>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" form="short" prefix="(" suffix=")"/>
+            <number variable="issue" form="short" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -327,7 +327,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -335,9 +335,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" form="short" prefix="(" suffix=")"/>
+    <number variable="issue" form="short" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -357,7 +357,7 @@
           </else-if>
         </choose>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
     <choose>
       <!-- 纯电子资源显示“更新或修改日期” -->
@@ -403,7 +403,7 @@
           </else-if>
         </choose>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
     <choose>
       <!-- 纯电子资源显示“更新或修改日期” -->

--- a/src/中国农业科学院/中国农业科学院.csl
+++ b/src/中国农业科学院/中国农业科学院.csl
@@ -122,7 +122,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -154,11 +154,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -225,7 +225,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -233,11 +233,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -258,7 +258,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -266,9 +266,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -278,7 +278,7 @@
         <group delimiter=": ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </if>
     </choose>

--- a/src/中国农村经济/中国农村经济.csl
+++ b/src/中国农村经济/中国农村经济.csl
@@ -171,7 +171,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -183,7 +183,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -197,7 +197,7 @@
         </group>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -281,11 +281,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title" text-case="title" font-style="italic"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -328,7 +328,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -340,7 +340,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -367,7 +367,7 @@
         <group delimiter=" ">
           <text variable="publisher"/>
           <text macro="working-paper-genre"/>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </if>
       <else-if type="thesis">
@@ -453,7 +453,7 @@
         <number variable="number"/>
       </if>
       <else>
-        <text variable="number"/>
+        <number variable="number"/>
       </else>
     </choose>
   </macro>
@@ -469,7 +469,7 @@
         <label variable="page" form="short"/>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -509,7 +509,7 @@
           <!-- 会议论文 -->
           <text macro="title-en"/>
           <text macro="event-en"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </else-if>
         <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" variable="container-title" match="any">
           <!-- 4.2 专著中的析出文献 -->
@@ -517,14 +517,14 @@
           <text macro="secondary-contributors-en"/>
           <text macro="container-booklike-en"/>
           <text macro="publisher-en"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </else-if>
         <else>
           <!-- 4.1 专著 -->
           <text macro="title-en"/>
           <text macro="secondary-contributors-en"/>
           <text macro="publisher-en"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </else>
       </choose>
       <text macro="access"/>

--- a/src/中国地质大学（武汉）（本科，顺序编码）/中国地质大学（武汉）（本科，顺序编码）.csl
+++ b/src/中国地质大学（武汉）（本科，顺序编码）/中国地质大学（武汉）（本科，顺序编码）.csl
@@ -78,7 +78,7 @@
                     <text macro="patent-country"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </if>
           </choose>
@@ -114,11 +114,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -257,7 +257,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -266,11 +266,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -285,7 +285,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -293,9 +293,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -323,7 +323,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中国地质大学（著者-出版年）/中国地质大学（著者-出版年）.csl
+++ b/src/中国地质大学（著者-出版年）/中国地质大学（著者-出版年）.csl
@@ -85,7 +85,7 @@
   </macro>
   <macro name="title">
     <text variable="title"/>
-    <text variable="number" prefix=": "/>
+    <number variable="number" prefix=": "/>
     <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-id"/>
       <choose>
@@ -145,7 +145,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -153,10 +153,10 @@
   </macro>
   <macro name="serial-information">
     <group delimiter=", ">
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -167,7 +167,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/中国工业经济/中国工业经济.csl
+++ b/src/中国工业经济/中国工业经济.csl
@@ -124,7 +124,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -159,11 +159,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -263,7 +263,7 @@
           <text variable="container-title" text-case="title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <group delimiter=":">
@@ -271,11 +271,11 @@
             <group delimiter=", ">
               <text variable="container-title" text-case="title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -306,7 +306,7 @@
         </choose>
         <text macro="issued-year"/>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
   </macro>
   <!-- 出版年 -->

--- a/src/中国当代儿科杂志/中国当代儿科杂志.csl
+++ b/src/中国当代儿科杂志/中国当代儿科杂志.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -238,7 +238,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -247,11 +247,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -266,7 +266,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -274,9 +274,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -304,7 +304,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中国政法大学/中国政法大学.csl
+++ b/src/中国政法大学/中国政法大学.csl
@@ -240,7 +240,7 @@
                 <!-- 若同时有期刊卷册数和年份，则将卷册数标注在期刊名称之后，随后再以括号标记年份。 -->
                 <if variable="volume">
                   <text macro="container-de"/>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                   <text macro="issuance-de" prefix="(" suffix=")"/>
                 </if>
                 <else>
@@ -337,12 +337,12 @@
                 </if>
                 <!-- 引用判例集中的判决时，标出判例集的名称、卷号 -->
                 <else>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                 </else>
               </choose>
             </group>
             <group delimiter=" ">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
               <text variable="locator" prefix="(" suffix=")"/>
             </group>
           </group>
@@ -369,7 +369,7 @@
             <group delimiter=" ">
               <text macro="container-en"/>
               <group delimiter=", ">
-                <text variable="page-first"/>
+                <number variable="page-first"/>
                 <text macro="locator-en"/>
               </group>
               <text macro="issuance-en" prefix="(" suffix=")"/>
@@ -413,7 +413,7 @@
                   <text macro="title-en"/>
                   <group delimiter=" ">
                     <text value="Pub. L. No."/>
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </group>
                   <text macro="section-en"/>
                   <text macro="container-en"/>
@@ -430,7 +430,7 @@
                 </group>
               </else>
             </choose>
-            <text variable="page"/>
+            <number variable="page"/>
             <text macro="locator-en"/>
             <text macro="issuance-en" prefix="(" suffix=")"/>
           </group>
@@ -442,13 +442,13 @@
               <text macro="title-en"/>
               <group delimiter=" ">
                 <text value="No."/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
             <text macro="container-en"/>
             <group delimiter=", ">
-              <text variable="page"/>
+              <number variable="page"/>
               <text variable="locator"/>
             </group>
             <group delimiter=" " prefix="(" suffix=")">
@@ -517,7 +517,7 @@
           </choose>
           <group>
             <text value="nᵒ "/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issuance-fr"/>
           <text macro="locator-or-page-fr"/>
@@ -541,7 +541,7 @@
                   <text macro="title-en"/>
                   <group delimiter=" ">
                     <text value="Pub. L. No."/>
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </group>
                   <text macro="container-en"/>
                 </group>
@@ -552,7 +552,7 @@
                 <text macro="container-en"/>
               </else>
             </choose>
-            <text variable="page"/>
+            <number variable="page"/>
             <text macro="locator-fr"/>
             <text macro="issuance-en" prefix="(" suffix=")"/>
           </group>
@@ -564,13 +564,13 @@
               <text macro="title-en"/>
               <group delimiter=" ">
                 <text value="No."/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
             <text macro="container-en"/>
             <group delimiter=", ">
-              <text variable="page"/>
+              <number variable="page"/>
               <text variable="locator"/>
             </group>
             <group delimiter=" " prefix="(" suffix=")">
@@ -637,7 +637,7 @@
             <text variable="container-title"/>
             <text macro="volume-ja"/>
             <group>
-              <text variable="number"/>
+              <number variable="number"/>
               <text term="issue" form="short"/>
             </group>
             <text macro="locator-or-page-ja"/>
@@ -767,7 +767,7 @@
           <text macro="title-zh"/>
           <choose>
             <if variable="section locator" match="none">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -826,7 +826,7 @@
           <text macro="author-zh"/>
           <group delimiter="，">
             <text macro="title-zh"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </group>
       </else-if>
@@ -961,7 +961,7 @@
             </else-if>
             <else-if variable="section locator" match="any">
               <!-- 64.1 《最高人民法院关于适用〈中华人民共和国行政诉讼法〉的解释》(法释 〔2018〕1 号)，第 100 条。 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </else-if>
           </choose>
         </group>
@@ -1008,7 +1008,7 @@
         <label variable="edition" form="short" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1019,7 +1019,7 @@
         <label variable="edition" form="short" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1031,7 +1031,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1085,7 +1085,7 @@
       </else-if>
       <else-if type="legislation">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title"/>
         </group>
       </else-if>
@@ -1098,7 +1098,7 @@
     <choose>
       <if type="article-journal article-magazine" match="any">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title" text-case="title"/>
         </group>
       </if>
@@ -1108,7 +1108,7 @@
           <group delimiter=", ">
             <text macro="editor-en"/>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title" text-case="title"/>
             </group>
           </group>
@@ -1116,7 +1116,7 @@
       </else-if>
       <else-if type="legislation">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title" text-case="title"/>
         </group>
       </else-if>
@@ -1236,7 +1236,7 @@
                 <text value="判决书"/>
               </else>
             </choose>
-            <text variable="number"/>
+            <number variable="number"/>
           </else>
         </choose>
       </else-if>
@@ -1278,7 +1278,7 @@
         <number variable="volume" form="roman" text-case="uppercase"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1303,7 +1303,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1315,7 +1315,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1326,7 +1326,7 @@
         <number variable="issue"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1337,7 +1337,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1356,7 +1356,7 @@
         </choose>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1553,7 +1553,7 @@
             <number variable="page"/>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>
@@ -1605,11 +1605,11 @@
         <choose>
           <if type="article-newspaper">
             <text term="at" suffix=" "/>
-            <text variable="page" form="short"/>
+            <number variable="page" form="short"/>
           </if>
           <else-if type="article-magazine">
             <label variable="page" form="short" suffix=" "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </else-if>
         </choose>
       </else-if>
@@ -1622,10 +1622,10 @@
       </if>
       <else-if is-numeric="page">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -1635,11 +1635,11 @@
         <text macro="locator-ja"/>
       </if>
       <else-if is-numeric="page">
-        <text variable="page-first"/>
+        <number variable="page-first"/>
         <label variable="page" form="short"/>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -1653,11 +1653,11 @@
         <choose>
           <if is-numeric="page">
             <text value="第"/>
-            <text variable="page"/>
+            <number variable="page"/>
             <text value="版"/>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>

--- a/src/中国林业科学研究院/中国林业科学研究院.csl
+++ b/src/中国林业科学研究院/中国林业科学研究院.csl
@@ -88,7 +88,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -129,7 +129,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -164,11 +164,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -338,7 +338,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -347,11 +347,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -364,7 +364,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -373,11 +373,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -392,7 +392,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -400,16 +400,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -450,7 +450,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -517,7 +517,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/中国现代文学研究丛刊/中国现代文学研究丛刊.csl
+++ b/src/中国现代文学研究丛刊/中国现代文学研究丛刊.csl
@@ -165,7 +165,7 @@
           <text variable="title" prefix="“" suffix=",” "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if position="subsequent" type="chapter" match="all">
@@ -175,7 +175,7 @@
           <text variable="title" prefix="“" suffix=",” "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="book">
@@ -218,7 +218,7 @@
           <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="paper-conference">
@@ -232,7 +232,7 @@
           <date date-parts="year-month-date" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="thesis">
@@ -257,8 +257,8 @@
               </names>
               <text variable="title" prefix="“" suffix=",” "/>
               <text variable="container-title" font-style="italic" suffix=", "/>
-              <text variable="volume" prefix="Vol. " suffix=", "/>
-              <text variable="issue" prefix="No. " suffix=", "/>
+              <number variable="volume" prefix="Vol. " suffix=", "/>
+              <number variable="issue" prefix="No. " suffix=", "/>
               <date date-parts="year" form="text" variable="issued"/>
               <group>
                 <label variable="locator" form="short" prefix=", "/>
@@ -271,12 +271,12 @@
               </names>
               <text variable="title" prefix="“" suffix=",” "/>
               <text variable="container-title" font-style="italic" suffix=", "/>
-              <text variable="volume" prefix="Vol. " suffix=", "/>
-              <text variable="issue" prefix="No. " suffix=", "/>
+              <number variable="volume" prefix="Vol. " suffix=", "/>
+              <number variable="issue" prefix="No. " suffix=", "/>
               <date date-parts="year" form="text" variable="issued"/>
               <group>
                 <label variable="page" form="short" prefix=", "/>
-                <text variable="page"/>
+                <number variable="page"/>
               </group>
             </else>
           </choose>
@@ -316,7 +316,7 @@
           <text variable="archive_location"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else>
       </choose>
@@ -350,7 +350,7 @@
           <text macro="secondAuthor" suffix="，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date date-parts="year" form="text" variable="issued"/>
-          <text variable="issue" prefix="第" suffix="期"/>
+          <number variable="issue" prefix="第" suffix="期"/>
         </else-if>
         <else-if type="article-newspaper">
           <text macro="author" suffix="："/>
@@ -358,7 +358,7 @@
           <text macro="secondAuthor" suffix="，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date form="text" variable="issued"/>
-          <text variable="edition" prefix="，"/>
+          <number variable="edition" prefix="，"/>
           <text variable="section" prefix="，"/>
         </else-if>
         <else-if type="chapter">
@@ -368,25 +368,25 @@
               <text variable="title" prefix="：《" suffix="》，"/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="editor" prefix="，" suffix="主编"/>
               <text macro="secondAuthor" prefix="，" suffix="，"/>
               <text variable="publisher"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </if>
             <else>
               <text macro="author"/>
               <text variable="title" prefix="：《" suffix="》，"/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="editor" prefix="，" suffix="主编"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </else>
           </choose>
         </else-if>
@@ -425,8 +425,8 @@
               <text variable="title" prefix="《" suffix="》，"/>
               <text macro="secondAuthor" suffix="，"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher"/>
               <text macro="date" suffix="版"/>
               <text macro="locators-zh"/>
@@ -437,8 +437,8 @@
               <text macro="editor" suffix="主编："/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
               <text macro="locators-zh"/>
@@ -452,8 +452,8 @@
           <text variable="title" prefix="《" suffix="》"/>
           <text macro="secondAuthor"/>
           <date date-parts="year-month-date" form="text" variable="issued" prefix="，" suffix="，"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
           <text variable="publisher-place" prefix="，" suffix="："/>
           <text variable="publisher"/>
           <text variable="archive" suffix="，"/>
@@ -511,7 +511,7 @@
           <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="paper-conference">
@@ -525,7 +525,7 @@
           <date date-parts="year-month-date" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="thesis">
@@ -548,12 +548,12 @@
           </names>
           <text variable="title" prefix="“" suffix=",” "/>
           <text variable="container-title" font-style="italic" suffix=", "/>
-          <text variable="volume" prefix="Vol. " suffix=", "/>
-          <text variable="issue" prefix="No. " suffix=", "/>
+          <number variable="volume" prefix="Vol. " suffix=", "/>
+          <number variable="issue" prefix="No. " suffix=", "/>
           <date date-parts="year" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="article-newspaper">
@@ -591,7 +591,7 @@
           <text variable="archive_location"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else>
       </choose>
@@ -625,7 +625,7 @@
           <text macro="secondAuthor" suffix="，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date date-parts="year" form="text" variable="issued"/>
-          <text variable="issue" prefix="第" suffix="期"/>
+          <number variable="issue" prefix="第" suffix="期"/>
         </else-if>
         <else-if type="article-newspaper">
           <text macro="author" suffix="："/>
@@ -633,7 +633,7 @@
           <text macro="secondAuthor" suffix="，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date form="text" variable="issued"/>
-          <text variable="edition" prefix="，"/>
+          <number variable="edition" prefix="，"/>
           <text variable="section" prefix="，"/>
         </else-if>
         <else-if type="chapter">
@@ -643,25 +643,25 @@
               <text variable="title" prefix="：《" suffix="》，"/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="editor" prefix="，" suffix="主编"/>
               <text macro="secondAuthor" prefix="，" suffix="，"/>
               <text variable="publisher"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </if>
             <else>
               <text macro="author"/>
               <text variable="title" prefix="：《" suffix="》，"/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="editor" prefix="，" suffix="主编"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </else>
           </choose>
         </else-if>
@@ -700,8 +700,8 @@
               <text variable="title" prefix="《" suffix="》，"/>
               <text macro="secondAuthor" suffix="，"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher"/>
               <text macro="date" suffix="版"/>
               <text macro="locators-zh"/>
@@ -712,8 +712,8 @@
               <text macro="editor" suffix="主编："/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
               <text macro="locators-zh"/>
@@ -727,8 +727,8 @@
           <text variable="title" prefix="《" suffix="》"/>
           <text macro="secondAuthor"/>
           <date date-parts="year-month-date" form="text" variable="issued" prefix="，" suffix="，"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
           <text variable="publisher-place" prefix="，" suffix="："/>
           <text variable="publisher"/>
           <text variable="archive" suffix="，"/>

--- a/src/中国生态农业学报/中国生态农业学报.csl
+++ b/src/中国生态农业学报/中国生态农业学报.csl
@@ -95,7 +95,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -135,7 +135,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -160,11 +160,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -302,7 +302,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -311,11 +311,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -328,7 +328,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -337,11 +337,11 @@
             <group delimiter=", ">
               <text variable="original-container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -356,7 +356,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -364,9 +364,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -394,7 +394,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -440,7 +440,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中国电机工程学报/中国电机工程学报.csl
+++ b/src/中国电机工程学报/中国电机工程学报.csl
@@ -85,7 +85,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -126,7 +126,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -161,11 +161,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -313,7 +313,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -322,11 +322,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -339,7 +339,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -348,11 +348,11 @@
             <group delimiter="，">
               <text variable="original-container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -367,7 +367,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -375,9 +375,9 @@
   <macro name="year-volume-issue">
     <group delimiter="，">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -405,7 +405,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -460,7 +460,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中国矿业大学-外文学院（文学、翻译方向-MLA）/中国矿业大学-外文学院（文学、翻译方向-MLA）.csl
+++ b/src/中国矿业大学-外文学院（文学、翻译方向-MLA）/中国矿业大学-外文学院（文学、翻译方向-MLA）.csl
@@ -134,9 +134,9 @@
             <group delimiter=". ">
               <group delimiter=" ">
                 <text macro="container-title-en"/>
-                <text variable="volume"/>
+                <number variable="volume"/>
               </group>
-              <text variable="issue"/>
+              <number variable="issue"/>
             </group>
             <text macro="publication-date-en" prefix="(" suffix=")"/>
           </group>
@@ -210,7 +210,7 @@
           </group>
         </if>
         <else>
-          <text variable="edition" text-case="capitalize-first"/>
+          <number variable="edition" text-case="capitalize-first"/>
         </else>
       </choose>
       <text variable="version"/>
@@ -220,7 +220,7 @@
   <macro name="volume-lowercase-en">
     <group delimiter=" ">
       <text term="volume" form="short"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
   </macro>
   <macro name="number-en">
@@ -252,21 +252,21 @@
           <else>
             <group delimiter=" ">
               <text term="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </else>
         </choose>
       </group>
       <group delimiter=" ">
         <text term="issue" form="short"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <choose>
         <if type="report">
           <text variable="genre"/>
         </if>
       </choose>
-      <text variable="number"/>
+      <number variable="number"/>
     </group>
   </macro>
   <macro name="publisher-en">
@@ -309,14 +309,14 @@
     <group delimiter=", ">
       <choose>
         <if type="article-journal article-magazine" match="any">
-          <text variable="page"/>
+          <number variable="page"/>
         </if>
         <else-if type="article-newspaper">
           <label variable="page" text-case="capitalize-first" suffix=" "/>
-          <text variable="page"/>
+          <number variable="page"/>
         </else-if>
         <else-if variable="container-title" match="any">
-          <text variable="page"/>
+          <number variable="page"/>
         </else-if>
       </choose>
     </group>
@@ -401,7 +401,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -436,11 +436,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -567,7 +567,7 @@
           <text variable="container-title"/>
           <text macro="issued-date-zh"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）: 页码[引用日期]” -->
@@ -576,11 +576,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -595,7 +595,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -603,9 +603,9 @@
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-zh">
@@ -633,7 +633,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/中国矿业大学/中国矿业大学.csl
+++ b/src/中国矿业大学/中国矿业大学.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -238,7 +238,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -247,11 +247,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -266,7 +266,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -274,9 +274,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -304,7 +304,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中国社会科学/中国社会科学.csl
+++ b/src/中国社会科学/中国社会科学.csl
@@ -70,7 +70,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -90,7 +90,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -102,7 +102,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -265,7 +265,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -526,7 +526,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -545,7 +545,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/中国科学院大学（著者-出版年）/中国科学院大学（著者-出版年）.csl
+++ b/src/中国科学院大学（著者-出版年）/中国科学院大学（著者-出版年）.csl
@@ -114,7 +114,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -149,11 +149,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -280,7 +280,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -289,11 +289,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -308,7 +308,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -316,9 +316,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -346,7 +346,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中国科学院大学（顺序编码）/中国科学院大学（顺序编码）.csl
+++ b/src/中国科学院大学（顺序编码）/中国科学院大学（顺序编码）.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -238,7 +238,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -247,11 +247,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -266,7 +266,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -274,9 +274,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -304,7 +304,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中国科学：地球科学/中国科学：地球科学.csl
+++ b/src/中国科学：地球科学/中国科学：地球科学.csl
@@ -128,7 +128,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -159,11 +159,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -228,7 +228,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -236,16 +236,16 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <choose>
             <if variable="page">
-              <text variable="page"/>
+              <number variable="page"/>
             </if>
             <else>
-              <text variable="number"/>
+              <number variable="number"/>
             </else>
           </choose>
         </group>
@@ -262,7 +262,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -270,9 +270,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -291,7 +291,7 @@
             </choose>
             <text term="patent" text-case="title"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-date"/>
         </group>
       </if>
@@ -327,7 +327,7 @@
                 </else>
               </choose>
             </group>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </group>
       </else-if>
@@ -349,7 +349,7 @@
             </choose>
             <text term="patent" text-case="title"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-date"/>
         </group>
       </if>
@@ -385,7 +385,7 @@
                 </else>
               </choose>
             </group>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </group>
       </else-if>

--- a/src/中国药科大学（本科）/中国药科大学（本科）.csl
+++ b/src/中国药科大学（本科）/中国药科大学（本科）.csl
@@ -58,7 +58,7 @@
             </group>
             <group delimiter=", ">
               <text macro="patent-country" font-style="italic"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </else-if>
@@ -69,7 +69,7 @@
         <else>
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <group delimiter=": ">
@@ -93,11 +93,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -236,7 +236,7 @@
           </group>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -248,11 +248,11 @@
                 <text variable="original-container-title" prefix="(" suffix=")"/>
               </group>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -267,7 +267,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -275,9 +275,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -298,7 +298,7 @@
               </group>
               <text macro="issued-year"/>
             </group>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
           <text macro="accessed-date"/>
         </else-if>

--- a/src/中国行政管理/中国行政管理.csl
+++ b/src/中国行政管理/中国行政管理.csl
@@ -85,7 +85,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -131,7 +131,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -166,11 +166,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -294,7 +294,7 @@
           <text variable="container-title" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page"/>
+        <number variable="page"/>
       </if>
       <else>
         <group delimiter=": ">
@@ -302,11 +302,11 @@
             <group delimiter=", ">
               <text variable="container-title" font-style="italic"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -327,7 +327,7 @@
             <text variable="container-title"/>
             <text macro="issued-year"/>
           </group>
-          <text variable="issue" prefix="（" suffix="）"/>
+          <number variable="issue" prefix="（" suffix="）"/>
         </group>
       </else>
     </choose>
@@ -342,7 +342,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -350,9 +350,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -371,7 +371,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中国计量大学/中国计量大学.csl
+++ b/src/中国计量大学/中国计量大学.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -238,7 +238,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -247,11 +247,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -266,7 +266,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -274,9 +274,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -304,7 +304,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中国高等学校自然科学学报编排规范/中国高等学校自然科学学报编排规范.csl
+++ b/src/中国高等学校自然科学学报编排规范/中国高等学校自然科学学报编排规范.csl
@@ -84,7 +84,7 @@
       <group delimiter=" ">
         <choose>
           <if type="standard">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
         <text variable="title"/>
@@ -95,7 +95,7 @@
         </choose>
         <choose>
           <if type="bill legal_case legislation regulation report" match="any">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
       </group>
@@ -111,7 +111,7 @@
       <group delimiter=" ">
         <choose>
           <if type="standard">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
         <group delimiter="：">
@@ -124,7 +124,7 @@
             </choose>
             <choose>
               <if type="bill legal_case legislation regulation report" match="any">
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
           </group>
@@ -145,11 +145,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -261,7 +261,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <date variable="issued" form="numeric"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -270,11 +270,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <date variable="issued" form="numeric" date-parts="year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -287,7 +287,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <date variable="issued" form="numeric"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -296,11 +296,11 @@
             <group delimiter="，">
               <text variable="container-title" form="short" strip-periods="true"/>
               <date variable="issued" form="numeric" date-parts="year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -315,7 +315,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -327,7 +327,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -335,16 +335,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <date variable="issued" form="numeric" date-parts="year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <date variable="issued" form="numeric" date-parts="year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -357,7 +357,7 @@
               <text macro="patent-country-en"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <date variable="issued" form="numeric"/>
         </group>
@@ -371,7 +371,7 @@
             </group>
             <date variable="issued" form="numeric" date-parts="year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -386,7 +386,7 @@
               <text macro="patent-country-zh"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <date variable="issued" form="numeric"/>
         </group>
@@ -400,7 +400,7 @@
             </group>
             <date variable="issued" form="numeric" date-parts="year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>

--- a/src/中外法学/中外法学.csl
+++ b/src/中外法学/中外法学.csl
@@ -205,7 +205,7 @@
                 <!-- 若同时有期刊卷册数和年份，则将卷册数标注在期刊名称之后，随后再以括号标记年份。 -->
                 <if variable="volume">
                   <text macro="container-de"/>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                   <text macro="issuance-de" prefix="(" suffix=")"/>
                 </if>
                 <else>
@@ -302,12 +302,12 @@
                 </if>
                 <!-- 引用判例集中的判决时，标出判例集的名称、卷号 -->
                 <else>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                 </else>
               </choose>
             </group>
             <group delimiter=" ">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
               <text variable="locator" prefix="(" suffix=")"/>
             </group>
           </group>
@@ -373,7 +373,7 @@
                   <text macro="title-en"/>
                   <group delimiter=" ">
                     <text value="Pub. L. No."/>
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </group>
                   <text macro="section-en"/>
                   <text macro="container-en"/>
@@ -390,7 +390,7 @@
                 </group>
               </else>
             </choose>
-            <text variable="page"/>
+            <number variable="page"/>
             <text macro="locator-en"/>
             <text macro="issuance-en" prefix="(" suffix=")"/>
           </group>
@@ -402,13 +402,13 @@
               <text macro="title-en"/>
               <group delimiter=" ">
                 <text value="No."/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
             <text macro="container-en"/>
             <group delimiter=", ">
-              <text variable="page"/>
+              <number variable="page"/>
               <text variable="locator"/>
             </group>
             <group delimiter=" " prefix="(" suffix=")">
@@ -526,7 +526,7 @@
           <text macro="title-zh"/>
           <choose>
             <if variable="section locator" match="none">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -585,7 +585,7 @@
           <text macro="author-zh"/>
           <group delimiter="，">
             <text macro="title-zh"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </group>
       </else-if>
@@ -679,7 +679,7 @@
             </else-if>
             <else-if variable="section locator" match="any">
               <!-- 64.1 《最高人民法院关于适用〈中华人民共和国行政诉讼法〉的解释》(法释 〔2018〕1 号)，第 100 条。 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </else-if>
           </choose>
         </group>
@@ -729,7 +729,7 @@
         <label variable="edition" form="short" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -741,7 +741,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -780,7 +780,7 @@
       </else-if>
       <else-if type="legislation">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title"/>
         </group>
       </else-if>
@@ -804,7 +804,7 @@
           <group delimiter=", ">
             <text macro="editor-en"/>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title" text-case="title" font-style="italic"/>
             </group>
           </group>
@@ -812,7 +812,7 @@
       </else-if>
       <else-if type="legislation">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title" text-case="title"/>
         </group>
       </else-if>
@@ -878,7 +878,7 @@
                   </else>
                 </choose>
               </group>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </else>
         </choose>
@@ -916,7 +916,7 @@
         <number variable="volume" form="roman" text-case="uppercase"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -927,7 +927,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -939,7 +939,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -950,7 +950,7 @@
         <number variable="issue"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -969,7 +969,7 @@
         </choose>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1137,16 +1137,16 @@
         <choose>
           <if type="article-newspaper">
             <text term="at" suffix=" "/>
-            <text variable="page" form="short"/>
+            <number variable="page" form="short"/>
           </if>
           <else>
             <label variable="page" form="short" suffix=" "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -1160,11 +1160,11 @@
         <choose>
           <if is-numeric="page">
             <text value="第"/>
-            <text variable="page"/>
+            <number variable="page"/>
             <text value="版"/>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>

--- a/src/中央财经大学学报/中央财经大学学报.csl
+++ b/src/中央财经大学学报/中央财经大学学报.csl
@@ -118,7 +118,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -153,11 +153,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -284,7 +284,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -293,11 +293,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -312,7 +312,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -320,9 +320,9 @@
   <macro name="year-volume-issue">
     <group delimiter="，">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -350,7 +350,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/中山大学/中山大学.csl
+++ b/src/中山大学/中山大学.csl
@@ -100,7 +100,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -137,7 +137,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -168,11 +168,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -266,7 +266,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -275,11 +275,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -292,7 +292,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码[引用日期]” -->
@@ -301,11 +301,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -320,7 +320,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -328,16 +328,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -370,7 +370,7 @@
             </else>
           </choose>
           <text variable="publisher"/>
-          <text variable="page"/>
+          <number variable="page"/>
           <text macro="issued-year-en"/>
         </group>
       </else-if>
@@ -393,7 +393,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -454,7 +454,7 @@
             </else>
           </choose>
           <text variable="publisher"/>
-          <text variable="page"/>
+          <number variable="page"/>
           <text macro="issued-year-zh"/>
         </group>
       </else-if>
@@ -477,7 +477,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/云南大学/云南大学.csl
+++ b/src/云南大学/云南大学.csl
@@ -73,7 +73,7 @@
   </macro>
   <macro name="title">
     <text variable="title"/>
-    <text variable="number" prefix=": "/>
+    <number variable="number" prefix=": "/>
     <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-id"/>
       <choose>
@@ -133,7 +133,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -141,10 +141,10 @@
   </macro>
   <macro name="serial-information">
     <group delimiter=", ">
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -155,7 +155,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/云南师范大学（本科）/云南师范大学（本科）.csl
+++ b/src/云南师范大学（本科）/云南师范大学（本科）.csl
@@ -87,7 +87,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -128,7 +128,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -163,11 +163,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -337,7 +337,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -346,11 +346,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -363,7 +363,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码[引用日期]” -->
@@ -372,11 +372,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -391,7 +391,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -399,16 +399,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -436,7 +436,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -491,7 +491,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/人文地理/人文地理.csl
+++ b/src/人文地理/人文地理.csl
@@ -79,7 +79,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -114,7 +114,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -139,11 +139,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -294,7 +294,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -303,16 +303,16 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <choose>
             <if variable="page">
-              <text variable="page"/>
+              <number variable="page"/>
             </if>
             <else>
-              <text variable="number"/>
+              <number variable="number"/>
             </else>
           </choose>
         </group>
@@ -327,7 +327,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -336,16 +336,16 @@
             <group delimiter=", ">
               <text variable="original-container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <choose>
             <if variable="page">
-              <text variable="page"/>
+              <number variable="page"/>
             </if>
             <else>
-              <text variable="number"/>
+              <number variable="number"/>
             </else>
           </choose>
         </group>
@@ -362,7 +362,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -370,9 +370,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -400,7 +400,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -455,7 +455,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/人民出版社/人民出版社.csl
+++ b/src/人民出版社/人民出版社.csl
@@ -67,7 +67,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -79,7 +79,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -91,7 +91,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -197,7 +197,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -391,7 +391,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/会计研究/会计研究.csl
+++ b/src/会计研究/会计研究.csl
@@ -74,7 +74,7 @@
     <text variable="title" text-case="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation patent report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -93,7 +93,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -101,15 +101,15 @@
   </macro>
   <macro name="serial-information">
     <group delimiter=", ">
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="serial-information-zh">
     <group delimiter=": ">
-      <text variable="issue"/>
-      <text variable="page"/>
+      <number variable="issue"/>
+      <number variable="page"/>
     </group>
   </macro>
   <macro name="publisher">
@@ -121,7 +121,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/信息安全学报/信息安全学报.csl
+++ b/src/信息安全学报/信息安全学报.csl
@@ -94,7 +94,7 @@
           <choose>
             <if type="article article-journal report" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -132,7 +132,7 @@
           <choose>
             <if type="article article-journal report" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -167,11 +167,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -290,7 +290,7 @@
           </group>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -301,11 +301,11 @@
                 <text variable="container-title"/>
               </group>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -320,7 +320,7 @@
           </group>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -331,11 +331,11 @@
                 <text variable="original-container-title"/>
               </group>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -350,7 +350,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -358,9 +358,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -372,7 +372,7 @@
       <else-if type="paper-conference">
         <group delimiter=": ">
           <text macro="issued-year"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if type="dataset post post-weblog software webpage" match="any"/>
@@ -387,7 +387,7 @@
                 <text term="report" text-case="capitalize-first"/>
               </else>
             </choose>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <group delimiter=", ">
             <text variable="publisher"/>
@@ -401,7 +401,7 @@
           <group delimiter=" ">
             <text variable="publisher"/>
             <text term="preprint" text-case="capitalize-first"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </group>
       </else-if>
@@ -424,7 +424,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -438,7 +438,7 @@
       <else-if type="paper-conference">
         <group delimiter=": ">
           <text macro="issued-year"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if type="dataset post post-weblog software webpage" match="any"/>
@@ -453,7 +453,7 @@
                 <text term="report" text-case="capitalize-first"/>
               </else>
             </choose>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <group delimiter=", ">
             <text variable="original-publisher"/>
@@ -467,7 +467,7 @@
           <group delimiter=" ">
             <text variable="original-publisher"/>
             <text term="preprint" text-case="capitalize-first"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </group>
       </else-if>
@@ -490,7 +490,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>

--- a/src/傳播與社會學刊/傳播與社會學刊.csl
+++ b/src/傳播與社會學刊/傳播與社會學刊.csl
@@ -691,7 +691,7 @@
                     <if is-numeric="volume" match="none">
                       <group delimiter=" ">
                         <label variable="volume" form="short" text-case="capitalize-first"/>
-                        <text variable="volume"/>
+                        <number variable="volume"/>
                       </group>
                     </if>
                   </choose>
@@ -710,7 +710,7 @@
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
                     <label variable="volume" form="short" text-case="capitalize-first"/>
-                    <text variable="volume"/>
+                    <number variable="volume"/>
                   </group>
                 </if>
               </choose>
@@ -747,7 +747,7 @@
                     <if is-numeric="volume" match="none">
                       <group delimiter=" ">
                         <label variable="volume" form="short" text-case="capitalize-first"/>
-                        <text variable="volume"/>
+                        <number variable="volume"/>
                       </group>
                     </if>
                   </choose>
@@ -766,7 +766,7 @@
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
                     <label variable="volume" form="short" text-case="capitalize-first"/>
-                    <text variable="volume"/>
+                    <number variable="volume"/>
                   </group>
                 </if>
               </choose>
@@ -796,7 +796,7 @@
                     <label variable="number" form="short" text-case="capitalize-first"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </group>
           </else>
@@ -853,7 +853,7 @@
                     <label variable="number" form="short" text-case="capitalize-first"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </group>
           </else>
@@ -910,7 +910,7 @@
             </choose>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </if>
@@ -988,7 +988,7 @@
             </choose>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </if>
@@ -1873,7 +1873,7 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <choose>
@@ -1899,7 +1899,7 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <choose>
@@ -1986,7 +1986,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -2026,11 +2026,11 @@
       </choose>
       <group delimiter=" ">
         <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -2070,11 +2070,11 @@
       </choose>
       <group delimiter=" ">
         <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <group>
         <label variable="page" form="short"/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -2264,12 +2264,12 @@
         <choose>
           <if variable="volume">
             <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
+              <number variable="volume" font-style="italic"/>
+              <number variable="issue" prefix="(" suffix=")"/>
             </group>
           </if>
           <else>
-            <text variable="issue" font-style="italic"/>
+            <number variable="issue" font-style="italic"/>
           </else>
         </choose>
         <choose>
@@ -2278,7 +2278,7 @@
             <!-- This should be localized -->
             <group delimiter=" ">
               <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </if>
           <else>
@@ -2288,7 +2288,7 @@
                   <label variable="page" form="short"/>
                 </if>
               </choose>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -2312,12 +2312,12 @@
         <group>
           <group>
             <text value="第"/>
-            <text variable="volume"/>
+            <number variable="volume"/>
             <label variable="volume"/>
           </group>
           <group>
             <text value="第"/>
-            <text variable="issue"/>
+            <number variable="issue"/>
             <label variable="issue"/>
           </group>
         </group>
@@ -2327,7 +2327,7 @@
             <!-- This should be localized -->
             <group delimiter=" ">
               <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </if>
           <else>
@@ -2335,14 +2335,14 @@
               <if type="article-newspaper">
                 <group>
                   <text value="第"/>
-                  <text variable="page"/>
+                  <number variable="page"/>
                   <text value="版"/>
                 </group>
               </if>
               <else>
                 <group>
                   <label variable="page"/>
-                  <text variable="page"/>
+                  <number variable="page"/>
                 </group>
               </else>
             </choose>
@@ -2385,7 +2385,7 @@
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
                     <label variable="volume" form="short" text-case="capitalize-first"/>
-                    <text variable="volume"/>
+                    <number variable="volume"/>
                   </group>
                 </if>
               </choose>
@@ -2419,7 +2419,7 @@
               <if is-numeric="volume" match="none">
                 <group delimiter=" ">
                   <label variable="volume" form="short" text-case="capitalize-first"/>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                 </group>
               </if>
             </choose>
@@ -2805,7 +2805,7 @@
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
                 <text term="on"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
@@ -2835,7 +2835,7 @@
               <group delimiter=" ">
                 <!-- APA manual omits the bill number，but it should be included per Bluebook if relevant -->
                 <text term="on"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
@@ -2951,12 +2951,12 @@
           <text variable="container-title"/>
           <choose>
             <if variable="page page-first" match="any">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -2967,7 +2967,7 @@
           <choose>
             <if variable="container-title">
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
                 <group delimiter=" ">
                   <label variable="section" form="symbol"/>
@@ -2975,7 +2975,7 @@
                 </group>
                 <choose>
                   <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
+                    <number variable="page-first"/>
                   </if>
                   <else>
                     <text value="___"/>
@@ -2986,7 +2986,7 @@
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3005,7 +3005,7 @@
                   <label variable="number" form="short" text-case="capitalize-first"/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
@@ -3014,9 +3014,9 @@
             <text variable="chapter-number"/>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </group>
         </group>
       </else-if>
@@ -3032,17 +3032,17 @@
           <if variable="number">
             <!-- There's a public law number. -->
             <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
+              <number variable="number" prefix="Pub. L. No. "/>
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </group>
             </group>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title"/>
               <choose>
                 <if variable="section">
@@ -3052,7 +3052,7 @@
                   </group>
                 </if>
                 <else>
-                  <text variable="page-first"/>
+                  <number variable="page-first"/>
                 </else>
               </choose>
             </group>
@@ -3065,11 +3065,11 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
             <choose>
               <if variable="section">
@@ -3079,7 +3079,7 @@
                 </group>
               </if>
               <else>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </else>
             </choose>
           </group>
@@ -3096,12 +3096,12 @@
           <text variable="container-title"/>
           <choose>
             <if variable="page page-first" match="any">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3112,7 +3112,7 @@
           <choose>
             <if variable="container-title">
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
                 <group delimiter=" ">
                   <label variable="section" form="symbol"/>
@@ -3120,7 +3120,7 @@
                 </group>
                 <choose>
                   <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
+                    <number variable="page-first"/>
                   </if>
                   <else>
                     <text value="___"/>
@@ -3131,7 +3131,7 @@
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3150,7 +3150,7 @@
                   <label variable="number" form="short" text-case="capitalize-first"/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
@@ -3159,9 +3159,9 @@
             <text variable="chapter-number"/>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </group>
         </group>
       </else-if>
@@ -3177,17 +3177,17 @@
           <if variable="number">
             <!-- There's a public law number. -->
             <group delimiter="，">
-              <text variable="number" prefix="Pub. L. No. "/>
+              <number variable="number" prefix="Pub. L. No. "/>
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </group>
             </group>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title"/>
               <choose>
                 <if variable="section">
@@ -3197,7 +3197,7 @@
                   </group>
                 </if>
                 <else>
-                  <text variable="page-first"/>
+                  <number variable="page-first"/>
                 </else>
               </choose>
             </group>
@@ -3210,11 +3210,11 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
             <choose>
               <if variable="section">
@@ -3224,7 +3224,7 @@
                 </group>
               </if>
               <else>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </else>
             </choose>
           </group>

--- a/src/公共行政评论/公共行政评论.csl
+++ b/src/公共行政评论/公共行政评论.csl
@@ -984,7 +984,7 @@
             <group delimiter=". ">
               <group delimiter=" ">
                 <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
+                <number variable="volume"/>
               </group>
               <text variable="volume-title"/>
             </group>
@@ -993,7 +993,7 @@
         <else-if is-numeric="volume" match="none">
           <group delimiter=" ">
             <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </group>
         </else-if>
       </choose>
@@ -1009,7 +1009,7 @@
             <group delimiter="．">
               <group>
                 <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
+                <number variable="volume"/>
               </group>
               <text variable="volume-title"/>
             </group>
@@ -1018,7 +1018,7 @@
         <else-if is-numeric="volume" match="none">
           <group>
             <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </group>
         </else-if>
       </choose>
@@ -1045,7 +1045,7 @@
                     <label variable="number" form="short" text-case="capitalize-first"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </group>
           </else>
@@ -1101,7 +1101,7 @@
                     <label variable="number" form="short" text-case="capitalize-first"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </group>
           </else>
@@ -1157,7 +1157,7 @@
             </choose>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </if>
@@ -1234,7 +1234,7 @@
             </choose>
             <group>
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </if>
@@ -2271,7 +2271,7 @@
             <text variable="genre" text-case="title"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <choose>
@@ -2296,7 +2296,7 @@
             <text variable="genre"/>
             <group>
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <choose>
@@ -2374,7 +2374,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -2417,11 +2417,11 @@
       </choose>
       <group delimiter=" ">
         <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -2464,11 +2464,11 @@
       </choose>
       <group>
         <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <group>
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -2643,12 +2643,12 @@
         <choose>
           <if variable="volume">
             <group>
-              <text variable="volume"/>
-              <text variable="issue" prefix="(" suffix=")"/>
+              <number variable="volume"/>
+              <number variable="issue" prefix="(" suffix=")"/>
             </group>
           </if>
           <else>
-            <text variable="issue"/>
+            <number variable="issue"/>
           </else>
         </choose>
         <choose>
@@ -2656,11 +2656,11 @@
             <!-- Ex. 6: Journal article with article number or eLocator -->
             <group delimiter=" ">
               <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </group>
@@ -2683,12 +2683,12 @@
         <choose>
           <if variable="volume">
             <group>
-              <text variable="volume"/>
-              <text variable="issue" prefix="（" suffix="）"/>
+              <number variable="volume"/>
+              <number variable="issue" prefix="（" suffix="）"/>
             </group>
           </if>
           <else>
-            <text variable="issue"/>
+            <number variable="issue"/>
           </else>
         </choose>
         <choose>
@@ -2696,11 +2696,11 @@
             <!-- Ex. 6：Journal article with article number or eLocator -->
             <group>
               <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </group>
@@ -3256,7 +3256,7 @@
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
                 <text term="on"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
@@ -3286,7 +3286,7 @@
               <group>
                 <!-- APA manual omits the bill number，but it should be included per Bluebook if relevant -->
                 <text term="on"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
               <group>
                 <!-- Use the `at` term to hold "before the" -->
@@ -3402,12 +3402,12 @@
           <text variable="container-title"/>
           <choose>
             <if variable="page page-first" match="any">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3418,7 +3418,7 @@
           <choose>
             <if variable="container-title">
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
                 <group delimiter=" ">
                   <label variable="section" form="symbol"/>
@@ -3426,7 +3426,7 @@
                 </group>
                 <choose>
                   <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
+                    <number variable="page-first"/>
                   </if>
                   <else>
                     <text value="___"/>
@@ -3437,7 +3437,7 @@
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3456,7 +3456,7 @@
                   <label variable="number" form="short" text-case="capitalize-first"/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
@@ -3465,9 +3465,9 @@
             <text variable="chapter-number"/>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </group>
         </group>
       </else-if>
@@ -3483,17 +3483,17 @@
           <if variable="number">
             <!-- There's a public law number. -->
             <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
+              <number variable="number" prefix="Pub. L. No. "/>
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </group>
             </group>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title"/>
               <choose>
                 <if variable="section">
@@ -3503,7 +3503,7 @@
                   </group>
                 </if>
                 <else>
-                  <text variable="page-first"/>
+                  <number variable="page-first"/>
                 </else>
               </choose>
             </group>
@@ -3516,11 +3516,11 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
             <choose>
               <if variable="section">
@@ -3530,7 +3530,7 @@
                 </group>
               </if>
               <else>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </else>
             </choose>
           </group>
@@ -3547,12 +3547,12 @@
           <text variable="container-title"/>
           <choose>
             <if variable="page page-first" match="any">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
               <group>
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3563,7 +3563,7 @@
           <choose>
             <if variable="container-title">
               <group>
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
                 <group>
                   <label variable="section" form="symbol"/>
@@ -3571,7 +3571,7 @@
                 </group>
                 <choose>
                   <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
+                    <number variable="page-first"/>
                   </if>
                   <else>
                     <text value="___"/>
@@ -3582,7 +3582,7 @@
             <else>
               <group>
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3601,7 +3601,7 @@
                   <label variable="number" form="short" text-case="capitalize-first"/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group>
@@ -3610,9 +3610,9 @@
             <text variable="chapter-number"/>
           </group>
           <group>
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </group>
         </group>
       </else-if>
@@ -3628,17 +3628,17 @@
           <if variable="number">
             <!-- There's a public law number. -->
             <group delimiter="，">
-              <text variable="number" prefix="Pub. L. No. "/>
+              <number variable="number" prefix="Pub. L. No. "/>
               <group>
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </group>
             </group>
           </if>
           <else>
             <group>
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title"/>
               <choose>
                 <if variable="section">
@@ -3648,7 +3648,7 @@
                   </group>
                 </if>
                 <else>
-                  <text variable="page-first"/>
+                  <number variable="page-first"/>
                 </else>
               </choose>
             </group>
@@ -3661,11 +3661,11 @@
             <text variable="genre"/>
             <group>
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group>
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
             <choose>
               <if variable="section">
@@ -3675,7 +3675,7 @@
                 </group>
               </if>
               <else>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </else>
             </choose>
           </group>

--- a/src/兽类学报/兽类学报.csl
+++ b/src/兽类学报/兽类学报.csl
@@ -121,7 +121,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -152,11 +152,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -220,7 +220,7 @@
           <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -228,11 +228,11 @@
           <group delimiter=" ">
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
-              <text variable="volume" font-weight="bold"/>
+              <number variable="volume" font-weight="bold"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -247,7 +247,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -255,9 +255,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -282,7 +282,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/农业工程学报/农业工程学报.csl
+++ b/src/农业工程学报/农业工程学报.csl
@@ -75,7 +75,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation patent report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -172,7 +172,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -181,10 +181,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -196,7 +196,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/农业技术经济/农业技术经济.csl
+++ b/src/农业技术经济/农业技术经济.csl
@@ -113,7 +113,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -144,11 +144,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -209,7 +209,7 @@
           <text variable="container-title" text-case="title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -218,11 +218,11 @@
             <group delimiter=", ">
               <text variable="container-title" text-case="title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -237,7 +237,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -245,9 +245,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -273,7 +273,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/化学进展/化学进展.csl
+++ b/src/化学进展/化学进展.csl
@@ -84,7 +84,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -117,7 +117,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -150,11 +150,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -202,7 +202,7 @@
           <text variable="container-title" form="short" font-style="italic"/>
           <text macro="issued-date" font-weight="bold"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -211,11 +211,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" font-style="italic"/>
               <text macro="issued-year" font-weight="bold"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -228,7 +228,7 @@
           <text variable="container-title" form="short"/>
           <text macro="issued-date" font-weight="bold"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -237,11 +237,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short"/>
               <text macro="issued-year" font-weight="bold"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -254,7 +254,7 @@
           <text variable="original-container-title" form="short" font-style="italic"/>
           <text macro="issued-date" font-weight="bold"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -263,11 +263,11 @@
             <group delimiter=", ">
               <text variable="original-container-title" form="short" font-style="italic"/>
               <text macro="issued-year" font-weight="bold"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -282,7 +282,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -290,9 +290,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -300,7 +300,7 @@
       <if type="patent">
         <!-- 专利的出版项格式“公告日期[引用日期]” -->
         <group delimiter=". ">
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-year" font-weight="bold"/>
         </group>
       </if>
@@ -340,7 +340,7 @@
             </group>
             <text macro="issued-year" font-weight="bold"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>
@@ -376,7 +376,7 @@
       <if type="patent">
         <!-- 专利的出版项格式“公告日期[引用日期]” -->
         <group delimiter=". ">
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-year" font-weight="bold"/>
         </group>
       </if>
@@ -415,7 +415,7 @@
             </group>
             <text macro="issued-year" font-weight="bold"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>
@@ -451,7 +451,7 @@
       <if type="patent">
         <!-- 专利的出版项格式“公告日期[引用日期]” -->
         <group delimiter=". ">
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-year" font-weight="bold"/>
         </group>
       </if>
@@ -488,7 +488,7 @@
             </group>
             <text macro="issued-year" font-weight="bold"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/北京大学（顺序编码）/北京大学（顺序编码）.csl
+++ b/src/北京大学（顺序编码）/北京大学（顺序编码）.csl
@@ -78,7 +78,7 @@
                     <text macro="patent-country"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </if>
           </choose>
@@ -114,11 +114,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -257,7 +257,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -266,11 +266,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -285,7 +285,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -293,9 +293,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -323,7 +323,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/北京师范大学/北京师范大学.csl
+++ b/src/北京师范大学/北京师范大学.csl
@@ -115,7 +115,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -150,11 +150,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -281,7 +281,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -289,11 +289,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -308,7 +308,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -316,9 +316,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -343,7 +343,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/北京林业大学/北京林业大学.csl
+++ b/src/北京林业大学/北京林业大学.csl
@@ -77,7 +77,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -112,11 +112,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -231,7 +231,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -240,11 +240,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -259,7 +259,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -267,9 +267,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -284,7 +284,7 @@
           <group delimiter=" ">
             <text variable="publisher"/>
             <text term="preprint"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-year"/>
         </group>
@@ -308,7 +308,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/北京林业大学（本科）/北京林业大学（本科）.csl
+++ b/src/北京林业大学（本科）/北京林业大学（本科）.csl
@@ -73,7 +73,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -108,11 +108,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -247,7 +247,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -256,11 +256,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -275,7 +275,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -283,9 +283,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -313,7 +313,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/北京理工大学/北京理工大学.csl
+++ b/src/北京理工大学/北京理工大学.csl
@@ -71,11 +71,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -142,7 +142,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -183,7 +183,7 @@
           </else-if>
         </choose>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
     <choose>
       <!-- 纯电子资源显示“更新或修改日期” -->
@@ -227,11 +227,11 @@
               <text macro="issued-year"/>
             </else>
           </choose>
-          <text variable="volume"/>
+          <number variable="volume"/>
         </group>
-        <text variable="issue" prefix="(" suffix=")"/>
+        <number variable="issue" prefix="(" suffix=")"/>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
   </macro>
   <!-- 题名 -->
@@ -257,11 +257,11 @@
                     <text variable="publisher-place"/>
                   </else>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </if>
             <else-if type="bill legal_case legislation regulation report standard" match="any">
-              <text variable="number"/>
+              <number variable="number"/>
             </else-if>
           </choose>
         </group>
@@ -362,9 +362,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 专著和电子资源 -->
   <macro name="monograph-layout">

--- a/src/北京航空航天大学/北京航空航天大学.csl
+++ b/src/北京航空航天大学/北京航空航天大学.csl
@@ -67,7 +67,7 @@
     <group delimiter=", ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=": ">
@@ -82,7 +82,7 @@
           <choose>
             <if type="article article-journal patent standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -117,11 +117,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -256,7 +256,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -266,12 +266,12 @@
               <text variable="container-title"/>
               <group delimiter=",">
                 <text macro="issued-year"/>
-                <text variable="volume"/>
+                <number variable="volume"/>
               </group>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -286,7 +286,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -294,9 +294,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -308,7 +308,7 @@
               <text macro="patent-country"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -332,7 +332,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else>
@@ -349,7 +349,7 @@
               <text macro="patent-country"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -373,7 +373,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else>

--- a/src/北方工业大学-英语专业（本科）/北方工业大学-英语专业（本科）.csl
+++ b/src/北方工业大学-英语专业（本科）/北方工业大学-英语专业（本科）.csl
@@ -134,7 +134,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -175,7 +175,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -210,11 +210,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -409,7 +409,7 @@
           <text variable="container-title" text-case="title" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -417,11 +417,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title" text-case="title" font-style="italic"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -434,7 +434,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，卷（期）：页码[引用日期]” -->
@@ -442,11 +442,11 @@
           <group>
             <group delimiter="，">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -461,7 +461,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -469,16 +469,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -503,7 +503,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -546,7 +546,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/华东师范大学/华东师范大学.csl
+++ b/src/华东师范大学/华东师范大学.csl
@@ -66,7 +66,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation patent report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -125,7 +125,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -134,10 +134,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -149,7 +149,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/华东理工大学-社会与公共管理学院/华东理工大学-社会与公共管理学院.csl
+++ b/src/华东理工大学-社会与公共管理学院/华东理工大学-社会与公共管理学院.csl
@@ -89,7 +89,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -109,7 +109,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -121,7 +121,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -253,7 +253,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -496,7 +496,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -515,7 +515,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/华东理工大学（本科）/华东理工大学（本科）.csl
+++ b/src/华东理工大学（本科）/华东理工大学（本科）.csl
@@ -74,7 +74,7 @@
           <choose>
             <if type="article article-journal patent standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -109,11 +109,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -296,7 +296,7 @@
               <date-part name="day" prefix="(" suffix=")"/>
             </date>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </if>
       <else>
@@ -306,11 +306,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -325,7 +325,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -333,9 +333,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -348,7 +348,7 @@
               <text macro="patent-country-en"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -372,7 +372,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if type="dataset post post-weblog software webpage" match="any">
@@ -407,7 +407,7 @@
               <text macro="patent-country-zh"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -431,7 +431,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if type="dataset post post-weblog software webpage" match="any">
@@ -549,7 +549,7 @@
         </else-if>
         <else-if type="standard">
           <!-- 国际、国家标准 -->
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="title"/>
           <text macro="publisher-en"/>
         </else-if>
@@ -603,7 +603,7 @@
         </else-if>
         <else-if type="standard">
           <!-- 国际、国家标准 -->
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="title"/>
           <text macro="publisher-zh"/>
         </else-if>

--- a/src/华中农业大学/华中农业大学.csl
+++ b/src/华中农业大学/华中农业大学.csl
@@ -80,7 +80,7 @@
   </macro>
   <macro name="title">
     <text variable="title"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
     <!-- <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-id"/>
       <text macro="medium-id"/>
@@ -101,7 +101,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -110,18 +110,18 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <!-- <text variable="issue" prefix="(" suffix=")"/> -->
-    <text variable="page" prefix=":"/>
+    <!-- <number variable="issue" prefix="(" suffix=")"/> -->
+    <number variable="page" prefix=":"/>
   </macro>
   <macro name="serial-information-zh">
     <group delimiter="，">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <!-- <text variable="issue" prefix="(" suffix=")"/> -->
-    <text variable="page" prefix=":"/>
+    <!-- <number variable="issue" prefix="(" suffix=")"/> -->
+    <number variable="page" prefix=":"/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -133,7 +133,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/华中科技大学-同济医学院/华中科技大学-同济医学院.csl
+++ b/src/华中科技大学-同济医学院/华中科技大学-同济医学院.csl
@@ -84,7 +84,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -119,7 +119,7 @@
         </choose>
         <choose>
           <if type="bill legal_case legislation regulation report standard" match="any">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
       </group>
@@ -144,11 +144,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -199,7 +199,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -208,11 +208,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -224,7 +224,7 @@
         <label variable="edition" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -237,7 +237,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -245,9 +245,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -257,7 +257,7 @@
         <group delimiter=", ">
           <text macro="patent-country"/>
           <text variable="genre"/>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-year"/>
         </group>
       </if>
@@ -270,7 +270,7 @@
             <text variable="publisher"/>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else>
@@ -292,7 +292,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>

--- a/src/华中科技大学-电气与电子工程学院/华中科技大学-电气与电子工程学院.csl
+++ b/src/华中科技大学-电气与电子工程学院/华中科技大学-电气与电子工程学院.csl
@@ -108,7 +108,7 @@
       <group delimiter=" ">
         <choose>
           <if type="standard">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
         <group delimiter=": ">
@@ -130,7 +130,7 @@
                 <choose>
                   <if type="article article-journal standard" match="none">
                     <!-- 预印本和期刊文章的编号用于其他位置 -->
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </if>
                 </choose>
               </group>
@@ -165,7 +165,7 @@
       <group delimiter=" ">
         <choose>
           <if type="standard">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
         <group delimiter="：">
@@ -187,7 +187,7 @@
                 <choose>
                   <if type="article article-journal standard" match="none">
                     <!-- 预印本和期刊文章的编号用于其他位置 -->
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </if>
                 </choose>
               </group>
@@ -235,11 +235,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -427,7 +427,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -436,11 +436,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -453,7 +453,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -462,11 +462,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -481,7 +481,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -493,7 +493,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -501,16 +501,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -538,7 +538,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -594,7 +594,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/华中科技大学-网络空间安全学院/华中科技大学-网络空间安全学院.csl
+++ b/src/华中科技大学-网络空间安全学院/华中科技大学-网络空间安全学院.csl
@@ -88,7 +88,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -123,7 +123,7 @@
         </choose>
         <choose>
           <if type="bill legal_case legislation regulation report standard" match="any">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
       </group>
@@ -148,11 +148,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -203,7 +203,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -212,11 +212,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -228,7 +228,7 @@
         <label variable="edition" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -241,7 +241,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -249,9 +249,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -261,7 +261,7 @@
         <group delimiter=", ">
           <text macro="patent-country"/>
           <text variable="genre"/>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-year"/>
         </group>
       </if>
@@ -274,7 +274,7 @@
             <text variable="publisher"/>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else>
@@ -296,7 +296,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>

--- a/src/华中科技大学（理工科）/华中科技大学（理工科）.csl
+++ b/src/华中科技大学（理工科）/华中科技大学（理工科）.csl
@@ -88,7 +88,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -123,7 +123,7 @@
         </choose>
         <choose>
           <if type="bill legal_case legislation regulation report standard" match="any">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
       </group>
@@ -148,11 +148,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -203,7 +203,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -212,11 +212,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -228,7 +228,7 @@
         <label variable="edition" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -241,7 +241,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -249,9 +249,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -261,7 +261,7 @@
         <group delimiter=", ">
           <text macro="patent-country"/>
           <text variable="genre"/>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-year"/>
         </group>
       </if>
@@ -274,7 +274,7 @@
             <text variable="publisher"/>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else>
@@ -296,7 +296,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>

--- a/src/华北农学报/华北农学报.csl
+++ b/src/华北农学报/华北农学报.csl
@@ -53,7 +53,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation patent report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <text macro="type-id" prefix="[" suffix="]"/>
@@ -118,7 +118,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -127,10 +127,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
     <choose>
       <if variable="DOI">
         <text variable="DOI" prefix=". doi: "/>
@@ -147,7 +147,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/华南农业大学/华南农业大学.csl
+++ b/src/华南农业大学/华南农业大学.csl
@@ -105,7 +105,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -126,7 +126,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -162,11 +162,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -299,7 +299,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -307,11 +307,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -326,7 +326,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -334,9 +334,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -362,7 +362,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/华南农业大学（本科）/华南农业大学（本科）.csl
+++ b/src/华南农业大学（本科）/华南农业大学（本科）.csl
@@ -110,7 +110,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -145,11 +145,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -276,7 +276,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -285,11 +285,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -304,7 +304,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -312,9 +312,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -342,7 +342,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/华南师范大学-1202-工商管理学/华南师范大学-1202-工商管理学.csl
+++ b/src/华南师范大学-1202-工商管理学/华南师范大学-1202-工商管理学.csl
@@ -115,7 +115,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -150,11 +150,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -297,7 +297,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -306,11 +306,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -325,7 +325,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -333,9 +333,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -363,7 +363,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/华南理工大学-公共管理学院/华南理工大学-公共管理学院.csl
+++ b/src/华南理工大学-公共管理学院/华南理工大学-公共管理学院.csl
@@ -87,7 +87,7 @@
           <choose>
             <if type="article article-journal standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -128,7 +128,7 @@
           <choose>
             <if type="article article-journal standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -163,11 +163,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -333,7 +333,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -342,11 +342,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -359,7 +359,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -368,11 +368,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -387,7 +387,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -395,16 +395,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -432,7 +432,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -488,7 +488,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>
@@ -636,7 +636,7 @@
         </else-if>
         <else-if type="standard">
           <group delimiter=", ">
-            <text variable="number"/>
+            <number variable="number"/>
             <text macro="title-en"/>
           </group>
           <text macro="secondary-contributors-en"/>
@@ -695,7 +695,7 @@
         <else-if type="standard">
           <!-- （6）技术标准 -->
           <group delimiter="，">
-            <text variable="number"/>
+            <number variable="number"/>
             <text macro="title-zh"/>
           </group>
           <text macro="secondary-contributors-zh"/>

--- a/src/南京农业大学（人文社科类，脚注）/南京农业大学（人文社科类，脚注）.csl
+++ b/src/南京农业大学（人文社科类，脚注）/南京农业大学（人文社科类，脚注）.csl
@@ -90,7 +90,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -130,7 +130,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -169,7 +169,7 @@
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -185,7 +185,7 @@
             <label variable="volume" form="short"/>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -365,9 +365,9 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -391,9 +391,9 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -411,7 +411,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -419,9 +419,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -546,7 +546,7 @@
         <text variable="locator"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/南京农业大学（自然科学类）/南京农业大学（自然科学类）.csl
+++ b/src/南京农业大学（自然科学类）/南京农业大学（自然科学类）.csl
@@ -141,7 +141,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -183,7 +183,7 @@
             <if type="bill legal_case legislation patent regulation report standard" match="any">
               <choose>
                 <if variable="number">
-                  <text variable="number"/>
+                  <number variable="number"/>
                 </if>
                 <!-- 如果专利号码不还在用申请代码 -->
                 <else-if type="patent">
@@ -218,11 +218,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -236,11 +236,11 @@
           <if is-numeric="volume">
             <group delimiter="．">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -399,7 +399,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <group delimiter=": ">
@@ -407,11 +407,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>  <!-- 0320 -->
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -425,7 +425,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <group delimiter="：">
@@ -433,11 +433,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year"/>  <!-- 0320 -->
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -452,7 +452,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -460,9 +460,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 英文专著的出版项 -->
   <macro name="publisher">
@@ -490,7 +490,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -535,7 +535,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>
@@ -621,9 +621,9 @@
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 英文参考文献表格式 -->
   <macro name="entry-layout">

--- a/src/南京工程学院/南京工程学院.csl
+++ b/src/南京工程学院/南京工程学院.csl
@@ -75,7 +75,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -90,7 +90,7 @@
           <choose>
             <if type="article article-journal standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -139,11 +139,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -274,7 +274,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -283,11 +283,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -302,7 +302,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -310,9 +310,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -340,7 +340,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if type="dataset post post-weblog software webpage" match="none">

--- a/src/南京理工大学学报（社会科学版）/南京理工大学学报（社会科学版）.csl
+++ b/src/南京理工大学学报（社会科学版）/南京理工大学学报（社会科学版）.csl
@@ -226,7 +226,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -246,7 +246,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -264,7 +264,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -392,7 +392,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -522,7 +522,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/南京航空航天大学/南京航空航天大学.csl
+++ b/src/南京航空航天大学/南京航空航天大学.csl
@@ -79,7 +79,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -134,11 +134,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -265,7 +265,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -274,9 +274,9 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <number variable="page"/>
         </group>
@@ -293,7 +293,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -301,9 +301,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -331,7 +331,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/南京邮电大学/南京邮电大学.csl
+++ b/src/南京邮电大学/南京邮电大学.csl
@@ -71,7 +71,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -106,11 +106,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -237,7 +237,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -246,11 +246,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -265,7 +265,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -273,9 +273,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -303,7 +303,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/南方民族考古/南方民族考古.csl
+++ b/src/南方民族考古/南方民族考古.csl
@@ -225,7 +225,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -245,7 +245,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -263,7 +263,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -397,7 +397,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -523,7 +523,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -542,7 +542,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/南昌大学（本科生）/南昌大学（本科生）.csl
+++ b/src/南昌大学（本科生）/南昌大学（本科生）.csl
@@ -88,7 +88,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -129,7 +129,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -164,11 +164,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -338,7 +338,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -347,11 +347,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -364,7 +364,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码[引用日期]” -->
@@ -373,11 +373,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -392,7 +392,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -400,16 +400,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -437,7 +437,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -492,7 +492,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/历史研究/历史研究.csl
+++ b/src/历史研究/历史研究.csl
@@ -76,7 +76,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -96,7 +96,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -108,7 +108,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -271,7 +271,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -532,7 +532,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -551,7 +551,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/原子核物理评论/原子核物理评论.csl
+++ b/src/原子核物理评论/原子核物理评论.csl
@@ -87,7 +87,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -122,7 +122,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
         </group>
@@ -141,11 +141,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -304,7 +304,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -313,11 +313,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -330,7 +330,7 @@
           <text variable="original-container-title" form="short" strip-periods="true"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -339,11 +339,11 @@
             <group delimiter=", ">
               <text variable="original-container-title" form="short" strip-periods="true"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -358,7 +358,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -366,9 +366,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -396,7 +396,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -450,7 +450,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -570,7 +570,7 @@
         <else-if type="article">
           <!-- 预印本(Preprint) -->
           <group delimiter=", ">
-            <text variable="number"/>
+            <number variable="number"/>
             <text macro="issued-year"/>
           </group>
         </else-if>
@@ -621,7 +621,7 @@
         <else-if type="article">
           <!-- 预印本(Preprint) -->
           <group delimiter=", ">
-            <text variable="number"/>
+            <number variable="number"/>
             <text macro="issued-year"/>
           </group>
         </else-if>

--- a/src/原子能科学技术/原子能科学技术.csl
+++ b/src/原子能科学技术/原子能科学技术.csl
@@ -104,7 +104,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -145,7 +145,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -170,11 +170,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -307,7 +307,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -316,11 +316,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -333,7 +333,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -342,11 +342,11 @@
             <group delimiter=", ">
               <text variable="original-container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -361,7 +361,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -369,9 +369,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -404,7 +404,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/同济大学/同济大学.csl
+++ b/src/同济大学/同济大学.csl
@@ -84,7 +84,7 @@
       <group delimiter=" ">
         <choose>
           <if type="standard">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
         <text variable="title"/>
@@ -95,7 +95,7 @@
         </choose>
         <choose>
           <if type="bill legal_case legislation regulation report" match="any">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
       </group>
@@ -111,7 +111,7 @@
       <group delimiter=" ">
         <choose>
           <if type="standard">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
         <group delimiter="：">
@@ -124,7 +124,7 @@
             </choose>
             <choose>
               <if type="bill legal_case legislation regulation report" match="any">
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
           </group>
@@ -152,11 +152,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -268,7 +268,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <date variable="issued" form="numeric"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -277,11 +277,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <date variable="issued" form="numeric" date-parts="year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -294,7 +294,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <date variable="issued" form="numeric"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -303,11 +303,11 @@
             <group delimiter="，">
               <text variable="container-title" form="short" strip-periods="true"/>
               <date variable="issued" form="numeric" date-parts="year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -322,7 +322,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -334,7 +334,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -342,16 +342,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <date variable="issued" form="numeric" date-parts="year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <date variable="issued" form="numeric" date-parts="year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -364,7 +364,7 @@
               <text macro="patent-country-en"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <date variable="issued" form="numeric"/>
         </group>
@@ -378,7 +378,7 @@
             </group>
             <date variable="issued" form="numeric" date-parts="year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -393,7 +393,7 @@
               <text macro="patent-country-zh"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <date variable="issued" form="numeric"/>
         </group>
@@ -407,7 +407,7 @@
             </group>
             <date variable="issued" form="numeric" date-parts="year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>

--- a/src/哈尔滨医科大学/哈尔滨医科大学.csl
+++ b/src/哈尔滨医科大学/哈尔滨医科大学.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -238,7 +238,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -247,16 +247,16 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <choose>
             <if variable="page">
-              <text variable="page"/>
+              <number variable="page"/>
             </if>
             <else-if type="article-journal">
-              <text variable="number"/>
+              <number variable="number"/>
             </else-if>
           </choose>
         </group>
@@ -273,7 +273,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -281,9 +281,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -311,7 +311,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/哈尔滨理工大学/哈尔滨理工大学.csl
+++ b/src/哈尔滨理工大学/哈尔滨理工大学.csl
@@ -76,7 +76,7 @@
                   <text variable="event-place" suffix=", "/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -111,11 +111,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -242,7 +242,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -251,11 +251,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -270,7 +270,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -278,9 +278,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -303,7 +303,7 @@
               </group>
               <text macro="issued-year"/>
             </group>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
           <text macro="accessed-date"/>
         </group>

--- a/src/四川农业大学/四川农业大学.csl
+++ b/src/四川农业大学/四川农业大学.csl
@@ -73,7 +73,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -108,11 +108,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -236,7 +236,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -245,11 +245,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -264,7 +264,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -272,9 +272,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -302,7 +302,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/四川外国语大学-英语语言文学（语言学、教学法方向）/四川外国语大学-英语语言文学（语言学、教学法方向）.csl
+++ b/src/四川外国语大学-英语语言文学（语言学、教学法方向）/四川外国语大学-英语语言文学（语言学、教学法方向）.csl
@@ -943,7 +943,7 @@
             <group delimiter=". ">
               <group delimiter=" ">
                 <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
+                <number variable="volume"/>
               </group>
               <text variable="volume-title"/>
             </group>
@@ -952,7 +952,7 @@
         <else-if is-numeric="volume" match="none">
           <group delimiter=" ">
             <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </group>
         </else-if>
       </choose>
@@ -979,7 +979,7 @@
                     <label variable="number" form="short" text-case="capitalize-first"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </group>
           </else>
@@ -1036,7 +1036,7 @@
                     <label variable="number" form="short" text-case="capitalize-first"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </group>
           </else>
@@ -1092,7 +1092,7 @@
             </choose>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </if>
@@ -1169,7 +1169,7 @@
             </choose>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </if>
@@ -2204,7 +2204,7 @@
             <text variable="genre" text-case="title"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <choose>
@@ -2229,7 +2229,7 @@
             <text variable="genre" text-case="title"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <choose>
@@ -2284,7 +2284,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -2327,11 +2327,11 @@
       </choose>
       <group delimiter=" ">
         <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -2608,12 +2608,12 @@
         <choose>
           <if variable="volume">
             <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
+              <number variable="volume" font-style="italic"/>
+              <number variable="issue" prefix="(" suffix=")"/>
             </group>
           </if>
           <else>
-            <text variable="issue" font-style="italic"/>
+            <number variable="issue" font-style="italic"/>
           </else>
         </choose>
         <choose>
@@ -2621,11 +2621,11 @@
             <!-- Ex. 6: Journal article with article number or eLocator -->
             <group delimiter=" ">
               <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </group>
@@ -2648,12 +2648,12 @@
         <choose>
           <if variable="volume">
             <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
+              <number variable="volume" font-style="italic"/>
+              <number variable="issue" prefix="(" suffix=")"/>
             </group>
           </if>
           <else>
-            <text variable="issue" font-style="italic"/>
+            <number variable="issue" font-style="italic"/>
           </else>
         </choose>
         <choose>
@@ -2661,11 +2661,11 @@
             <!-- Ex. 6: Journal article with article number or eLocator -->
             <group delimiter=" ">
               <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </group>
@@ -3135,7 +3135,7 @@
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
                 <text term="on"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
@@ -3166,7 +3166,7 @@
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
                 <text term="on"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
@@ -3284,12 +3284,12 @@
           <text variable="container-title"/>
           <choose>
             <if variable="page page-first" match="any">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3300,7 +3300,7 @@
           <choose>
             <if variable="container-title">
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
                 <group delimiter=" ">
                   <label variable="section" form="symbol"/>
@@ -3308,7 +3308,7 @@
                 </group>
                 <choose>
                   <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
+                    <number variable="page-first"/>
                   </if>
                   <else>
                     <text value="___"/>
@@ -3319,7 +3319,7 @@
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3338,7 +3338,7 @@
                   <label variable="number" form="short" text-case="capitalize-first"/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
@@ -3347,9 +3347,9 @@
             <text variable="chapter-number"/>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </group>
         </group>
       </else-if>
@@ -3365,17 +3365,17 @@
           <if variable="number">
             <!-- There's a public law number. -->
             <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
+              <number variable="number" prefix="Pub. L. No. "/>
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </group>
             </group>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title"/>
               <choose>
                 <if variable="section">
@@ -3385,7 +3385,7 @@
                   </group>
                 </if>
                 <else>
-                  <text variable="page-first"/>
+                  <number variable="page-first"/>
                 </else>
               </choose>
             </group>
@@ -3398,11 +3398,11 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
             <choose>
               <if variable="section">
@@ -3412,7 +3412,7 @@
                 </group>
               </if>
               <else>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </else>
             </choose>
           </group>
@@ -3429,12 +3429,12 @@
           <text variable="original-container-title"/>
           <choose>
             <if variable="page page-first" match="any">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3445,7 +3445,7 @@
           <choose>
             <if variable="original-container-title">
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="original-container-title"/>
                 <group delimiter=" ">
                   <label variable="section" form="symbol"/>
@@ -3453,7 +3453,7 @@
                 </group>
                 <choose>
                   <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
+                    <number variable="page-first"/>
                   </if>
                   <else>
                     <text value="___"/>
@@ -3464,7 +3464,7 @@
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3483,7 +3483,7 @@
                   <label variable="number" form="short" text-case="capitalize-first"/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
@@ -3492,9 +3492,9 @@
             <text variable="chapter-number"/>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="original-container-title"/>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </group>
         </group>
       </else-if>
@@ -3510,17 +3510,17 @@
           <if variable="number">
             <!-- There's a public law number. -->
             <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
+              <number variable="number" prefix="Pub. L. No. "/>
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="original-container-title"/>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </group>
             </group>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="original-container-title"/>
               <choose>
                 <if variable="section">
@@ -3530,7 +3530,7 @@
                   </group>
                 </if>
                 <else>
-                  <text variable="page-first"/>
+                  <number variable="page-first"/>
                 </else>
               </choose>
             </group>
@@ -3543,11 +3543,11 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="original-container-title"/>
             <choose>
               <if variable="section">
@@ -3557,7 +3557,7 @@
                 </group>
               </if>
               <else>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </else>
             </choose>
           </group>

--- a/src/四川大学-华西临床医学院/四川大学-华西临床医学院.csl
+++ b/src/四川大学-华西临床医学院/四川大学-华西临床医学院.csl
@@ -76,7 +76,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -111,11 +111,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -242,7 +242,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -251,11 +251,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -270,7 +270,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -278,9 +278,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -308,7 +308,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/四川大学-外国语学院（本科）/四川大学-外国语学院（本科）.csl
+++ b/src/四川大学-外国语学院（本科）/四川大学-外国语学院（本科）.csl
@@ -175,8 +175,8 @@
         <choose>
           <if type="article-journal">
             <group delimiter=".">
-              <text variable="volume"/>
-              <text variable="issue"/>
+              <number variable="volume"/>
+              <number variable="issue"/>
             </group>
             <text macro="publication-date-en" prefix="(" suffix=")"/>
           </if>
@@ -185,7 +185,7 @@
           </else>
         </choose>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
   </macro>
   <macro name="container-title-en">
@@ -296,7 +296,7 @@
           </group>
         </if>
         <else>
-          <text variable="edition" text-case="capitalize-first"/>
+          <number variable="edition" text-case="capitalize-first"/>
         </else>
       </choose>
       <text variable="version"/>
@@ -314,7 +314,7 @@
           </group>
         </if>
         <else>
-          <text variable="edition" text-case="capitalize-first"/>
+          <number variable="edition" text-case="capitalize-first"/>
         </else>
       </choose>
       <text variable="version"/>
@@ -324,18 +324,18 @@
   <macro name="volume-lowercase-en">
     <group delimiter=" ">
       <text term="volume" form="short"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
   </macro>
   <macro name="volume-lowercase-zh">
     <choose>
       <if type="article-journal">
-        <text variable="volume"/>
+        <number variable="volume"/>
       </if>
       <else>
         <group delimiter=" ">
           <text term="volume" form="short"/>
-          <text variable="volume"/>
+          <number variable="volume"/>
         </group>
       </else>
     </choose>
@@ -369,21 +369,21 @@
           <else>
             <group delimiter=" ">
               <text term="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </else>
         </choose>
       </group>
       <group delimiter=" ">
         <text term="issue" form="short"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <choose>
         <if type="report">
           <text variable="genre"/>
         </if>
       </choose>
-      <text variable="number"/>
+      <number variable="number"/>
     </group>
   </macro>
   <macro name="number-zh">
@@ -413,17 +413,17 @@
             <text macro="volume-lowercase-zh"/>
           </else-if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </group>
-      <text variable="issue"/>
+      <number variable="issue"/>
       <choose>
         <if type="report">
           <text variable="genre"/>
         </if>
       </choose>
-      <text variable="number"/>
+      <number variable="number"/>
     </group>
   </macro>
   <macro name="publisher-en">
@@ -516,13 +516,13 @@
     <group delimiter=", ">
       <group delimiter=" ">
         <label variable="page" form="short"/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
   <macro name="location-zh">
     <group delimiter=", ">
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
   </macro>
   <macro name="container2-title-en">

--- a/src/园艺学报/园艺学报.csl
+++ b/src/园艺学报/园艺学报.csl
@@ -153,7 +153,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -197,7 +197,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -231,11 +231,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -312,7 +312,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -320,11 +320,11 @@
           <group>
             <group delimiter="，">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -337,7 +337,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -345,11 +345,11 @@
           <group>
             <group delimiter="，">
               <text variable="original-container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -364,7 +364,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -372,9 +372,9 @@
   <macro name="year-volume-issue">
     <group delimiter="，">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -399,7 +399,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -442,7 +442,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/国防科技大学研究生学位论文/国防科技大学研究生学位论文.csl
+++ b/src/国防科技大学研究生学位论文/国防科技大学研究生学位论文.csl
@@ -67,7 +67,7 @@
     <group delimiter=", ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=": ">
@@ -82,7 +82,7 @@
           <choose>
             <if type="article article-journal patent standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -117,11 +117,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -256,7 +256,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -266,12 +266,12 @@
               <text variable="container-title"/>
               <group delimiter=",">
                 <text macro="issued-year"/>
-                <text variable="volume"/>
+                <number variable="volume"/>
               </group>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -286,7 +286,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -294,9 +294,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -308,7 +308,7 @@
               <text macro="patent-country"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -332,7 +332,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else>
@@ -349,7 +349,7 @@
               <text macro="patent-country"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -373,7 +373,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else>

--- a/src/国际关系研究/国际关系研究.csl
+++ b/src/国际关系研究/国际关系研究.csl
@@ -135,7 +135,7 @@
           <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="paper-conference">
@@ -149,7 +149,7 @@
           <date date-parts="year-month-date" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="thesis">
@@ -173,8 +173,8 @@
               </names>
               <text variable="title" prefix="“" suffix=",” "/>
               <text variable="container-title" font-style="italic" suffix=", "/>
-              <text variable="volume" prefix="Vol. " suffix=", "/>
-              <text variable="issue" prefix="No. " suffix=", "/>
+              <number variable="volume" prefix="Vol. " suffix=", "/>
+              <number variable="issue" prefix="No. " suffix=", "/>
               <date date-parts="year" form="text" variable="issued"/>
               <group>
                 <label variable="locator" form="short" prefix=", "/>
@@ -187,12 +187,12 @@
               </names>
               <text variable="title" prefix="“" suffix=",” "/>
               <text variable="container-title" font-style="italic" suffix=", "/>
-              <text variable="volume" prefix="Vol. " suffix=", "/>
-              <text variable="issue" prefix="No. " suffix=", "/>
+              <number variable="volume" prefix="Vol. " suffix=", "/>
+              <number variable="issue" prefix="No. " suffix=", "/>
               <date date-parts="year" form="text" variable="issued"/>
               <group>
                 <label variable="page" form="short" prefix=", "/>
-                <text variable="page"/>
+                <number variable="page"/>
               </group>
             </else>
           </choose>
@@ -226,7 +226,7 @@
           <text variable="archive_location"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else>
       </choose>
@@ -251,8 +251,8 @@
           <text variable="title" prefix="：《" suffix="》，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date date-parts="year" form="text" variable="issued"/>
-          <text variable="issue" prefix="第" suffix="期"/>
-          <text variable="page" prefix="，第" suffix="页"/>
+          <number variable="issue" prefix="第" suffix="期"/>
+          <number variable="page" prefix="，第" suffix="页"/>
         </else-if>
         <else-if type="article-newspaper">
           <text macro="author" suffix="："/>
@@ -260,7 +260,7 @@
           <text variable="title" prefix="《" suffix="》，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date form="text" variable="issued"/>
-          <text variable="edition" prefix="，"/>
+          <number variable="edition" prefix="，"/>
           <text variable="section" prefix="，"/>
         </else-if>
         <else-if type="chapter">
@@ -273,11 +273,11 @@
               <text macro="secondAuthor" suffix="："/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </if>
             <else>
               <text macro="author"/>
@@ -285,11 +285,11 @@
               <text macro="editor" suffix="主编："/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </else>
           </choose>
         </else-if>
@@ -327,8 +327,8 @@
               <text macro="secondAuthor" suffix="："/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
               <text macro="locators-zh"/>
@@ -339,8 +339,8 @@
               <text macro="editor" suffix="主编："/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
               <text macro="locators-zh"/>
@@ -354,8 +354,8 @@
           <text macro="secondAuthor"/>
           <text variable="title" prefix="《" suffix="》"/>
           <date date-parts="year-month-date" form="text" variable="issued" prefix="，" suffix="，"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
           <text variable="publisher-place" prefix="，" suffix="："/>
           <text variable="publisher"/>
           <text variable="archive" suffix="，"/>
@@ -411,7 +411,7 @@
           <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="paper-conference">
@@ -425,7 +425,7 @@
           <date date-parts="year-month-date" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="thesis">
@@ -447,12 +447,12 @@
           </names>
           <text variable="title" prefix="“" suffix=",” "/>
           <text variable="container-title" font-style="italic" suffix=", "/>
-          <text variable="volume" prefix="Vol. " suffix=", "/>
-          <text variable="issue" prefix="No. " suffix=", "/>
+          <number variable="volume" prefix="Vol. " suffix=", "/>
+          <number variable="issue" prefix="No. " suffix=", "/>
           <date date-parts="year" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="article-newspaper">
@@ -484,7 +484,7 @@
           <text variable="archive_location"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else>
       </choose>
@@ -509,8 +509,8 @@
           <text variable="title" prefix="：《" suffix="》，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date date-parts="year" form="text" variable="issued"/>
-          <text variable="issue" prefix="第" suffix="期"/>
-          <text variable="page" prefix="，第" suffix="页"/>
+          <number variable="issue" prefix="第" suffix="期"/>
+          <number variable="page" prefix="，第" suffix="页"/>
         </else-if>
         <else-if type="article-newspaper">
           <text macro="author" suffix="："/>
@@ -518,7 +518,7 @@
           <text variable="title" prefix="《" suffix="》，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date form="text" variable="issued"/>
-          <text variable="edition" prefix="，"/>
+          <number variable="edition" prefix="，"/>
           <text variable="section" prefix="，"/>
         </else-if>
         <else-if type="chapter">
@@ -531,11 +531,11 @@
               <text macro="secondAuthor" suffix="："/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </if>
             <else>
               <text macro="author"/>
@@ -543,11 +543,11 @@
               <text macro="editor" suffix="主编："/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </else>
           </choose>
         </else-if>
@@ -585,8 +585,8 @@
               <text macro="secondAuthor" suffix="："/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
               <text macro="locators-zh"/>
@@ -597,8 +597,8 @@
               <text macro="editor" suffix="主编："/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
               <text macro="locators-zh"/>
@@ -612,8 +612,8 @@
           <text macro="secondAuthor"/>
           <text variable="title" prefix="《" suffix="》"/>
           <date date-parts="year-month-date" form="text" variable="issued" prefix="，" suffix="，"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
           <text variable="publisher-place" prefix="，" suffix="："/>
           <text variable="publisher"/>
           <text variable="archive" suffix="，"/>

--- a/src/国际安全研究/国际安全研究.csl
+++ b/src/国际安全研究/国际安全研究.csl
@@ -170,7 +170,7 @@
             <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
             <group>
               <label variable="page" form="short"/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -208,7 +208,7 @@
             </group>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -234,8 +234,8 @@
             <group prefix=" " delimiter=", ">
               <text variable="title" quotes="true"/>
               <text variable="container-title" font-style="italic"/>
-              <text variable="volume" prefix="Vol. "/>
-              <text variable="issue" prefix="No. "/>
+              <number variable="volume" prefix="Vol. "/>
+              <number variable="issue" prefix="No. "/>
             </group>
             <date date-parts="year-month" form="text" variable="issued" prefix=" (" suffix=")"/>
             <label variable="locator" form="short" prefix=", "/>
@@ -246,12 +246,12 @@
             <group prefix=" " delimiter=", ">
               <text variable="title" quotes="true"/>
               <text variable="container-title" font-style="italic"/>
-              <text variable="volume" prefix="Vol. "/>
-              <text variable="issue" prefix="No. "/>
+              <number variable="volume" prefix="Vol. "/>
+              <number variable="issue" prefix="No. "/>
             </group>
             <date date-parts="year-month" form="text" variable="issued" prefix=" (" suffix=")"/>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>
@@ -295,7 +295,7 @@
             <date date-parts="year" form="numeric" variable="issued"/>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -319,7 +319,7 @@
             <text variable="publisher-place" prefix="（" suffix="）"/>
             <date date-parts="year" form="text" variable="issued"/>
             <group delimiter="，">
-              <text variable="issue" prefix="第" suffix="期"/>
+              <number variable="issue" prefix="第" suffix="期"/>
               <text macro="locators-zh"/>
               <text variable="locator" prefix="第" suffix="页"/>
             </group>
@@ -335,8 +335,8 @@
             <text variable="publisher-place" prefix="（" suffix="）"/>
             <date date-parts="year" form="text" variable="issued"/>
             <group delimiter="，">
-              <text variable="issue" prefix="第" suffix="期"/>
-              <text variable="page" prefix="第" suffix="页"/>
+              <number variable="issue" prefix="第" suffix="期"/>
+              <number variable="page" prefix="第" suffix="页"/>
             </group>
           </else>
         </choose>
@@ -350,7 +350,7 @@
           <text variable="container-title" prefix="载《" suffix="》"/>
         </group>
         <date form="text" variable="issued"/>
-        <text variable="edition" prefix="，第" suffix="版"/>
+        <number variable="edition" prefix="，第" suffix="版"/>
       </else-if>
       <else-if type="chapter">
         <!-- 中文章节 -->
@@ -368,8 +368,8 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text macro="secondAuthor"/>
                 </group>
@@ -388,14 +388,14 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                 </group>
                 <text variable="publisher-place" prefix="，" suffix="："/>
                 <text variable="publisher"/>
                 <text macro="date" suffix="版"/>
-                <text variable="page" prefix="，第" suffix="页"/>
+                <number variable="page" prefix="，第" suffix="页"/>
               </else>
             </choose>
           </if>
@@ -411,8 +411,8 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                 </group>
                 <text variable="publisher-place" prefix="，" suffix="："/>
@@ -429,14 +429,14 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                 </group>
                 <text variable="publisher-place" prefix="，" suffix="："/>
                 <text variable="publisher"/>
                 <text macro="date" suffix="版"/>
-                <text variable="page" prefix="，第" suffix="页"/>
+                <number variable="page" prefix="，第" suffix="页"/>
               </else>
             </choose>
           </else>
@@ -474,7 +474,7 @@
               <text variable="event"/>
               <date date-parts="year-month-date" form="text" variable="issued"/>
             </group>
-            <text variable="page" prefix="，第" suffix="页"/>
+            <number variable="page" prefix="，第" suffix="页"/>
           </else>
         </choose>
       </else-if>
@@ -505,8 +505,8 @@
               <group>
                 <text variable="title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
               <text macro="secondAuthor"/>
             </group>
@@ -524,8 +524,8 @@
               <group>
                 <text variable="title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
             </group>
             <text variable="publisher-place" prefix="，" suffix="："/>
@@ -543,8 +543,8 @@
         <group delimiter="，" suffix="，">
           <text variable="title" prefix="《" suffix="》"/>
           <text variable="collection-number" prefix="第" suffix="册"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
         </group>
         <text macro="secondAuthor" prefix="，"/>
         <group delimiter="：" suffix="，">
@@ -645,7 +645,7 @@
           <text variable="title" quotes="true" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if position="subsequent" type="chapter" match="all">
@@ -655,7 +655,7 @@
           <text variable="title" quotes="true" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else>

--- a/src/国际政治研究/国际政治研究.csl
+++ b/src/国际政治研究/国际政治研究.csl
@@ -100,7 +100,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -112,7 +112,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -124,7 +124,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -153,12 +153,12 @@
           <choose>
             <if is-numeric="number">
               <text variable="genre"/>
-              <text variable="number" prefix="No."/>
+              <number variable="number" prefix="No."/>
             </if>
             <else>
               <group delimiter=" ">
                 <text variable="genre"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -234,7 +234,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -449,7 +449,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -468,7 +468,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/国际新闻界/国际新闻界.csl
+++ b/src/国际新闻界/国际新闻界.csl
@@ -292,7 +292,7 @@
         <label variable="edition" form="short" text-case="capitalize-first" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -304,7 +304,7 @@
         <label variable="edition" form="short" text-case="capitalize-first"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -356,7 +356,7 @@
               <text variable="container-title" font-style="italic"/>
               <group delimiter=" " prefix="(" suffix=")">
                 <label variable="page" form="short"/>
-                <text variable="page"/>
+                <number variable="page"/>
               </group>
             </group>
           </group>
@@ -376,7 +376,7 @@
           <group>
             <text variable="container-title" prefix="《" suffix="》"/>
             <group prefix="（" suffix="）">
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </group>
         </group>

--- a/src/国际法研究/国际法研究.csl
+++ b/src/国际法研究/国际法研究.csl
@@ -127,7 +127,7 @@
               <text macro="issuance-en" prefix="(" suffix=")"/>
               <text macro="container-en"/>
               <group delimiter=", ">
-                <text variable="page-first"/>
+                <number variable="page-first"/>
                 <text macro="locator-en"/>
               </group>
             </group>
@@ -176,7 +176,7 @@
                   <text macro="title-en"/>
                   <group delimiter=" ">
                     <text value="Pub. L. No."/>
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </group>
                   <text macro="section-en"/>
                   <text macro="container-en"/>
@@ -193,7 +193,7 @@
                 </group>
               </else>
             </choose>
-            <text variable="page"/>
+            <number variable="page"/>
             <text macro="locator-en"/>
             <text macro="issuance-en" prefix="(" suffix=")"/>
           </group>
@@ -205,13 +205,13 @@
               <text macro="title-en"/>
               <group delimiter=" ">
                 <text value="No."/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
             <text macro="container-en"/>
             <group delimiter=", ">
-              <text variable="page"/>
+              <number variable="page"/>
               <text variable="locator"/>
             </group>
             <group delimiter=" " prefix="(" suffix=")">
@@ -333,7 +333,7 @@
           <text macro="title-zh"/>
           <choose>
             <if variable="section locator" match="none">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -392,7 +392,7 @@
           <text macro="author-zh"/>
           <group delimiter="，">
             <text macro="title-zh"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </group>
       </else-if>
@@ -490,7 +490,7 @@
             </else-if>
             <else-if variable="section locator" match="any">
               <!-- 64.1 《最高人民法院关于适用〈中华人民共和国行政诉讼法〉的解释》(法释 〔2018〕1 号)，第 100 条。 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </else-if>
           </choose>
         </group>
@@ -539,7 +539,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -551,7 +551,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -571,7 +571,7 @@
     <choose>
       <if type="article-journal article-magazine" match="any">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title" text-case="title" font-style="italic"/>
         </group>
       </if>
@@ -581,7 +581,7 @@
           <group delimiter=", ">
             <text macro="editor-en"/>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title" text-case="title"/>
             </group>
           </group>
@@ -589,7 +589,7 @@
       </else-if>
       <else-if type="legislation">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title" text-case="title"/>
         </group>
       </else-if>
@@ -642,7 +642,7 @@
           </else-if>
           <else>
             <text variable="authority"/>
-            <text variable="number"/>
+            <number variable="number"/>
             <choose>
               <if variable="genre">
                 <!-- 用户需要在 genre 中填写司法案例的文书名称，如“民事判决书”、“行政判决书” -->
@@ -694,7 +694,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -713,7 +713,7 @@
         </choose>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -852,11 +852,11 @@
       <else-if variable="page">
         <choose>
           <if type="article-newspaper">
-            <text variable="page" form="short"/>
+            <number variable="page" form="short"/>
           </if>
           <else-if type="article-magazine">
             <label variable="page" form="short" suffix=" "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </else-if>
         </choose>
       </else-if>
@@ -872,11 +872,11 @@
         <choose>
           <if is-numeric="page">
             <text value="第"/>
-            <text variable="page"/>
+            <number variable="page"/>
             <text value="版"/>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>

--- a/src/国际经贸探索/国际经贸探索.csl
+++ b/src/国际经贸探索/国际经贸探索.csl
@@ -114,7 +114,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -149,11 +149,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -280,7 +280,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -288,11 +288,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -307,7 +307,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -315,9 +315,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -342,7 +342,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/国际金融研究/国际金融研究.csl
+++ b/src/国际金融研究/国际金融研究.csl
@@ -117,7 +117,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -152,11 +152,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -283,7 +283,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷（期）: 页码[引用日期]” -->
@@ -292,11 +292,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -311,7 +311,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -319,9 +319,9 @@
   <macro name="year-volume-issue">
     <group delimiter="，">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -363,7 +363,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/地球物理学报/地球物理学报.csl
+++ b/src/地球物理学报/地球物理学报.csl
@@ -119,7 +119,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -169,7 +169,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -212,11 +212,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -322,7 +322,7 @@
           <text variable="container-title" form="short" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -330,11 +330,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title" form="short" font-style="italic"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -347,7 +347,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -355,11 +355,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -374,7 +374,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -382,9 +382,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -409,7 +409,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/地理学报/地理学报.csl
+++ b/src/地理学报/地理学报.csl
@@ -80,7 +80,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -115,7 +115,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -140,11 +140,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -288,7 +288,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -297,11 +297,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -314,7 +314,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -323,11 +323,11 @@
             <group delimiter=", ">
               <text variable="original-container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -342,7 +342,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -350,9 +350,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -380,7 +380,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -435,7 +435,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/地质学报/地质学报.csl
+++ b/src/地质学报/地质学报.csl
@@ -105,7 +105,7 @@
           </choose>
           <choose>
             <if type="article article-journal" match="none">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -138,11 +138,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -255,18 +255,18 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <group delimiter=": ">
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -280,16 +280,16 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -310,7 +310,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/复旦大学-大气与海洋科学系/复旦大学-大气与海洋科学系.csl
+++ b/src/复旦大学-大气与海洋科学系/复旦大学-大气与海洋科学系.csl
@@ -110,7 +110,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -146,11 +146,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -277,7 +277,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -286,11 +286,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -305,7 +305,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -313,9 +313,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -343,7 +343,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/外交评论/外交评论.csl
+++ b/src/外交评论/外交评论.csl
@@ -101,7 +101,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -113,7 +113,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -125,7 +125,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -154,12 +154,12 @@
           <choose>
             <if is-numeric="number">
               <text variable="genre"/>
-              <text variable="number" prefix="No."/>
+              <number variable="number" prefix="No."/>
             </if>
             <else>
               <group delimiter=" ">
                 <text variable="genre"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -235,7 +235,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -439,7 +439,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -458,7 +458,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/外国文学评论/外国文学评论.csl
+++ b/src/外国文学评论/外国文学评论.csl
@@ -232,7 +232,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -252,7 +252,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -270,7 +270,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -369,7 +369,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -491,7 +491,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -510,7 +510,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/外语教学与研究/外语教学与研究.csl
+++ b/src/外语教学与研究/外语教学与研究.csl
@@ -173,7 +173,7 @@
               <choose>
                 <if type="article article-journal" match="none">
                   <!-- 预印本和期刊文章的编号用于其他位置 -->
-                  <text variable="number"/>
+                  <number variable="number"/>
                 </if>
               </choose>
               <choose>
@@ -231,7 +231,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -268,11 +268,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -471,7 +471,7 @@
         <group delimiter=" ">
           <text variable="container-title" font-style="italic"/>
           <text macro="issued-date"/>
-          <text variable="page" prefix="(" suffix=")"/>
+          <number variable="page" prefix="(" suffix=")"/>
         </group>
       </if>
       <else>
@@ -479,10 +479,10 @@
         <group delimiter=": ">
           <group delimiter=" ">
             <text variable="container-title" font-style="italic"/>
-            <text variable="volume"/>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="volume"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -502,11 +502,11 @@
           <group>
             <group delimiter="，">
               <text variable="container-title" prefix="《" suffix="》"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -521,7 +521,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -533,7 +533,7 @@
         <label variable="edition"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -541,16 +541,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="date"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="date"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -575,7 +575,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
     </choose>
@@ -602,7 +602,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
     </choose>

--- a/src/外语教学理论与实践/外语教学理论与实践.csl
+++ b/src/外语教学理论与实践/外语教学理论与实践.csl
@@ -149,11 +149,11 @@
     <choose>
       <if is-numeric="volume">
         <text value="第"/>
-        <text variable="volume"/>
+        <number variable="volume"/>
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -245,7 +245,7 @@
         <label variable="issue"/>
       </if>
       <else-if variable="issue">
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else-if>
       <else-if is-numeric="volume">
         <text value="第"/>
@@ -253,7 +253,7 @@
         <label variable="volume"/>
       </else-if>
       <else-if variable="volume">
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else-if>
     </choose>
   </macro>
@@ -267,7 +267,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -280,7 +280,7 @@
           <group delimiter=", ">
             <text macro="patent-country"/>
             <text variable="genre"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </group>
       </if>
@@ -311,7 +311,7 @@
           <group delimiter="，">
             <text macro="patent-country"/>
             <text variable="genre"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </group>
       </if>

--- a/src/大连海事大学/大连海事大学.csl
+++ b/src/大连海事大学/大连海事大学.csl
@@ -79,13 +79,13 @@
           <!-- <choose>
             <if type="patent" match="any">
               <text macro="patent-country" suffix=", "/>
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose> -->
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -230,7 +230,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -239,11 +239,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -258,7 +258,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -266,9 +266,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -276,7 +276,7 @@
       <if type="patent">
         <!-- 专利的出版项格式“公告日期[引用日期]” -->
         <text macro="patent-country_region" suffix=": "/>
-        <text variable="number" suffix=", "/>
+        <number variable="number" suffix=", "/>
         <text macro="issued-date"/>
       </if>
       <!-- 图书 需要标明所引页码  第一优先选项 其他 中输入“Pages:11-26”  备选项  “存档位置”手动写入引用页码范围，例如60-65 图书类型的条目 存档位置、版权、索书号等几乎不被占用 备选可行，毕竟只输入数字还是要快一些 -->
@@ -310,7 +310,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -359,7 +359,7 @@
   <macro name="book_seleced_page">
     <choose>
       <if variable="page">
-        <text variable="page"/>
+        <number variable="page"/>
       </if>
       <else-if variable="archive_location">
         <!-- 档案的卷宗号 -->

--- a/src/大连理工大学/大连理工大学.csl
+++ b/src/大连理工大学/大连理工大学.csl
@@ -76,7 +76,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -111,11 +111,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -236,7 +236,7 @@
           <text variable="container-title"/>
           <text macro="issued-date-newspaper"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -245,11 +245,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -264,7 +264,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -272,9 +272,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -287,7 +287,7 @@
         <!-- 论文集、会议录不显示出版地和出版者 -->
         <group delimiter=": ">
           <text macro="issued-year"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else>
@@ -308,7 +308,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>

--- a/src/天津大学（顺序编码）/天津大学（顺序编码）.csl
+++ b/src/天津大学（顺序编码）/天津大学（顺序编码）.csl
@@ -100,7 +100,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -142,7 +142,7 @@
             <if type="bill legal_case legislation patent regulation report standard" match="any">
               <choose>
                 <if variable="number">
-                  <text variable="number"/>
+                  <number variable="number"/>
                 </if>
                 <!-- 如果专利号码不还在用申请代码 -->
                 <else-if type="patent">
@@ -177,11 +177,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -195,11 +195,11 @@
           <if is-numeric="volume">
             <group delimiter="．">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -352,7 +352,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <group delimiter=": ">
@@ -360,11 +360,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>  <!-- 0320 -->
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -378,7 +378,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <group delimiter="：">
@@ -386,11 +386,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year"/>  <!-- 0320 -->
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -405,7 +405,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -413,9 +413,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 英文专著的出版项 -->
   <macro name="publisher">
@@ -443,7 +443,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -491,7 +491,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>
@@ -584,9 +584,9 @@
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 英文参考文献表格式 -->
   <macro name="entry-layout">

--- a/src/天然气工业/天然气工业.csl
+++ b/src/天然气工业/天然气工业.csl
@@ -87,7 +87,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -128,7 +128,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -163,11 +163,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -324,7 +324,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -333,11 +333,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -350,7 +350,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -359,11 +359,11 @@
             <group delimiter=", ">
               <text variable="original-container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -378,7 +378,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -386,9 +386,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -416,7 +416,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -471,7 +471,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/太平洋学报/太平洋学报.csl
+++ b/src/太平洋学报/太平洋学报.csl
@@ -94,7 +94,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -114,7 +114,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -126,7 +126,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -279,7 +279,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -514,7 +514,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -533,7 +533,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/宁波大学/宁波大学.csl
+++ b/src/宁波大学/宁波大学.csl
@@ -48,7 +48,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation patent report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -112,7 +112,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -121,10 +121,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -136,7 +136,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/安徽医科大学/安徽医科大学.csl
+++ b/src/安徽医科大学/安徽医科大学.csl
@@ -89,7 +89,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -131,7 +131,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -166,11 +166,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -356,7 +356,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -365,11 +365,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -382,7 +382,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -391,11 +391,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -410,7 +410,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -418,16 +418,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -455,7 +455,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -511,7 +511,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/安徽理工大学/安徽理工大学.csl
+++ b/src/安徽理工大学/安徽理工大学.csl
@@ -85,7 +85,7 @@
     <group delimiter=", ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <text variable="title"/>
@@ -147,7 +147,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -156,11 +156,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -175,7 +175,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -189,14 +189,14 @@
               <text macro="patent-country"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
       </if>
       <else-if type="legal_case legislation regulation report" match="any">
         <group delimiter=", ">
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-date"/>
         </group>
       </else-if>
@@ -219,7 +219,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
     </choose>

--- a/src/导出作者、刊名、年卷期页/导出作者、刊名、年卷期页.csl
+++ b/src/导出作者、刊名、年卷期页/导出作者、刊名、年卷期页.csl
@@ -57,7 +57,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -66,10 +66,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -81,7 +81,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/导出刊名、年卷期页/导出刊名、年卷期页.csl
+++ b/src/导出刊名、年卷期页/导出刊名、年卷期页.csl
@@ -54,7 +54,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -89,11 +89,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -226,7 +226,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -235,11 +235,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -254,7 +254,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -262,9 +262,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -292,7 +292,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/导出题名/导出题名.csl
+++ b/src/导出题名/导出题名.csl
@@ -17,7 +17,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation patent report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/山东农业大学/山东农业大学.csl
+++ b/src/山东农业大学/山东农业大学.csl
@@ -76,11 +76,11 @@
   </macro>
   <macro name="title">
     <text variable="title"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
   </macro>
   <macro name="title-zh">
     <text variable="title"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
   </macro>
   <macro name="container-contributors">
     <names variable="container-author">
@@ -98,7 +98,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -107,18 +107,18 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="serial-information-zh">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -129,7 +129,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -220,7 +220,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文专著 -->
       <else-if type="monograph">
@@ -249,7 +249,7 @@
         <text variable="publisher-place" prefix=". " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文专利 -->
       <else-if type="patent">
@@ -260,7 +260,7 @@
       <else-if type="article-newspaper">
         <text variable="publisher" prefix="[N]. " suffix=", "/>
         <text macro="issued-date"/>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </else-if>
       <else>
         <text macro="publisher" prefix=". "/>
@@ -323,7 +323,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文专著 -->
       <else-if type="monograph">
@@ -352,7 +352,7 @@
         <text variable="publisher-place" prefix=". " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文专利 -->
       <else-if type="patent">
@@ -363,7 +363,7 @@
       <else-if type="article-newspaper">
         <text variable="publisher" prefix="[N]. " suffix=", "/>
         <text macro="issued-date"/>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </else-if>
       <else>
         <text macro="publisher" prefix=". "/>

--- a/src/山东大学（顺序编码制）/山东大学（顺序编码制）.csl
+++ b/src/山东大学（顺序编码制）/山东大学（顺序编码制）.csl
@@ -73,7 +73,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -108,11 +108,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -251,7 +251,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -260,11 +260,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -279,7 +279,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -287,9 +287,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -317,7 +317,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/山西农业大学/山西农业大学.csl
+++ b/src/山西农业大学/山西农业大学.csl
@@ -75,7 +75,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation patent report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -134,7 +134,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -143,10 +143,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -158,7 +158,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/山西大学（本科生）/山西大学（本科生）.csl
+++ b/src/山西大学（本科生）/山西大学（本科生）.csl
@@ -89,7 +89,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -126,7 +126,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -157,11 +157,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -273,7 +273,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -282,11 +282,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -299,7 +299,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -308,11 +308,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -327,7 +327,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -335,16 +335,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -355,7 +355,7 @@
       </if>
       <else-if type="article">
         <group delimiter=" ">
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-year-en" prefix="(" suffix=")"/>
         </group>
       </else-if>
@@ -378,7 +378,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -416,7 +416,7 @@
       </if>
       <else-if type="article">
         <group>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-year-zh" prefix="（" suffix="）"/>
         </group>
       </else-if>
@@ -439,7 +439,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/广东工业大学/广东工业大学.csl
+++ b/src/广东工业大学/广东工业大学.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -238,7 +238,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -247,11 +247,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -266,7 +266,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -274,9 +274,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -304,7 +304,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/广州大学/广州大学.csl
+++ b/src/广州大学/广州大学.csl
@@ -73,7 +73,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -108,11 +108,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -233,7 +233,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -242,11 +242,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -261,7 +261,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -269,9 +269,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -299,7 +299,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/当代亚太/当代亚太.csl
+++ b/src/当代亚太/当代亚太.csl
@@ -168,7 +168,7 @@
             <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
             <group>
               <label variable="page" form="short"/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -206,7 +206,7 @@
             </group>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -232,8 +232,8 @@
             <group prefix=" " delimiter=", ">
               <text variable="title" quotes="true"/>
               <text variable="container-title" font-style="italic"/>
-              <text variable="volume" prefix="Vol. "/>
-              <text variable="issue" prefix="No. "/>
+              <number variable="volume" prefix="Vol. "/>
+              <number variable="issue" prefix="No. "/>
               <date date-parts="year" form="text" variable="issued"/>
             </group>
             <label variable="locator" form="short" prefix=", "/>
@@ -244,12 +244,12 @@
             <group prefix=" " delimiter=", ">
               <text variable="title" quotes="true"/>
               <text variable="container-title" font-style="italic"/>
-              <text variable="volume" prefix="Vol. "/>
-              <text variable="issue" prefix="No. "/>
+              <number variable="volume" prefix="Vol. "/>
+              <number variable="issue" prefix="No. "/>
               <date date-parts="year" form="text" variable="issued"/>
             </group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>
@@ -293,7 +293,7 @@
             <date date-parts="year" form="numeric" variable="issued"/>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -317,7 +317,7 @@
             <text variable="publisher-place" prefix="（" suffix="）"/>
             <date date-parts="year" form="text" variable="issued"/>
             <group delimiter="，">
-              <text variable="issue" prefix="第" suffix="期"/>
+              <number variable="issue" prefix="第" suffix="期"/>
               <text macro="locators-zh"/>
               <text variable="locator" prefix="第" suffix="页"/>
             </group>
@@ -333,8 +333,8 @@
             <text variable="publisher-place" prefix="（" suffix="）"/>
             <date date-parts="year" form="text" variable="issued"/>
             <group delimiter="，">
-              <text variable="issue" prefix="第" suffix="期"/>
-              <text variable="page" prefix="第" suffix="页"/>
+              <number variable="issue" prefix="第" suffix="期"/>
+              <number variable="page" prefix="第" suffix="页"/>
             </group>
           </else>
         </choose>
@@ -348,7 +348,7 @@
           <text variable="container-title" prefix="载《" suffix="》"/>
         </group>
         <date form="text" variable="issued"/>
-        <text variable="edition" prefix="，第" suffix="版"/>
+        <number variable="edition" prefix="，第" suffix="版"/>
       </else-if>
       <else-if type="chapter">
         <!-- 中文章节 -->
@@ -365,8 +365,8 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text macro="secondAuthor"/>
                   <text variable="publisher"/>
@@ -384,13 +384,13 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text variable="publisher"/>
                 </group>
                 <text macro="date" suffix="版"/>
-                <text variable="page" prefix="，第" suffix="页"/>
+                <number variable="page" prefix="，第" suffix="页"/>
               </else>
             </choose>
           </if>
@@ -406,8 +406,8 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text variable="publisher"/>
                 </group>
@@ -423,13 +423,13 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text variable="publisher"/>
                 </group>
                 <text macro="date" suffix="版"/>
-                <text variable="page" prefix="，第" suffix="页"/>
+                <number variable="page" prefix="，第" suffix="页"/>
               </else>
             </choose>
           </else>
@@ -467,7 +467,7 @@
               <text variable="event"/>
               <date date-parts="year-month-date" form="text" variable="issued"/>
             </group>
-            <text variable="page" prefix="，第" suffix="页"/>
+            <number variable="page" prefix="，第" suffix="页"/>
           </else>
         </choose>
       </else-if>
@@ -497,8 +497,8 @@
               <group>
                 <text variable="title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
               <text macro="secondAuthor"/>
               <text variable="publisher"/>
@@ -515,8 +515,8 @@
               <group>
                 <text variable="title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
               <text variable="publisher"/>
             </group>
@@ -533,8 +533,8 @@
         <group delimiter="，" suffix="，">
           <text variable="title" prefix="《" suffix="》"/>
           <text variable="collection-number" prefix="第" suffix="册"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
         </group>
         <text macro="secondAuthor" prefix="，"/>
         <group delimiter="：" suffix="，">
@@ -635,7 +635,7 @@
           <text variable="title" quotes="true" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if position="subsequent" type="chapter" match="all">
@@ -645,7 +645,7 @@
           <text variable="title" quotes="true" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else>

--- a/src/微生物学报/微生物学报.csl
+++ b/src/微生物学报/微生物学报.csl
@@ -47,7 +47,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation patent report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -111,7 +111,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -120,10 +120,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -135,7 +135,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/心理学报/心理学报.csl
+++ b/src/心理学报/心理学报.csl
@@ -323,7 +323,7 @@
         <group delimiter=" ">
           <text variable="genre" text-case="title"/>
           <text value="No."/>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </if>
     </choose>
@@ -349,7 +349,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -377,7 +377,7 @@
       </choose>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -404,12 +404,12 @@
         <choose>
           <if variable="volume">
             <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
+              <number variable="volume" font-style="italic"/>
+              <number variable="issue" prefix="(" suffix=")"/>
             </group>
           </if>
           <else>
-            <text variable="issue" font-style="italic"/>
+            <number variable="issue" font-style="italic"/>
           </else>
         </choose>
         <choose>
@@ -419,17 +419,17 @@
                 <!-- 《心理学报》报纸文献的版次有前缀“p” -->
                 <group>
                   <label variable="page" form="short" plural="never" strip-periods="true"/>
-                  <text variable="page"/>
+                  <number variable="page"/>
                 </group>
               </if>
               <else>
-                <text variable="page"/>
+                <number variable="page"/>
               </else>
             </choose>
           </if>
           <else>
             <!-- 只有论文编号而无页码的电子刊论文 -->
-            <text variable="number" prefix="Article "/>
+            <number variable="number" prefix="Article "/>
           </else>
         </choose>
       </group>
@@ -475,7 +475,7 @@
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
                     <label variable="volume" form="short" text-case="capitalize-first"/>
-                    <text variable="volume"/>
+                    <number variable="volume"/>
                   </group>
                 </if>
               </choose>
@@ -761,11 +761,11 @@
       <!-- <number variable="volume" form="numeric"/> -->
       <group delimiter=" ">
         <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -808,7 +808,7 @@
                   <number variable="volume" form="long-ordinal" prefix="(" suffix=")"/>
                 </if>
                 <else>
-                  <text variable="volume" prefix="(" suffix=")"/>
+                  <number variable="volume" prefix="(" suffix=")"/>
                 </else>
               </choose>
             </group>
@@ -960,8 +960,7 @@
             <text macro="locators-booklike-ZHtoEN"/>
           </group>
         </else-if>
-        <else-if variable="original-container-title">
-        </else-if>
+        <else-if variable="original-container-title"/>
         <else>
           <text macro="number-EN"/>
           <text macro="locators-booklike-ZHtoEN"/>
@@ -991,7 +990,7 @@
         <group delimiter=" ">
           <text variable="orginal-genre" text-case="title"/>
           <text value="No."/>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </if>
     </choose>
@@ -1045,7 +1044,7 @@
       </choose>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -1072,11 +1071,11 @@
         <choose>
           <if variable="volume">
             <group>
-              <text variable="volume" font-style="italic"/>
+              <number variable="volume" font-style="italic"/>
               <choose>
                 <if is-numeric="issue">
                   <!-- 仅当 issue 是数字时输出期号，避免“增刊”的情况 -->
-                  <text variable="issue" prefix="(" suffix=")"/>
+                  <number variable="issue" prefix="(" suffix=")"/>
                 </if>
                 <else>
                   <text variable="original-issue" text-case="capitalize-first" prefix="(" suffix=")"/>
@@ -1087,7 +1086,7 @@
           <else>
             <choose>
               <if is-numeric="issue">
-                <text variable="issue" font-style="italic"/>
+                <number variable="issue" font-style="italic"/>
               </if>
               <else>
                 <text variable="original-issue" text-case="capitalize-first" prefix="(" suffix=")"/>
@@ -1097,11 +1096,11 @@
         </choose>
         <choose>
           <if variable="page">
-            <text variable="page"/>
+            <number variable="page"/>
           </if>
           <else>
             <!-- 只有论文编号而无页码的电子刊论文 -->
-            <text variable="number" prefix="Article "/>
+            <number variable="number" prefix="Article "/>
           </else>
         </choose>
       </group>

--- a/src/心理科学进展/心理科学进展.csl
+++ b/src/心理科学进展/心理科学进展.csl
@@ -323,7 +323,7 @@
         <group delimiter=" ">
           <text variable="genre" text-case="title"/>
           <text value="No."/>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </if>
     </choose>
@@ -349,7 +349,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -377,7 +377,7 @@
       </choose>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -404,12 +404,12 @@
         <choose>
           <if variable="volume">
             <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
+              <number variable="volume" font-style="italic"/>
+              <number variable="issue" prefix="(" suffix=")"/>
             </group>
           </if>
           <else>
-            <text variable="issue" font-style="italic"/>
+            <number variable="issue" font-style="italic"/>
           </else>
         </choose>
         <choose>
@@ -419,17 +419,17 @@
                 <!-- 《心理学报》报纸文献的版次有前缀“p” -->
                 <group>
                   <label variable="page" form="short" plural="never" strip-periods="true"/>
-                  <text variable="page"/>
+                  <number variable="page"/>
                 </group>
               </if>
               <else>
-                <text variable="page"/>
+                <number variable="page"/>
               </else>
             </choose>
           </if>
           <else>
             <!-- 只有论文编号而无页码的电子刊论文 -->
-            <text variable="number" prefix="Article "/>
+            <number variable="number" prefix="Article "/>
           </else>
         </choose>
       </group>
@@ -475,7 +475,7 @@
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
                     <label variable="volume" form="short" text-case="capitalize-first"/>
-                    <text variable="volume"/>
+                    <number variable="volume"/>
                   </group>
                 </if>
               </choose>
@@ -761,11 +761,11 @@
       <!-- <number variable="volume" form="numeric"/> -->
       <group delimiter=" ">
         <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -808,7 +808,7 @@
                   <number variable="volume" form="long-ordinal" prefix="(" suffix=")"/>
                 </if>
                 <else>
-                  <text variable="volume" prefix="(" suffix=")"/>
+                  <number variable="volume" prefix="(" suffix=")"/>
                 </else>
               </choose>
             </group>

--- a/src/成都理工大学/成都理工大学.csl
+++ b/src/成都理工大学/成都理工大学.csl
@@ -115,7 +115,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -150,11 +150,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -276,7 +276,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -284,11 +284,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -304,7 +304,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -312,9 +312,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -340,7 +340,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>

--- a/src/扬州大学/扬州大学.csl
+++ b/src/扬州大学/扬州大学.csl
@@ -55,11 +55,11 @@
   </macro>
   <macro name="title">
     <text variable="title"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
   </macro>
   <macro name="title-zh">
     <text variable="title"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
   </macro>
   <macro name="container-contributors">
     <names variable="container-author">
@@ -77,7 +77,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -86,18 +86,18 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="serial-information-zh">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -108,7 +108,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -199,7 +199,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文专著 -->
       <else-if type="monograph">
@@ -228,7 +228,7 @@
         <text variable="publisher-place" prefix=". " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文专利 -->
       <else-if type="patent">
@@ -239,7 +239,7 @@
       <else-if type="article-newspaper">
         <text variable="publisher" prefix="[N]. " suffix=", "/>
         <text macro="issued-date"/>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </else-if>
       <else>
         <text macro="publisher" prefix=". "/>
@@ -305,7 +305,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文专著 -->
       <else-if type="monograph">
@@ -334,7 +334,7 @@
         <text variable="publisher-place" prefix=". " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文专利 -->
       <else-if type="patent">
@@ -345,7 +345,7 @@
       <else-if type="article-newspaper">
         <text variable="publisher" prefix="[N]. " suffix=", "/>
         <text macro="issued-date"/>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </else-if>
       <else>
         <text macro="publisher" prefix=". "/>

--- a/src/探索与争鸣/探索与争鸣.csl
+++ b/src/探索与争鸣/探索与争鸣.csl
@@ -96,7 +96,7 @@
         <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
         <group>
           <label variable="page" form="short"/>
-          <text variable="page" suffix="."/>
+          <number variable="page" suffix="."/>
         </group>
       </else-if>
       <else-if type="webpage">
@@ -119,12 +119,12 @@
       <else>
         <text variable="title" prefix="“" suffix=",” "/>
         <text variable="container-title" font-style="italic" suffix=", "/>
-        <text variable="volume" prefix="Vol. " suffix=", "/>
-        <text variable="issue" prefix="No. "/>
+        <number variable="volume" prefix="Vol. " suffix=", "/>
+        <number variable="issue" prefix="No. "/>
         <date date-parts="year" form="text" variable="issued" prefix="(" suffix="), "/>
         <group>
           <label variable="page" form="short"/>
-          <text variable="page" suffix="."/>
+          <number variable="page" suffix="."/>
         </group>
       </else>
     </choose>
@@ -179,7 +179,7 @@
           <text variable="title" prefix="：《" suffix="》，"/>
           <text macro="container-title"/>
           <date date-parts="year" form="text" variable="issued"/>
-          <text variable="issue" prefix="第" suffix="期。"/>
+          <number variable="issue" prefix="第" suffix="期。"/>
         </else-if>
         <else-if type="article-newspaper">
           <text macro="author"/>
@@ -197,7 +197,7 @@
           <text variable="publisher-place" suffix="："/>
           <text variable="publisher"/>
           <date date-parts="year" form="text" variable="issued" prefix="，"/>
-          <text variable="page" prefix="，第" suffix="页。"/>
+          <number variable="page" prefix="，第" suffix="页。"/>
         </else-if>
         <else-if type="webpage">
           <text macro="author" suffix="："/>
@@ -270,7 +270,7 @@
           <text variable="title" prefix="：《" suffix="》，"/>
           <text macro="container-title"/>
           <date date-parts="year" form="text" variable="issued"/>
-          <text variable="issue" prefix="第" suffix="期。"/>
+          <number variable="issue" prefix="第" suffix="期。"/>
         </else-if>
         <else-if type="article-newspaper">
           <text macro="author"/>
@@ -288,7 +288,7 @@
           <text variable="publisher-place" suffix="："/>
           <text variable="publisher"/>
           <date date-parts="year" form="text" variable="issued" prefix="，"/>
-          <text variable="page" prefix="，第" suffix="页。"/>
+          <number variable="page" prefix="，第" suffix="页。"/>
         </else-if>
         <else-if type="webpage">
           <text macro="author" suffix="："/>

--- a/src/教育史研究/教育史研究.csl
+++ b/src/教育史研究/教育史研究.csl
@@ -78,7 +78,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -98,7 +98,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -110,7 +110,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -270,7 +270,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -502,7 +502,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -521,7 +521,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/数量经济技术经济研究/数量经济技术经济研究.csl
+++ b/src/数量经济技术经济研究/数量经济技术经济研究.csl
@@ -133,7 +133,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -175,7 +175,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -210,11 +210,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -226,11 +226,11 @@
         <choose>
           <if is-numeric="volume">
             <text value="第"/>
-            <text variable="volume"/>
+            <number variable="volume"/>
             <label variable="volume" form="short"/>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -409,17 +409,17 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
         <group delimiter=", ">
           <text variable="container-title"/>
           <group>
-            <text variable="volume"/>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="volume"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -432,7 +432,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -442,14 +442,14 @@
             <text macro="issued-year"/>
             <choose>
               <if variable="issue">
-                <text variable="issue" prefix="(" suffix=")"/>
+                <number variable="issue" prefix="(" suffix=")"/>
               </if>
               <else>
-                <text variable="volume"/>
+                <number variable="volume"/>
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -464,7 +464,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -472,9 +472,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -526,7 +526,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -562,7 +562,7 @@
             </choose>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>

--- a/src/文学评论/文学评论.csl
+++ b/src/文学评论/文学评论.csl
@@ -165,7 +165,7 @@
           <text variable="title" prefix="“" suffix=",” "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if position="subsequent" type="chapter" match="all">
@@ -175,7 +175,7 @@
           <text variable="title" prefix="“" suffix=",” "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="book">
@@ -218,7 +218,7 @@
           <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="paper-conference">
@@ -232,7 +232,7 @@
           <date date-parts="year-month-date" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="thesis">
@@ -257,8 +257,8 @@
               </names>
               <text variable="title" prefix="“" suffix=",” "/>
               <text variable="container-title" font-style="italic" suffix=", "/>
-              <text variable="volume" prefix="Vol. " suffix=", "/>
-              <text variable="issue" prefix="No. " suffix=", "/>
+              <number variable="volume" prefix="Vol. " suffix=", "/>
+              <number variable="issue" prefix="No. " suffix=", "/>
               <date date-parts="year" form="text" variable="issued"/>
               <group>
                 <label variable="locator" form="short" prefix=", "/>
@@ -271,12 +271,12 @@
               </names>
               <text variable="title" prefix="“" suffix=",” "/>
               <text variable="container-title" font-style="italic" suffix=", "/>
-              <text variable="volume" prefix="Vol. " suffix=", "/>
-              <text variable="issue" prefix="No. " suffix=", "/>
+              <number variable="volume" prefix="Vol. " suffix=", "/>
+              <number variable="issue" prefix="No. " suffix=", "/>
               <date date-parts="year" form="text" variable="issued"/>
               <group>
                 <label variable="page" form="short" prefix=", "/>
-                <text variable="page"/>
+                <number variable="page"/>
               </group>
             </else>
           </choose>
@@ -316,7 +316,7 @@
           <text variable="archive_location"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else>
       </choose>
@@ -352,7 +352,7 @@
               <text variable="title" prefix="：《" suffix="》，"/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <date date-parts="year" form="text" variable="issued"/>
-              <text variable="issue" prefix="第" suffix="期"/>
+              <number variable="issue" prefix="第" suffix="期"/>
             </if>
             <else>
               <text macro="author"/>
@@ -360,7 +360,7 @@
               <text macro="secondAuthor" suffix="，"/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <date date-parts="year" form="text" variable="issued"/>
-              <text variable="issue" prefix="第" suffix="期"/>
+              <number variable="issue" prefix="第" suffix="期"/>
             </else>
           </choose>
         </else-if>
@@ -370,7 +370,7 @@
           <text macro="secondAuthor" suffix="，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date form="text" variable="issued"/>
-          <text variable="edition" prefix="，"/>
+          <number variable="edition" prefix="，"/>
           <text variable="section" prefix="，"/>
         </else-if>
         <else-if type="chapter">
@@ -381,12 +381,12 @@
               <text macro="editor" prefix="见" suffix="编，"/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="secondAuthor" prefix="，"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </if>
             <else>
               <text macro="author"/>
@@ -394,11 +394,11 @@
               <text macro="editor" prefix="见" suffix="编："/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </else>
           </choose>
         </else-if>
@@ -436,8 +436,8 @@
               <text macro="editor" suffix="主编，"/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="secondAuthor" prefix="，"/>
               <text macro="locators-zh"/>
               <text variable="locator" prefix="，第" suffix="页"/>
@@ -449,8 +449,8 @@
               <text macro="editor" suffix="主编："/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="locators-zh"/>
               <text variable="locator" prefix="，第" suffix="页"/>
               <text variable="publisher" prefix="，"/>
@@ -464,8 +464,8 @@
           <text macro="secondAuthor"/>
           <text variable="title" prefix="《" suffix="》"/>
           <date date-parts="year-month-date" form="text" variable="issued" prefix="，" suffix="，"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
           <text macro="locators-zh"/>
           <text variable="locator" prefix="，第" suffix="页"/>
           <text variable="publisher-place" prefix="，" suffix="："/>
@@ -523,7 +523,7 @@
           <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="paper-conference">
@@ -537,7 +537,7 @@
           <date date-parts="year-month-date" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="thesis">
@@ -560,12 +560,12 @@
           </names>
           <text variable="title" prefix="“" suffix=",” "/>
           <text variable="container-title" font-style="italic" suffix=", "/>
-          <text variable="volume" prefix="Vol. " suffix=", "/>
-          <text variable="issue" prefix="No. " suffix=", "/>
+          <number variable="volume" prefix="Vol. " suffix=", "/>
+          <number variable="issue" prefix="No. " suffix=", "/>
           <date date-parts="year" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="article-newspaper">
@@ -603,7 +603,7 @@
           <text variable="archive_location"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else>
       </choose>
@@ -639,7 +639,7 @@
               <text variable="title" prefix="：《" suffix="》，"/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <date date-parts="year" form="text" variable="issued"/>
-              <text variable="issue" prefix="第" suffix="期"/>
+              <number variable="issue" prefix="第" suffix="期"/>
             </if>
             <else>
               <text macro="author"/>
@@ -647,7 +647,7 @@
               <text macro="secondAuthor" suffix="，"/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <date date-parts="year" form="text" variable="issued"/>
-              <text variable="issue" prefix="第" suffix="期"/>
+              <number variable="issue" prefix="第" suffix="期"/>
             </else>
           </choose>
         </else-if>
@@ -657,7 +657,7 @@
           <text macro="secondAuthor" suffix="，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date form="text" variable="issued"/>
-          <text variable="edition" prefix="，"/>
+          <number variable="edition" prefix="，"/>
           <text variable="section" prefix="，"/>
         </else-if>
         <else-if type="chapter">
@@ -668,12 +668,12 @@
               <text macro="editor" prefix="见" suffix="编，"/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="secondAuthor" prefix="，"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </if>
             <else>
               <text macro="author"/>
@@ -681,11 +681,11 @@
               <text macro="editor" prefix="见" suffix="编："/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" suffix="版"/>
-              <text variable="page" prefix="，第" suffix="页"/>
+              <number variable="page" prefix="，第" suffix="页"/>
             </else>
           </choose>
         </else-if>
@@ -723,8 +723,8 @@
               <text macro="editor" suffix="主编，"/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="secondAuthor" prefix="，"/>
               <text macro="locators-zh"/>
               <text variable="locator" prefix="，第" suffix="页"/>
@@ -736,8 +736,8 @@
               <text macro="editor" suffix="主编："/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="locators-zh"/>
               <text variable="locator" prefix="，第" suffix="页"/>
               <text variable="publisher" prefix="，"/>
@@ -751,8 +751,8 @@
           <text macro="secondAuthor"/>
           <text variable="title" prefix="《" suffix="》"/>
           <date date-parts="year-month-date" form="text" variable="issued" prefix="，" suffix="，"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
           <text macro="locators-zh"/>
           <text variable="locator" prefix="，第" suffix="页"/>
           <text variable="publisher-place" prefix="，" suffix="："/>

--- a/src/文艺争鸣/文艺争鸣.csl
+++ b/src/文艺争鸣/文艺争鸣.csl
@@ -164,7 +164,7 @@
           <text variable="title" prefix="“" suffix=",” "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if position="subsequent" type="chapter" match="all">
@@ -174,7 +174,7 @@
           <text variable="title" prefix="“" suffix=",” "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="book">
@@ -217,7 +217,7 @@
           <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="paper-conference">
@@ -231,7 +231,7 @@
           <date date-parts="year-month-date" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="thesis">
@@ -256,8 +256,8 @@
               </names>
               <text variable="title" prefix="“" suffix=",” "/>
               <text variable="container-title" font-style="italic" suffix=", "/>
-              <text variable="volume" prefix="Vol. " suffix=", "/>
-              <text variable="issue" prefix="No. " suffix=", "/>
+              <number variable="volume" prefix="Vol. " suffix=", "/>
+              <number variable="issue" prefix="No. " suffix=", "/>
               <date date-parts="year" form="text" variable="issued"/>
               <group>
                 <label variable="locator" form="short" prefix=", "/>
@@ -270,12 +270,12 @@
               </names>
               <text variable="title" prefix="“" suffix=",” "/>
               <text variable="container-title" font-style="italic" suffix=", "/>
-              <text variable="volume" prefix="Vol. " suffix=", "/>
-              <text variable="issue" prefix="No. " suffix=", "/>
+              <number variable="volume" prefix="Vol. " suffix=", "/>
+              <number variable="issue" prefix="No. " suffix=", "/>
               <date date-parts="year" form="text" variable="issued"/>
               <group>
                 <label variable="page" form="short" prefix=", "/>
-                <text variable="page"/>
+                <number variable="page"/>
               </group>
             </else>
           </choose>
@@ -315,7 +315,7 @@
           <text variable="archive_location"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else>
       </choose>
@@ -349,7 +349,7 @@
           <text macro="secondAuthor" suffix="，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date date-parts="year" form="text" variable="issued"/>
-          <text variable="issue" prefix="第" suffix="期"/>
+          <number variable="issue" prefix="第" suffix="期"/>
         </else-if>
         <else-if type="article-newspaper">
           <text macro="author" suffix="："/>
@@ -357,7 +357,7 @@
           <text macro="secondAuthor" suffix="，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date form="text" variable="issued"/>
-          <text variable="edition" prefix="，"/>
+          <number variable="edition" prefix="，"/>
           <text variable="section" prefix="，"/>
         </else-if>
         <else-if type="chapter">
@@ -368,10 +368,10 @@
               <text macro="editor" prefix="见" suffix="主编："/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="secondAuthor" prefix="，" suffix="，"/>
-              <text variable="page" prefix="第" suffix="页，"/>
+              <number variable="page" prefix="第" suffix="页，"/>
               <text variable="publisher" suffix="，"/>
               <text macro="date" suffix="版"/>
             </if>
@@ -381,9 +381,9 @@
               <text macro="editor" prefix="见" suffix="主编："/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
-              <text variable="page" prefix="，第" suffix="页，"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
+              <number variable="page" prefix="，第" suffix="页，"/>
               <text variable="publisher" suffix="，"/>
               <text macro="date" suffix="版"/>
             </else>
@@ -424,8 +424,8 @@
               <text variable="title" prefix="《" suffix="》，"/>
               <text macro="secondAuthor"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" prefix="，" suffix="版"/>
               <text macro="locators-zh"/>
@@ -436,8 +436,8 @@
               <text macro="editor" suffix="主编："/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" prefix="，" suffix="版"/>
               <text macro="locators-zh"/>
@@ -451,8 +451,8 @@
           <text variable="title" prefix="《" suffix="》"/>
           <text macro="secondAuthor"/>
           <date date-parts="year-month-date" form="text" variable="issued" prefix="，" suffix="，"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
           <text variable="publisher-place" prefix="，" suffix="："/>
           <text variable="publisher"/>
           <text variable="archive" suffix="，"/>
@@ -510,7 +510,7 @@
           <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="paper-conference">
@@ -524,7 +524,7 @@
           <date date-parts="year-month-date" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="thesis">
@@ -547,12 +547,12 @@
           </names>
           <text variable="title" prefix="“" suffix=",” "/>
           <text variable="container-title" font-style="italic" suffix=", "/>
-          <text variable="volume" prefix="Vol. " suffix=", "/>
-          <text variable="issue" prefix="No. " suffix=", "/>
+          <number variable="volume" prefix="Vol. " suffix=", "/>
+          <number variable="issue" prefix="No. " suffix=", "/>
           <date date-parts="year" form="text" variable="issued"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if type="article-newspaper">
@@ -590,7 +590,7 @@
           <text variable="archive_location"/>
           <group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else>
       </choose>
@@ -624,7 +624,7 @@
           <text macro="secondAuthor" suffix="，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date date-parts="year" form="text" variable="issued"/>
-          <text variable="issue" prefix="第" suffix="期"/>
+          <number variable="issue" prefix="第" suffix="期"/>
         </else-if>
         <else-if type="article-newspaper">
           <text macro="author" suffix="："/>
@@ -632,7 +632,7 @@
           <text macro="secondAuthor" suffix="，"/>
           <text variable="container-title" prefix="《" suffix="》"/>
           <date form="text" variable="issued"/>
-          <text variable="edition" prefix="，"/>
+          <number variable="edition" prefix="，"/>
           <text variable="section" prefix="，"/>
         </else-if>
         <else-if type="chapter">
@@ -643,10 +643,10 @@
               <text macro="editor" prefix="见" suffix="主编："/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text macro="secondAuthor" prefix="，" suffix="，"/>
-              <text variable="page" prefix="第" suffix="页，"/>
+              <number variable="page" prefix="第" suffix="页，"/>
               <text variable="publisher" suffix="，"/>
               <text macro="date" suffix="版"/>
             </if>
@@ -656,9 +656,9 @@
               <text macro="editor" prefix="见" suffix="主编："/>
               <text variable="container-title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
-              <text variable="page" prefix="，第" suffix="页，"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
+              <number variable="page" prefix="，第" suffix="页，"/>
               <text variable="publisher" suffix="，"/>
               <text macro="date" suffix="版"/>
             </else>
@@ -699,8 +699,8 @@
               <text variable="title" prefix="《" suffix="》，"/>
               <text macro="secondAuthor" suffix="，"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher"/>
               <text macro="date" prefix="，" suffix="版"/>
               <text macro="locators-zh"/>
@@ -711,8 +711,8 @@
               <text macro="editor" suffix="主编："/>
               <text variable="title" prefix="《" suffix="》"/>
               <text variable="collection-number" prefix="第" suffix="册"/>
-              <text variable="edition"/>
-              <text variable="volume" prefix="第" suffix="卷"/>
+              <number variable="edition"/>
+              <number variable="volume" prefix="第" suffix="卷"/>
               <text variable="publisher" prefix="，"/>
               <text macro="date" prefix="，" suffix="版"/>
               <text macro="locators-zh"/>
@@ -726,8 +726,8 @@
           <text variable="title" prefix="《" suffix="》"/>
           <text macro="secondAuthor"/>
           <date date-parts="year-month-date" form="text" variable="issued" prefix="，" suffix="，"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
           <text variable="publisher-place" prefix="，" suffix="："/>
           <text variable="publisher"/>
           <text variable="archive" suffix="，"/>

--- a/src/新疆农业大学动科学院/新疆农业大学动科学院.csl
+++ b/src/新疆农业大学动科学院/新疆农业大学动科学院.csl
@@ -73,7 +73,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -135,7 +135,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -144,10 +144,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -159,7 +159,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -220,7 +220,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <text variable="edition" suffix=". "/>
+            <number variable="edition" suffix=". "/>
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -254,7 +254,7 @@
         <text variable="publisher-place" prefix="[C]. " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -263,7 +263,7 @@
         <text variable="publisher-place" prefix="[C]. " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -271,7 +271,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文报纸 -->
       <else-if type="article-newspaper">
@@ -279,7 +279,7 @@
           <group>
             <text variable="publisher" suffix=". "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>
@@ -340,7 +340,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <text variable="edition" suffix=". "/>
+            <number variable="edition" suffix=". "/>
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -374,7 +374,7 @@
         <text variable="publisher-place" prefix="[C]. " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -383,7 +383,7 @@
         <text variable="publisher-place" prefix="[C]. " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -391,7 +391,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文报纸 -->
       <else-if type="article-newspaper">
@@ -399,7 +399,7 @@
           <group>
             <text variable="publisher" suffix=". "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>

--- a/src/新疆大学/新疆大学.csl
+++ b/src/新疆大学/新疆大学.csl
@@ -76,7 +76,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -111,11 +111,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -248,7 +248,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -257,11 +257,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -276,7 +276,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -284,9 +284,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -314,7 +314,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/新金融/新金融.csl
+++ b/src/新金融/新金融.csl
@@ -133,7 +133,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -170,7 +170,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -201,11 +201,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -315,7 +315,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -323,11 +323,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -341,7 +341,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，卷（期）：页码［引用日期］” -->
@@ -349,11 +349,11 @@
           <group>
             <group delimiter="，">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -369,7 +369,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -377,16 +377,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -412,7 +412,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -448,7 +448,7 @@
             <text variable="publisher-place"/>
             <text variable="publisher"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/新闻与传播研究/新闻与传播研究.csl
+++ b/src/新闻与传播研究/新闻与传播研究.csl
@@ -170,7 +170,7 @@
             <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
             <group>
               <label variable="page" form="short"/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -213,7 +213,7 @@
             <date date-parts="year-month-date" form="text" variable="issued"/>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -239,8 +239,8 @@
             <group delimiter=", ">
               <text variable="title" quotes="true"/>
               <text variable="container-title" font-style="italic"/>
-              <text variable="volume" prefix="Vol. "/>
-              <text variable="issue" prefix="No. "/>
+              <number variable="volume" prefix="Vol. "/>
+              <number variable="issue" prefix="No. "/>
               <date date-parts="year" form="numeric" variable="issued"/>
             </group>
             <group>
@@ -253,13 +253,13 @@
             <group delimiter=", ">
               <text variable="title" quotes="true"/>
               <text variable="container-title" font-style="italic"/>
-              <text variable="volume" prefix="Vol. "/>
-              <text variable="issue" prefix="No. "/>
+              <number variable="volume" prefix="Vol. "/>
+              <number variable="issue" prefix="No. "/>
               <date date-parts="year" form="numeric" variable="issued"/>
             </group>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -304,7 +304,7 @@
             <date date-parts="year" form="numeric" variable="issued"/>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -329,7 +329,7 @@
             <text variable="publisher-place" prefix="（" suffix="）"/>
             <date date-parts="year" form="text" variable="issued"/>
             <group delimiter="，">
-              <text variable="issue" prefix="第" suffix="期"/>
+              <number variable="issue" prefix="第" suffix="期"/>
               <text macro="locators-zh"/>
               <text variable="locator" prefix="第" suffix="页"/>
             </group>
@@ -345,8 +345,8 @@
             <text variable="publisher-place" prefix="（" suffix="）"/>
             <date date-parts="year" form="text" variable="issued"/>
             <group delimiter="，">
-              <text variable="issue" prefix="第" suffix="期"/>
-              <text variable="page" prefix="第" suffix="页"/>
+              <number variable="issue" prefix="第" suffix="期"/>
+              <number variable="page" prefix="第" suffix="页"/>
             </group>
           </else>
         </choose>
@@ -360,7 +360,7 @@
           <text variable="container-title" prefix="《" suffix="》，"/>
         </group>
         <date form="text" variable="issued"/>
-        <text variable="edition" prefix="，第" suffix="版"/>
+        <number variable="edition" prefix="，第" suffix="版"/>
       </else-if>
       <else-if type="chapter">
         <!-- 中文章节 -->
@@ -375,8 +375,8 @@
               <group>
                 <text variable="container-title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
               <text macro="secondAuthor"/>
               <group delimiter="：">
@@ -397,8 +397,8 @@
               <group>
                 <text variable="container-title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
               <text macro="secondAuthor"/>
               <group delimiter="：">
@@ -407,7 +407,7 @@
               </group>
               <text macro="date"/>
             </group>
-            <text variable="page" prefix="，第" suffix="页"/>
+            <number variable="page" prefix="，第" suffix="页"/>
           </else>
         </choose>
       </else-if>
@@ -445,7 +445,7 @@
               <text variable="event-place"/>
               <date date-parts="year-month-date" form="text" variable="issued"/>
             </group>
-            <text variable="page" prefix="，第" suffix="页"/>
+            <number variable="page" prefix="，第" suffix="页"/>
           </else>
         </choose>
       </else-if>
@@ -475,8 +475,8 @@
               <group>
                 <text variable="title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
               <text macro="secondAuthor"/>
               <group delimiter="：">
@@ -496,8 +496,8 @@
               <group>
                 <text variable="title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
               <group delimiter="：">
                 <text variable="publisher-place"/>
@@ -517,8 +517,8 @@
         <group delimiter="，" suffix="，">
           <text variable="title" prefix="《" suffix="》"/>
           <text variable="collection-number" prefix="第" suffix="册"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
         </group>
         <text macro="secondAuthor" prefix="，"/>
         <group delimiter="：" suffix="，">
@@ -619,7 +619,7 @@
           <text variable="title" quotes="true" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if position="subsequent" type="chapter" match="all">
@@ -629,7 +629,7 @@
           <text variable="title" quotes="true" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else>

--- a/src/无机材料学报/无机材料学报.csl
+++ b/src/无机材料学报/无机材料学报.csl
@@ -83,7 +83,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -114,11 +114,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -181,7 +181,7 @@
           <text variable="container-title" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -189,20 +189,20 @@
           <group delimiter=", ">
             <text variable="container-title" font-style="italic"/>
             <text macro="issued-year"/>
-            <text variable="volume" font-weight="bold"/>
+            <number variable="volume" font-weight="bold"/>
           </group>
           <group font-weight="bold">
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
         </group>
         <group>
           <text value=": " font-weight="bold"/>
           <choose>
             <if variable="page">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
-              <text variable="number"/>
+              <number variable="number"/>
             </else>
           </choose>
         </group>
@@ -219,7 +219,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -227,9 +227,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -239,7 +239,7 @@
         <text macro="issued-date"/>
       </if>
       <else-if type="paper-conference" variable="event-title" match="all">
-        <text variable="page"/>
+        <number variable="page"/>
       </else-if>
       <else-if type="book chapter paper-conference periodical thesis" variable="archive archive-place publisher publisher-place page" match="any">
         <!-- 非纯电子资源的格式“出版地: 出版者, 出版年: 页码[引用日期]” -->
@@ -260,7 +260,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/昆明医科大学/昆明医科大学.csl
+++ b/src/昆明医科大学/昆明医科大学.csl
@@ -73,7 +73,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -108,11 +108,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -239,7 +239,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -248,11 +248,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -267,7 +267,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -275,9 +275,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -305,7 +305,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/暨南大学/暨南大学.csl
+++ b/src/暨南大学/暨南大学.csl
@@ -75,7 +75,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation patent report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -134,7 +134,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -143,10 +143,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -158,7 +158,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/材料导报/材料导报.csl
+++ b/src/材料导报/材料导报.csl
@@ -103,7 +103,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -143,7 +143,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -164,11 +164,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -240,7 +240,7 @@
           </group>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -251,11 +251,11 @@
                 <text variable="container-title"/>
               </group>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -270,7 +270,7 @@
           </group>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -281,11 +281,11 @@
                 <text variable="original-container-title"/>
               </group>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -300,7 +300,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -308,9 +308,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -321,7 +321,7 @@
             <text variable="publisher-place"/>
             <text term="patent"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-year"/>
         </group>
       </if>
@@ -360,7 +360,7 @@
             <text variable="original-publisher-place"/>
             <text term="patent"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-year"/>
         </group>
       </if>
@@ -406,7 +406,7 @@
             <text variable="publisher-place"/>
             <text term="patent"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-year"/>
         </group>
       </if>
@@ -467,7 +467,7 @@
   <macro name="page">
     <group delimiter=" ">
       <label variable="page" form="short" plural="always"/>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
   </macro>
   <!-- 出版日期，用于报纸文献、专利的“公告日期或公开日期”、电子资源的“更新或修改日期” -->

--- a/src/林业科学/林业科学.csl
+++ b/src/林业科学/林业科学.csl
@@ -120,7 +120,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -150,7 +150,7 @@
         <choose>
           <if type="article article-journal" match="none">
             <!-- 预印本和期刊文章的编号用于其他位置 -->
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
         <choose>
@@ -170,11 +170,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -249,7 +249,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -257,11 +257,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -274,7 +274,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -282,11 +282,11 @@
           <group>
             <group delimiter=", ">
               <text variable="original-container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -301,7 +301,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -309,9 +309,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -336,7 +336,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -379,7 +379,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/林产化学与工业/林产化学与工业.csl
+++ b/src/林产化学与工业/林产化学与工业.csl
@@ -69,7 +69,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -84,7 +84,7 @@
           <choose>
             <if type="article article-journal standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -119,11 +119,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -256,7 +256,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -265,11 +265,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -284,7 +284,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -292,9 +292,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -322,7 +322,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/核农学报/核农学报.csl
+++ b/src/核农学报/核农学报.csl
@@ -88,7 +88,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -138,11 +138,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -274,7 +274,7 @@
         <group delimiter=", ">
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -282,11 +282,11 @@
           <group>
             <group delimiter=", ">
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -322,7 +322,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -330,9 +330,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -360,7 +360,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/核聚变与等离子体物理/核聚变与等离子体物理.csl
+++ b/src/核聚变与等离子体物理/核聚变与等离子体物理.csl
@@ -74,7 +74,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -110,11 +110,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -249,7 +249,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -258,11 +258,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -277,7 +277,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -285,9 +285,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -315,7 +315,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/植物保护学报/植物保护学报.csl
+++ b/src/植物保护学报/植物保护学报.csl
@@ -115,11 +115,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </if>
       <else>
@@ -148,11 +148,11 @@
           <group>
             <group delimiter=", ">
               <text variable="original-container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </if>
       <else>
@@ -169,7 +169,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -213,7 +213,7 @@
         </group>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/植物生理学报/植物生理学报.csl
+++ b/src/植物生理学报/植物生理学报.csl
@@ -193,7 +193,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -215,11 +215,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </if>
       <else-if variable="container-title">
@@ -247,11 +247,11 @@
           <group>
             <group delimiter=", ">
               <text variable="original-container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </if>
       <else-if variable="original-container-title">
@@ -291,7 +291,7 @@
         </group>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/植物遗传资源学报/植物遗传资源学报.csl
+++ b/src/植物遗传资源学报/植物遗传资源学报.csl
@@ -85,7 +85,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -122,7 +122,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -153,11 +153,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -244,7 +244,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -253,11 +253,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -270,7 +270,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -279,11 +279,11 @@
             <group delimiter="，">
               <text variable="original-container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -298,7 +298,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -306,9 +306,9 @@
   <macro name="year-volume-issue">
     <group delimiter="，">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -336,7 +336,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -391,7 +391,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/武汉大学（本科）/武汉大学（本科）.csl
+++ b/src/武汉大学（本科）/武汉大学（本科）.csl
@@ -63,7 +63,7 @@
     <group delimiter=", ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=": ">
@@ -79,7 +79,7 @@
                   <text value="中国"/>
                 </else>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </if>
         </choose>
@@ -96,11 +96,11 @@
       <if is-numeric="volume">
         <group delimiter=" ">
           <label variable="volume" form="short" text-case="capitalize-first"/>
-          <text variable="volume"/>
+          <number variable="volume"/>
         </group>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -224,7 +224,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -233,11 +233,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -252,7 +252,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -280,7 +280,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -322,7 +322,7 @@
         </else>
       </choose>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 参考文献表的格式 -->
   <macro name="entry-layout">

--- a/src/武汉理工大学（本科）/武汉理工大学（本科）.csl
+++ b/src/武汉理工大学（本科）/武汉理工大学（本科）.csl
@@ -78,7 +78,7 @@
     <group delimiter=". ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=", ">
@@ -94,7 +94,7 @@
             <choose>
               <if type="article article-journal patent standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -123,7 +123,7 @@
               <text macro="patent-country-en"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </if>
       </choose>
@@ -137,7 +137,7 @@
     <group delimiter="．">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter="，">
@@ -153,7 +153,7 @@
             <choose>
               <if type="article article-journal patent standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -182,7 +182,7 @@
               <text macro="patent-country-zh"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </if>
       </choose>
@@ -200,11 +200,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -403,7 +403,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -412,11 +412,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -429,7 +429,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -438,11 +438,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -457,7 +457,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -465,16 +465,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -502,7 +502,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -558,7 +558,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/水利水运工程学报/水利水运工程学报.csl
+++ b/src/水利水运工程学报/水利水运工程学报.csl
@@ -77,7 +77,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -98,7 +98,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -132,7 +132,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="original-title"/>
@@ -153,7 +153,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -189,11 +189,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -367,7 +367,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -376,11 +376,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -393,7 +393,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -402,11 +402,11 @@
             <group delimiter=", ">
               <text variable="original-container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -421,7 +421,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -429,9 +429,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -459,7 +459,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -515,7 +515,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/水生生物学报/水生生物学报.csl
+++ b/src/水生生物学报/水生生物学报.csl
@@ -84,7 +84,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -134,7 +134,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -177,7 +177,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -213,11 +213,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -371,7 +371,7 @@
           <text variable="container-title" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -380,11 +380,11 @@
             <group delimiter=", ">
               <text variable="container-title" font-style="italic"/>
               <text macro="issued-year"/>
-              <text variable="volume" font-weight="bold"/>
+              <number variable="volume" font-weight="bold"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -397,7 +397,7 @@
           <text variable="original-container-title" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -406,11 +406,11 @@
             <group delimiter=", ">
               <text variable="original-container-title" font-style="italic"/>
               <text macro="issued-year"/>
-              <text variable="volume" font-weight="bold"/>
+              <number variable="volume" font-weight="bold"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -425,7 +425,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -433,9 +433,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -463,7 +463,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -518,7 +518,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/水科学进展/水科学进展.csl
+++ b/src/水科学进展/水科学进展.csl
@@ -95,7 +95,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -145,11 +145,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -281,7 +281,7 @@
         <group delimiter=", ">
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -289,11 +289,11 @@
           <group>
             <group delimiter=", ">
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -329,7 +329,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -337,9 +337,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -367,7 +367,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/江南大学/江南大学.csl
+++ b/src/江南大学/江南大学.csl
@@ -71,7 +71,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -86,7 +86,7 @@
           <choose>
             <if type="article article-journal standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -135,11 +135,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -270,7 +270,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -279,11 +279,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -298,7 +298,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -306,9 +306,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -336,7 +336,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if type="dataset post post-weblog software webpage" match="none">

--- a/src/江西财经大学/江西财经大学.csl
+++ b/src/江西财经大学/江西财经大学.csl
@@ -73,7 +73,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -157,7 +157,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -166,10 +166,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -181,7 +181,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -249,7 +249,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <text variable="edition" suffix=". "/>
+            <number variable="edition" suffix=". "/>
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -283,7 +283,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -292,7 +292,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -300,7 +300,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文报纸 -->
       <else-if type="article-newspaper">
@@ -308,7 +308,7 @@
           <group>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>
@@ -369,7 +369,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <text variable="edition" suffix=". "/>
+            <number variable="edition" suffix=". "/>
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -403,7 +403,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -412,7 +412,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -420,7 +420,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文报纸 -->
       <else-if type="article-newspaper">
@@ -428,7 +428,7 @@
           <group>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>

--- a/src/沈阳农业大学/沈阳农业大学.csl
+++ b/src/沈阳农业大学/沈阳农业大学.csl
@@ -89,7 +89,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -98,10 +98,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <!-- <text macro="issued-year"/> -->
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -113,7 +113,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/河北农业大学/河北农业大学.csl
+++ b/src/河北农业大学/河北农业大学.csl
@@ -68,7 +68,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -102,11 +102,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -239,11 +239,11 @@
               <text macro="issued-year"/>
             </else>
           </choose>
-          <text variable="volume"/>
+          <number variable="volume"/>
         </group>
-        <text variable="issue" prefix="(" suffix=")"/>
+        <number variable="issue" prefix="(" suffix=")"/>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
   </macro>
   <macro name="edition">
@@ -255,16 +255,16 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -291,7 +291,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL" match="none">

--- a/src/河北大学研究生学位论文/河北大学研究生学位论文.csl
+++ b/src/河北大学研究生学位论文/河北大学研究生学位论文.csl
@@ -94,7 +94,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -136,7 +136,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -171,11 +171,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -361,7 +361,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -370,11 +370,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -387,7 +387,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码[引用日期]” -->
@@ -396,11 +396,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -415,7 +415,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -423,16 +423,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -460,7 +460,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -516,7 +516,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/河北工业大学学/河北工业大学学.csl
+++ b/src/河北工业大学学/河北工业大学学.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -238,7 +238,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -247,11 +247,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -266,7 +266,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -274,9 +274,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -304,7 +304,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/河海大学/河海大学.csl
+++ b/src/河海大学/河海大学.csl
@@ -53,7 +53,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -137,7 +137,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -146,10 +146,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -161,7 +161,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -230,7 +230,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <!-- <text variable="edition" suffix=". "/> -->
+            <!-- <number variable="edition" suffix=". "/> -->
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -265,7 +265,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -274,7 +274,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -282,7 +282,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文报纸 -->
       <else-if type="article-newspaper">
@@ -290,7 +290,7 @@
           <group>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>
@@ -355,7 +355,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <!-- <text variable="edition" suffix=". "/> -->
+            <!-- <number variable="edition" suffix=". "/> -->
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -390,7 +390,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -399,7 +399,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -407,7 +407,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文报纸 -->
       <else-if type="article-newspaper">
@@ -415,7 +415,7 @@
           <group>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>

--- a/src/法学引注手册（多语言）/法学引注手册（多语言）.csl
+++ b/src/法学引注手册（多语言）/法学引注手册（多语言）.csl
@@ -264,7 +264,7 @@
                 <!-- 若同时有期刊卷册数和年份，则将卷册数标注在期刊名称之后，随后再以括号标记年份。 -->
                 <if variable="volume">
                   <text macro="container-de"/>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                   <text macro="issuance-de" prefix="(" suffix=")"/>
                 </if>
                 <else>
@@ -361,12 +361,12 @@
                 </if>
                 <!-- 引用判例集中的判决时，标出判例集的名称、卷号 -->
                 <else>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                 </else>
               </choose>
             </group>
             <group delimiter=" ">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
               <text variable="locator" prefix="(" suffix=")"/>
             </group>
           </group>
@@ -393,7 +393,7 @@
             <group delimiter=" ">
               <text macro="container-en"/>
               <group delimiter=", ">
-                <text variable="page-first"/>
+                <number variable="page-first"/>
                 <text macro="locator-en"/>
               </group>
               <text macro="issuance-en" prefix="(" suffix=")"/>
@@ -437,7 +437,7 @@
                   <text macro="title-en"/>
                   <group delimiter=" ">
                     <text value="Pub. L. No."/>
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </group>
                   <text macro="section-en"/>
                   <text macro="container-en"/>
@@ -454,7 +454,7 @@
                 </group>
               </else>
             </choose>
-            <text variable="page"/>
+            <number variable="page"/>
             <text macro="locator-en"/>
             <text macro="issuance-en" prefix="(" suffix=")"/>
           </group>
@@ -466,13 +466,13 @@
               <text macro="title-en"/>
               <group delimiter=" ">
                 <text value="No."/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
             <text macro="container-en"/>
             <group delimiter=", ">
-              <text variable="page"/>
+              <number variable="page"/>
               <text variable="locator"/>
             </group>
             <group delimiter=" " prefix="(" suffix=")">
@@ -541,7 +541,7 @@
           </choose>
           <group>
             <text value="nᵒ "/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issuance-fr"/>
           <text macro="locator-or-page-fr"/>
@@ -565,7 +565,7 @@
                   <text macro="title-en"/>
                   <group delimiter=" ">
                     <text value="Pub. L. No."/>
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </group>
                   <text macro="container-en"/>
                 </group>
@@ -576,7 +576,7 @@
                 <text macro="container-en"/>
               </else>
             </choose>
-            <text variable="page"/>
+            <number variable="page"/>
             <text macro="locator-fr"/>
             <text macro="issuance-en" prefix="(" suffix=")"/>
           </group>
@@ -588,13 +588,13 @@
               <text macro="title-en"/>
               <group delimiter=" ">
                 <text value="No."/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
             <text macro="container-en"/>
             <group delimiter=", ">
-              <text variable="page"/>
+              <number variable="page"/>
               <text variable="locator"/>
             </group>
             <group delimiter=" " prefix="(" suffix=")">
@@ -661,7 +661,7 @@
             <text variable="container-title"/>
             <text macro="volume-ja"/>
             <group>
-              <text variable="number"/>
+              <number variable="number"/>
               <text term="issue" form="short"/>
             </group>
             <text macro="locator-or-page-ja"/>
@@ -791,7 +791,7 @@
           <text macro="title-zh"/>
           <choose>
             <if variable="section locator" match="none">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -850,7 +850,7 @@
           <text macro="author-zh"/>
           <group delimiter="，">
             <text macro="title-zh"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </group>
       </else-if>
@@ -985,7 +985,7 @@
             </else-if>
             <else-if variable="section locator" match="any">
               <!-- 64.1 《最高人民法院关于适用〈中华人民共和国行政诉讼法〉的解释》(法释 〔2018〕1 号)，第 100 条。 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </else-if>
           </choose>
         </group>
@@ -1032,7 +1032,7 @@
         <label variable="edition" form="short" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1043,7 +1043,7 @@
         <label variable="edition" form="short" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1055,7 +1055,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1109,7 +1109,7 @@
       </else-if>
       <else-if type="legislation">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title"/>
         </group>
       </else-if>
@@ -1122,7 +1122,7 @@
     <choose>
       <if type="article-journal article-magazine" match="any">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title" text-case="title"/>
         </group>
       </if>
@@ -1132,7 +1132,7 @@
           <group delimiter=", ">
             <text macro="editor-en"/>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title" text-case="title"/>
             </group>
           </group>
@@ -1140,7 +1140,7 @@
       </else-if>
       <else-if type="legislation">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title" text-case="title"/>
         </group>
       </else-if>
@@ -1260,7 +1260,7 @@
                 <text value="判决书"/>
               </else>
             </choose>
-            <text variable="number"/>
+            <number variable="number"/>
           </else>
         </choose>
       </else-if>
@@ -1302,7 +1302,7 @@
         <number variable="volume" form="roman" text-case="uppercase"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1327,7 +1327,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1339,7 +1339,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1350,7 +1350,7 @@
         <number variable="issue"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1361,7 +1361,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1380,7 +1380,7 @@
         </choose>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1577,7 +1577,7 @@
             <number variable="page"/>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>
@@ -1629,11 +1629,11 @@
         <choose>
           <if type="article-newspaper">
             <text term="at" suffix=" "/>
-            <text variable="page" form="short"/>
+            <number variable="page" form="short"/>
           </if>
           <else-if type="article-magazine">
             <label variable="page" form="short" suffix=" "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </else-if>
         </choose>
       </else-if>
@@ -1646,10 +1646,10 @@
       </if>
       <else-if is-numeric="page">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -1659,11 +1659,11 @@
         <text macro="locator-ja"/>
       </if>
       <else-if is-numeric="page">
-        <text variable="page-first"/>
+        <number variable="page-first"/>
         <label variable="page" form="short"/>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -1677,11 +1677,11 @@
         <choose>
           <if is-numeric="page">
             <text value="第"/>
-            <text variable="page"/>
+            <number variable="page"/>
             <text value="版"/>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>

--- a/src/法学引注手册（多语言，重复引用不省略）/法学引注手册（多语言，重复引用不省略）.csl
+++ b/src/法学引注手册（多语言，重复引用不省略）/法学引注手册（多语言，重复引用不省略）.csl
@@ -239,7 +239,7 @@
                 <!-- 若同时有期刊卷册数和年份，则将卷册数标注在期刊名称之后，随后再以括号标记年份。 -->
                 <if variable="volume">
                   <text macro="container-de"/>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                   <text macro="issuance-de" prefix="(" suffix=")"/>
                 </if>
                 <else>
@@ -336,12 +336,12 @@
                 </if>
                 <!-- 引用判例集中的判决时，标出判例集的名称、卷号 -->
                 <else>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                 </else>
               </choose>
             </group>
             <group delimiter=" ">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
               <text variable="locator" prefix="(" suffix=")"/>
             </group>
           </group>
@@ -368,7 +368,7 @@
             <group delimiter=" ">
               <text macro="container-en"/>
               <group delimiter=", ">
-                <text variable="page-first"/>
+                <number variable="page-first"/>
                 <text macro="locator-en"/>
               </group>
               <text macro="issuance-en" prefix="(" suffix=")"/>
@@ -412,7 +412,7 @@
                   <text macro="title-en"/>
                   <group delimiter=" ">
                     <text value="Pub. L. No."/>
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </group>
                   <text macro="section-en"/>
                   <text macro="container-en"/>
@@ -429,7 +429,7 @@
                 </group>
               </else>
             </choose>
-            <text variable="page"/>
+            <number variable="page"/>
             <text macro="locator-en"/>
             <text macro="issuance-en" prefix="(" suffix=")"/>
           </group>
@@ -441,13 +441,13 @@
               <text macro="title-en"/>
               <group delimiter=" ">
                 <text value="No."/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
             <text macro="container-en"/>
             <group delimiter=", ">
-              <text variable="page"/>
+              <number variable="page"/>
               <text variable="locator"/>
             </group>
             <group delimiter=" " prefix="(" suffix=")">
@@ -516,7 +516,7 @@
           </choose>
           <group>
             <text value="nᵒ "/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issuance-fr"/>
           <text macro="locator-or-page-fr"/>
@@ -540,7 +540,7 @@
                   <text macro="title-en"/>
                   <group delimiter=" ">
                     <text value="Pub. L. No."/>
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </group>
                   <text macro="container-en"/>
                 </group>
@@ -551,7 +551,7 @@
                 <text macro="container-en"/>
               </else>
             </choose>
-            <text variable="page"/>
+            <number variable="page"/>
             <text macro="locator-fr"/>
             <text macro="issuance-en" prefix="(" suffix=")"/>
           </group>
@@ -563,13 +563,13 @@
               <text macro="title-en"/>
               <group delimiter=" ">
                 <text value="No."/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
             <text macro="container-en"/>
             <group delimiter=", ">
-              <text variable="page"/>
+              <number variable="page"/>
               <text variable="locator"/>
             </group>
             <group delimiter=" " prefix="(" suffix=")">
@@ -636,7 +636,7 @@
             <text variable="container-title"/>
             <text macro="volume-ja"/>
             <group>
-              <text variable="number"/>
+              <number variable="number"/>
               <text term="issue" form="short"/>
             </group>
             <text macro="locator-or-page-ja"/>
@@ -766,7 +766,7 @@
           <text macro="title-zh"/>
           <choose>
             <if variable="section locator" match="none">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -825,7 +825,7 @@
           <text macro="author-zh"/>
           <group delimiter="，">
             <text macro="title-zh"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
         </group>
       </else-if>
@@ -960,7 +960,7 @@
             </else-if>
             <else-if variable="section locator" match="any">
               <!-- 64.1 《最高人民法院关于适用〈中华人民共和国行政诉讼法〉的解释》(法释 〔2018〕1 号)，第 100 条。 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </else-if>
           </choose>
         </group>
@@ -1007,7 +1007,7 @@
         <label variable="edition" form="short" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1018,7 +1018,7 @@
         <label variable="edition" form="short" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1030,7 +1030,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1084,7 +1084,7 @@
       </else-if>
       <else-if type="legislation">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title"/>
         </group>
       </else-if>
@@ -1097,7 +1097,7 @@
     <choose>
       <if type="article-journal article-magazine" match="any">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title" text-case="title"/>
         </group>
       </if>
@@ -1107,7 +1107,7 @@
           <group delimiter=", ">
             <text macro="editor-en"/>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title" text-case="title"/>
             </group>
           </group>
@@ -1115,7 +1115,7 @@
       </else-if>
       <else-if type="legislation">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title" text-case="title"/>
         </group>
       </else-if>
@@ -1235,7 +1235,7 @@
                 <text value="判决书"/>
               </else>
             </choose>
-            <text variable="number"/>
+            <number variable="number"/>
           </else>
         </choose>
       </else-if>
@@ -1277,7 +1277,7 @@
         <number variable="volume" form="roman" text-case="uppercase"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1302,7 +1302,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1314,7 +1314,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1325,7 +1325,7 @@
         <number variable="issue"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1336,7 +1336,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1355,7 +1355,7 @@
         </choose>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1552,7 +1552,7 @@
             <number variable="page"/>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>
@@ -1604,11 +1604,11 @@
         <choose>
           <if type="article-newspaper">
             <text term="at" suffix=" "/>
-            <text variable="page" form="short"/>
+            <number variable="page" form="short"/>
           </if>
           <else-if type="article-magazine">
             <label variable="page" form="short" suffix=" "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </else-if>
         </choose>
       </else-if>
@@ -1621,10 +1621,10 @@
       </if>
       <else-if is-numeric="page">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -1634,11 +1634,11 @@
         <text macro="locator-ja"/>
       </if>
       <else-if is-numeric="page">
-        <text variable="page-first"/>
+        <number variable="page-first"/>
         <label variable="page" form="short"/>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -1652,11 +1652,11 @@
         <choose>
           <if is-numeric="page">
             <text value="第"/>
-            <text variable="page"/>
+            <number variable="page"/>
             <text value="版"/>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>

--- a/src/浙江大学/浙江大学.csl
+++ b/src/浙江大学/浙江大学.csl
@@ -84,7 +84,7 @@
   </macro>
   <macro name="title">
     <text variable="title" strip-periods="false" font-style="normal" font-variant="normal" prefix=" "/>
-    <text variable="number" prefix=": "/>
+    <number variable="number" prefix=": "/>
     <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-id"/>
       <choose>
@@ -96,7 +96,7 @@
   </macro>
   <macro name="title-zh">
     <text variable="title" font-style="normal"/>
-    <text variable="number" prefix=": "/>
+    <number variable="number" prefix=": "/>
     <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-id"/>
       <choose>
@@ -164,7 +164,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -172,17 +172,17 @@
   </macro>
   <macro name="serial-information">
     <group delimiter=", ">
-      <text variable="volume" prefix=", "/>
+      <number variable="volume" prefix=", "/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="serial-information-zh">
     <group delimiter=", ">
-      <text variable="volume" prefix=", "/>
+      <number variable="volume" prefix=", "/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -194,7 +194,7 @@
           </group>
         </group>
         <date date-parts="year" form="text" variable="issued" prefix=" " suffix=". "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </if>
     </choose>
   </macro>
@@ -208,7 +208,7 @@
           </group>
         </group>
         <date date-parts="year" form="numeric" variable="issued" suffix=". "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </if>
     </choose>
   </macro>

--- a/src/浙江大学（社会科学类）/浙江大学（社会科学类）.csl
+++ b/src/浙江大学（社会科学类）/浙江大学（社会科学类）.csl
@@ -127,7 +127,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -168,7 +168,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -203,11 +203,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -377,7 +377,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -386,11 +386,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -403,7 +403,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码[引用日期]” -->
@@ -412,11 +412,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -431,7 +431,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -439,16 +439,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -476,7 +476,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -532,7 +532,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/海南大学-外国语学院/海南大学-外国语学院.csl
+++ b/src/海南大学-外国语学院/海南大学-外国语学院.csl
@@ -854,7 +854,7 @@
             <group delimiter=". ">
               <group delimiter=" ">
                 <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
+                <number variable="volume"/>
               </group>
               <text variable="volume-title"/>
             </group>
@@ -863,7 +863,7 @@
         <else-if is-numeric="volume" match="none">
           <group delimiter=" ">
             <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </group>
         </else-if>
       </choose>
@@ -890,7 +890,7 @@
                     <label variable="number" form="short" text-case="capitalize-first"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </group>
           </else>
@@ -947,7 +947,7 @@
                     <label variable="number" form="short" text-case="capitalize-first"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </group>
           </else>
@@ -1003,7 +1003,7 @@
             </choose>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </if>
@@ -1606,7 +1606,7 @@
             <text variable="genre" text-case="title"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <choose>
@@ -1661,7 +1661,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1704,11 +1704,11 @@
       </choose>
       <group delimiter=" ">
         <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -1931,12 +1931,12 @@
         <choose>
           <if variable="volume">
             <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
+              <number variable="volume" font-style="italic"/>
+              <number variable="issue" prefix="(" suffix=")"/>
             </group>
           </if>
           <else>
-            <text variable="issue" font-style="italic"/>
+            <number variable="issue" font-style="italic"/>
           </else>
         </choose>
         <choose>
@@ -1944,11 +1944,11 @@
             <!-- Ex. 6: Journal article with article number or eLocator -->
             <group delimiter=" ">
               <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </group>
@@ -2295,7 +2295,7 @@
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
                 <text term="on"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
@@ -2326,7 +2326,7 @@
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
                 <text term="on"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
@@ -2444,12 +2444,12 @@
           <text variable="container-title"/>
           <choose>
             <if variable="page page-first" match="any">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -2460,7 +2460,7 @@
           <choose>
             <if variable="container-title">
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
                 <group delimiter=" ">
                   <label variable="section" form="symbol"/>
@@ -2468,7 +2468,7 @@
                 </group>
                 <choose>
                   <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
+                    <number variable="page-first"/>
                   </if>
                   <else>
                     <text value="___"/>
@@ -2479,7 +2479,7 @@
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -2498,7 +2498,7 @@
                   <label variable="number" form="short" text-case="capitalize-first"/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
@@ -2507,9 +2507,9 @@
             <text variable="chapter-number"/>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </group>
         </group>
       </else-if>
@@ -2525,17 +2525,17 @@
           <if variable="number">
             <!-- There's a public law number. -->
             <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
+              <number variable="number" prefix="Pub. L. No. "/>
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </group>
             </group>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title"/>
               <choose>
                 <if variable="section">
@@ -2545,7 +2545,7 @@
                   </group>
                 </if>
                 <else>
-                  <text variable="page-first"/>
+                  <number variable="page-first"/>
                 </else>
               </choose>
             </group>
@@ -2558,11 +2558,11 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
             <choose>
               <if variable="section">
@@ -2572,7 +2572,7 @@
                 </group>
               </if>
               <else>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </else>
             </choose>
           </group>
@@ -2589,12 +2589,12 @@
           <text variable="original-container-title"/>
           <choose>
             <if variable="page page-first" match="any">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -2605,7 +2605,7 @@
           <choose>
             <if variable="original-container-title">
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="original-container-title"/>
                 <group delimiter=" ">
                   <label variable="section" form="symbol"/>
@@ -2613,7 +2613,7 @@
                 </group>
                 <choose>
                   <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
+                    <number variable="page-first"/>
                   </if>
                   <else>
                     <text value="___"/>
@@ -2624,7 +2624,7 @@
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -2643,7 +2643,7 @@
                   <label variable="number" form="short" text-case="capitalize-first"/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
@@ -2652,9 +2652,9 @@
             <text variable="chapter-number"/>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="original-container-title"/>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </group>
         </group>
       </else-if>
@@ -2670,17 +2670,17 @@
           <if variable="number">
             <!-- There's a public law number. -->
             <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
+              <number variable="number" prefix="Pub. L. No. "/>
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="original-container-title"/>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </group>
             </group>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="original-container-title"/>
               <choose>
                 <if variable="section">
@@ -2690,7 +2690,7 @@
                   </group>
                 </if>
                 <else>
-                  <text variable="page-first"/>
+                  <number variable="page-first"/>
                 </else>
               </choose>
             </group>
@@ -2703,11 +2703,11 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="original-container-title"/>
             <choose>
               <if variable="section">
@@ -2717,7 +2717,7 @@
                 </group>
               </if>
               <else>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </else>
             </choose>
           </group>

--- a/src/海南大学/海南大学.csl
+++ b/src/海南大学/海南大学.csl
@@ -73,7 +73,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -135,7 +135,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -144,10 +144,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -159,7 +159,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -220,7 +220,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <text variable="edition" suffix=". "/>
+            <number variable="edition" suffix=". "/>
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -254,7 +254,7 @@
         <text variable="publisher-place" prefix="[C]. " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -263,7 +263,7 @@
         <text variable="publisher-place" prefix="[C]. " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -271,7 +271,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文报纸 -->
       <else-if type="article-newspaper">
@@ -279,7 +279,7 @@
           <group>
             <text variable="publisher" suffix=". "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>
@@ -340,7 +340,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <text variable="edition" suffix=". "/>
+            <number variable="edition" suffix=". "/>
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -374,7 +374,7 @@
         <text variable="publisher-place" prefix="[C]. " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -383,7 +383,7 @@
         <text variable="publisher-place" prefix="[C]. " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -391,7 +391,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文报纸 -->
       <else-if type="article-newspaper">
@@ -399,7 +399,7 @@
           <group>
             <text variable="publisher" suffix=". "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>

--- a/src/海洋与湖沼/海洋与湖沼.csl
+++ b/src/海洋与湖沼/海洋与湖沼.csl
@@ -129,7 +129,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -171,7 +171,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -206,11 +206,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -345,7 +345,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -353,11 +353,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -372,7 +372,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -380,9 +380,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -407,7 +407,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/深圳大学/深圳大学.csl
+++ b/src/深圳大学/深圳大学.csl
@@ -75,7 +75,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -110,11 +110,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -247,7 +247,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -256,11 +256,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -275,7 +275,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -283,9 +283,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -313,7 +313,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/清华大学（人文社科）/清华大学（人文社科）.csl
+++ b/src/清华大学（人文社科）/清华大学（人文社科）.csl
@@ -226,7 +226,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -246,7 +246,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -264,7 +264,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -402,7 +402,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -524,7 +524,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -543,7 +543,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/清华大学（著者-出版年）/清华大学（著者-出版年）.csl
+++ b/src/清华大学（著者-出版年）/清华大学（著者-出版年）.csl
@@ -120,7 +120,7 @@
                     <text macro="patent-country"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </if>
           </choose>
@@ -156,11 +156,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -299,7 +299,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -307,11 +307,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -326,7 +326,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -334,9 +334,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -361,7 +361,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/清华大学（顺序编码）/清华大学（顺序编码）.csl
+++ b/src/清华大学（顺序编码）/清华大学（顺序编码）.csl
@@ -78,7 +78,7 @@
                     <text macro="patent-country"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </if>
           </choose>
@@ -114,11 +114,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -257,7 +257,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -266,11 +266,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -285,7 +285,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -293,9 +293,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -323,7 +323,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/湖北大学/湖北大学.csl
+++ b/src/湖北大学/湖北大学.csl
@@ -76,7 +76,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -111,11 +111,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -236,7 +236,7 @@
           <text variable="container-title"/>
           <text macro="issued-date-newspaper"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -245,11 +245,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -264,7 +264,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -272,9 +272,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -287,7 +287,7 @@
         <!-- 论文集、会议录不显示出版地和出版者 -->
         <group delimiter=": ">
           <text macro="issued-year"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else>
@@ -308,7 +308,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>

--- a/src/湖南大学（脚注）/湖南大学（脚注）.csl
+++ b/src/湖南大学（脚注）/湖南大学（脚注）.csl
@@ -196,9 +196,9 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -221,9 +221,9 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <text macro="locator"/>
         </group>
@@ -240,7 +240,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -251,7 +251,7 @@
         <group delimiter=", ">
           <group delimiter=". ">
             <text macro="patent-country-en"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -282,7 +282,7 @@
         <group delimiter="，">
           <group delimiter="．">
             <text macro="patent-country-zh"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -371,7 +371,7 @@
         <text variable="locator"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/湖南大学（顺序编码）/湖南大学（顺序编码）.csl
+++ b/src/湖南大学（顺序编码）/湖南大学（顺序编码）.csl
@@ -197,11 +197,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -222,11 +222,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -241,7 +241,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -252,7 +252,7 @@
         <group delimiter=", ">
           <group delimiter=". ">
             <text macro="patent-country-en"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -272,7 +272,7 @@
             </choose>
           </group>
           <text macro="issued-year"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
     </choose>
@@ -283,7 +283,7 @@
         <group delimiter="，">
           <group delimiter="．">
             <text macro="patent-country-zh"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -303,7 +303,7 @@
             </choose>
           </group>
           <text macro="issued-year"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
     </choose>

--- a/src/湖南师范大学/湖南师范大学.csl
+++ b/src/湖南师范大学/湖南师范大学.csl
@@ -78,7 +78,7 @@
       <group delimiter=", ">
         <choose>
           <if type="standard">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
         <group delimiter=": ">
@@ -98,7 +98,7 @@
             </choose>
             <choose>
               <if type="bill legal_case legislation patent regulation report" match="any">
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
           </group>
@@ -124,7 +124,7 @@
     <group delimiter=", ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=": ">
@@ -139,7 +139,7 @@
           <choose>
             <if type="article article-journal standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -174,11 +174,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -348,7 +348,7 @@
           <text variable="container-title" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -357,11 +357,11 @@
             <group delimiter=", ">
               <text variable="container-title" font-style="italic"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -374,7 +374,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -383,11 +383,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -402,7 +402,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -410,9 +410,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -440,7 +440,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/澳門科技大學/澳門科技大學.csl
+++ b/src/澳門科技大學/澳門科技大學.csl
@@ -952,7 +952,7 @@
             <group delimiter=". ">
               <group delimiter=" ">
                 <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
+                <number variable="volume"/>
               </group>
               <text variable="volume-title"/>
             </group>
@@ -961,7 +961,7 @@
         <else-if is-numeric="volume" match="none">
           <group delimiter=" ">
             <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </group>
         </else-if>
       </choose>
@@ -979,11 +979,11 @@
                 <if is-numeric="volume">
                   <group delimiter=" ">
                     <label variable="volume" form="short" text-case="capitalize-first"/>
-                    <text variable="volume"/>
+                    <number variable="volume"/>
                   </group>
                 </if>
                 <else>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                 </else>
               </choose>
               <text variable="volume-title"/>
@@ -991,7 +991,7 @@
           </group>
         </if>
         <else-if is-numeric="volume" match="none">
-          <text variable="volume"/>
+          <number variable="volume"/>
         </else-if>
       </choose>
       <!-- For book-like items，assume part-number and part-title refer to the book/volume. -->
@@ -1017,7 +1017,7 @@
                     <label variable="number" form="short" text-case="capitalize-first"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </group>
           </else>
@@ -1073,7 +1073,7 @@
                     <label variable="number" form="short" text-case="capitalize-first"/>
                   </if>
                 </choose>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </group>
           </else>
@@ -1129,7 +1129,7 @@
             </choose>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </if>
@@ -1206,7 +1206,7 @@
             </choose>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </if>
@@ -2202,7 +2202,7 @@
             <text variable="genre" text-case="title"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </group>
@@ -2217,7 +2217,7 @@
             <text variable="genre" text-case="title"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
         </group>
@@ -2263,7 +2263,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -2306,11 +2306,11 @@
       </choose>
       <group delimiter=" ">
         <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -2353,11 +2353,11 @@
       </choose>
       <group delimiter=" ">
         <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </group>
       <group delimiter=" ">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </group>
     </group>
   </macro>
@@ -2520,12 +2520,12 @@
         <choose>
           <if variable="volume">
             <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
+              <number variable="volume" font-style="italic"/>
+              <number variable="issue" prefix="(" suffix=")"/>
             </group>
           </if>
           <else>
-            <text variable="issue" font-style="italic"/>
+            <number variable="issue" font-style="italic"/>
           </else>
         </choose>
         <choose>
@@ -2533,11 +2533,11 @@
             <!-- Ex. 6: Journal article with article number or eLocator -->
             <group delimiter=" ">
               <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </group>
@@ -2557,17 +2557,17 @@
     <group delimiter="。">
       <group delimiter="，">
         <text variable="container-title" font-weight="bold"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
         <choose>
           <if variable="number">
             <!-- Ex. 6：Journal article with article number or eLocator -->
             <group delimiter=" ">
               <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </group>
@@ -3160,7 +3160,7 @@
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
                 <text term="on"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
@@ -3190,7 +3190,7 @@
               <group delimiter=" ">
                 <!-- APA manual omits the bill number，but it should be included per Bluebook if relevant -->
                 <text term="on"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
@@ -3306,12 +3306,12 @@
           <text variable="container-title"/>
           <choose>
             <if variable="page page-first" match="any">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3322,7 +3322,7 @@
           <choose>
             <if variable="container-title">
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
                 <group delimiter=" ">
                   <label variable="section" form="symbol"/>
@@ -3330,7 +3330,7 @@
                 </group>
                 <choose>
                   <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
+                    <number variable="page-first"/>
                   </if>
                   <else>
                     <text value="___"/>
@@ -3341,7 +3341,7 @@
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3360,7 +3360,7 @@
                   <label variable="number" form="short" text-case="capitalize-first"/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
@@ -3369,9 +3369,9 @@
             <text variable="chapter-number"/>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </group>
         </group>
       </else-if>
@@ -3387,17 +3387,17 @@
           <if variable="number">
             <!-- There's a public law number. -->
             <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
+              <number variable="number" prefix="Pub. L. No. "/>
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </group>
             </group>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title"/>
               <choose>
                 <if variable="section">
@@ -3407,7 +3407,7 @@
                   </group>
                 </if>
                 <else>
-                  <text variable="page-first"/>
+                  <number variable="page-first"/>
                 </else>
               </choose>
             </group>
@@ -3420,11 +3420,11 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
             <choose>
               <if variable="section">
@@ -3434,7 +3434,7 @@
                 </group>
               </if>
               <else>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </else>
             </choose>
           </group>
@@ -3451,12 +3451,12 @@
           <text variable="container-title"/>
           <choose>
             <if variable="page page-first" match="any">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
             </if>
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3467,7 +3467,7 @@
           <choose>
             <if variable="container-title">
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
                 <group delimiter=" ">
                   <label variable="section" form="symbol"/>
@@ -3475,7 +3475,7 @@
                 </group>
                 <choose>
                   <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
+                    <number variable="page-first"/>
                   </if>
                   <else>
                     <text value="___"/>
@@ -3486,7 +3486,7 @@
             <else>
               <group delimiter=" ">
                 <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
             </else>
           </choose>
@@ -3505,7 +3505,7 @@
                   <label variable="number" form="short" text-case="capitalize-first"/>
                 </if>
               </choose>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
@@ -3514,9 +3514,9 @@
             <text variable="chapter-number"/>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </group>
         </group>
       </else-if>
@@ -3532,17 +3532,17 @@
           <if variable="number">
             <!-- There's a public law number. -->
             <group delimiter="，">
-              <text variable="number" prefix="Pub. L. No. "/>
+              <number variable="number" prefix="Pub. L. No. "/>
               <group delimiter=" ">
-                <text variable="volume"/>
+                <number variable="volume"/>
                 <text variable="container-title"/>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </group>
             </group>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title"/>
               <choose>
                 <if variable="section">
@@ -3552,7 +3552,7 @@
                   </group>
                 </if>
                 <else>
-                  <text variable="page-first"/>
+                  <number variable="page-first"/>
                 </else>
               </choose>
             </group>
@@ -3565,11 +3565,11 @@
             <text variable="genre"/>
             <group delimiter=" ">
               <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <number variable="number"/>
             </group>
           </group>
           <group delimiter=" ">
-            <text variable="volume"/>
+            <number variable="volume"/>
             <text variable="container-title"/>
             <choose>
               <if variable="section">
@@ -3579,7 +3579,7 @@
                 </group>
               </if>
               <else>
-                <text variable="page-first"/>
+                <number variable="page-first"/>
               </else>
             </choose>
           </group>

--- a/src/物理学报（双语）/物理学报（双语）.csl
+++ b/src/物理学报（双语）/物理学报（双语）.csl
@@ -134,18 +134,18 @@
           </group>
         </if>
         <else>
-          <text variable="edition"/>
+          <number variable="edition"/>
         </else>
       </choose>
       <choose>
         <if is-numeric="volume">
           <group delimiter=" ">
             <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </group>
         </if>
         <else>
-          <text variable="volume"/>
+          <number variable="volume"/>
         </else>
       </choose>
     </group>
@@ -155,7 +155,7 @@
       <choose>
         <if type="article-journal article-magazine article-newspaper" match="any">
           <text variable="container-title" form="short" text-case="title" font-style="italic"/>
-          <text variable="volume" font-weight="bold"/>
+          <number variable="volume" font-weight="bold"/>
         </if>
         <else-if type="paper-conference">
           <choose>
@@ -196,7 +196,7 @@
               <text variable="original-container-title" text-case="title" font-style="italic"/>
             </else>
           </choose>
-          <text variable="volume" font-weight="bold"/>
+          <number variable="volume" font-weight="bold"/>
         </if>
         <else-if type="paper-conference">
           <choose>
@@ -248,7 +248,7 @@
             </choose>
             <text term="patent" text-case="capitalize-first"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </else-if>
       <else-if type="article article-journal article-magazine article-newspaper" match="none">
@@ -284,7 +284,7 @@
             </choose>
             <text term="patent" text-case="capitalize-first"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </else-if>
       <else-if type="article article-journal article-magazine article-newspaper" match="none">
@@ -300,27 +300,27 @@
       <if type="article-journal article-magazine article-newspaper" match="any">
         <choose>
           <if variable="number">
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
           <else>
-            <text variable="page-first"/>
+            <number variable="page-first"/>
           </else>
         </choose>
       </if>
       <else-if type="broadcast chapter entry entry-dictionary entry-encyclopedia paper-conference" match="any">
         <label variable="page" form="short" plural="never" strip-periods="true"/>
-        <text variable="page-first"/>
+        <number variable="page-first"/>
       </else-if>
       <else>
         <label variable="page" form="short" strip-periods="true"/>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
   <macro name="access">
     <choose>
       <if type="article">
-        <text variable="number"/>
+        <number variable="number"/>
       </if>
       <else-if type="dataset interview manuscript pamphlet personal_communication post post-weblog speech webpage" match="any">
         <group delimiter=" ">

--- a/src/环境昆虫学报/环境昆虫学报.csl
+++ b/src/环境昆虫学报/环境昆虫学报.csl
@@ -131,7 +131,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -172,7 +172,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -207,11 +207,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -362,7 +362,7 @@
           <text variable="container-title" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -371,11 +371,11 @@
             <group delimiter=", ">
               <text variable="container-title" font-style="italic"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -388,7 +388,7 @@
           <text variable="original-container-title" font-style="italic"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -397,11 +397,11 @@
             <group delimiter=", ">
               <text variable="original-container-title" form="short" font-style="italic"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -416,7 +416,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -424,9 +424,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -454,7 +454,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -509,7 +509,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/现代国际关系/现代国际关系.csl
+++ b/src/现代国际关系/现代国际关系.csl
@@ -169,7 +169,7 @@
             <date date-parts="year" form="numeric" variable="issued" suffix=", "/>
             <group>
               <label variable="page" form="short"/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -213,7 +213,7 @@
             </group>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -239,8 +239,8 @@
             <group prefix=" " delimiter=", ">
               <text variable="title" quotes="true"/>
               <text variable="container-title" font-style="italic"/>
-              <text variable="volume" prefix="Vol."/>
-              <text variable="issue" prefix="No."/>
+              <number variable="volume" prefix="Vol."/>
+              <number variable="issue" prefix="No."/>
               <date date-parts="year" form="text" variable="issued"/>
             </group>
             <label variable="locator" form="short" prefix=", "/>
@@ -251,12 +251,12 @@
             <group prefix=" " delimiter=", ">
               <text variable="title" quotes="true"/>
               <text variable="container-title" font-style="italic"/>
-              <text variable="volume" prefix="Vol."/>
-              <text variable="issue" prefix="No."/>
+              <number variable="volume" prefix="Vol."/>
+              <number variable="issue" prefix="No."/>
               <date date-parts="year" form="text" variable="issued"/>
             </group>
             <label variable="page" form="short" prefix=", "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>
@@ -300,7 +300,7 @@
             <date date-parts="year" form="numeric" variable="issued"/>
             <group>
               <label variable="page" form="short" prefix=", "/>
-              <text variable="page"/>
+              <number variable="page"/>
             </group>
           </else>
         </choose>
@@ -324,7 +324,7 @@
             <text variable="publisher-place" prefix="（" suffix="）"/>
             <date date-parts="year" form="text" variable="issued"/>
             <group delimiter="，">
-              <text variable="issue" prefix="第" suffix="期"/>
+              <number variable="issue" prefix="第" suffix="期"/>
               <text macro="locators-zh"/>
               <text variable="locator" prefix="第" suffix="页"/>
             </group>
@@ -340,8 +340,8 @@
             <text variable="publisher-place" prefix="（" suffix="）"/>
             <date date-parts="year" form="text" variable="issued"/>
             <group delimiter="，">
-              <text variable="issue" prefix="第" suffix="期"/>
-              <text variable="page" prefix="第" suffix="页"/>
+              <number variable="issue" prefix="第" suffix="期"/>
+              <number variable="page" prefix="第" suffix="页"/>
             </group>
           </else>
         </choose>
@@ -373,8 +373,8 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text variable="publisher"/>
                   <text macro="date"/>
@@ -391,13 +391,13 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text variable="publisher"/>
                   <text macro="date"/>
                 </group>
-                <text variable="page" prefix="，第" suffix="页"/>
+                <number variable="page" prefix="，第" suffix="页"/>
               </else>
             </choose>
           </if>
@@ -413,8 +413,8 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text variable="publisher"/>
                   <text macro="date"/>
@@ -430,13 +430,13 @@
                   <group>
                     <text variable="container-title" prefix="《" suffix="》"/>
                     <text variable="collection-number" prefix="第" suffix="册"/>
-                    <text variable="edition"/>
-                    <text variable="volume" prefix="第" suffix="卷"/>
+                    <number variable="edition"/>
+                    <number variable="volume" prefix="第" suffix="卷"/>
                   </group>
                   <text variable="publisher"/>
                   <text macro="date"/>
                 </group>
-                <text variable="page" prefix="，第" suffix="页"/>
+                <number variable="page" prefix="，第" suffix="页"/>
               </else>
             </choose>
           </else>
@@ -475,7 +475,7 @@
               <text variable="event"/>
               <date date-parts="year-month-date" form="text" variable="issued"/>
             </group>
-            <text variable="page" prefix="，第" suffix="页"/>
+            <number variable="page" prefix="，第" suffix="页"/>
           </else>
         </choose>
       </else-if>
@@ -505,8 +505,8 @@
               <group>
                 <text variable="title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
               <text variable="publisher"/>
               <text macro="date"/>
@@ -522,8 +522,8 @@
               <group>
                 <text variable="title" prefix="《" suffix="》"/>
                 <text variable="collection-number" prefix="第" suffix="册"/>
-                <text variable="edition"/>
-                <text variable="volume" prefix="第" suffix="卷"/>
+                <number variable="edition"/>
+                <number variable="volume" prefix="第" suffix="卷"/>
               </group>
               <text variable="publisher"/>
               <text macro="date"/>
@@ -540,8 +540,8 @@
         <group delimiter="，" suffix="，">
           <text variable="title" prefix="《" suffix="》"/>
           <text variable="collection-number" prefix="第" suffix="册"/>
-          <text variable="edition"/>
-          <text variable="volume" prefix="第" suffix="卷"/>
+          <number variable="edition"/>
+          <number variable="volume" prefix="第" suffix="卷"/>
         </group>
         <text macro="secondAuthor" prefix="，"/>
         <group delimiter="：" suffix="，">
@@ -642,7 +642,7 @@
           <text variable="title" quotes="true" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else-if position="subsequent" type="chapter" match="all">
@@ -652,7 +652,7 @@
           <text variable="title" quotes="true" suffix=", "/>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </else-if>
         <else>

--- a/src/生态学报/生态学报.csl
+++ b/src/生态学报/生态学报.csl
@@ -73,7 +73,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -104,11 +104,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -169,7 +169,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -178,11 +178,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -197,7 +197,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -205,9 +205,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -235,7 +235,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/生物化学与生物物理进展/生物化学与生物物理进展.csl
+++ b/src/生物化学与生物物理进展/生物化学与生物物理进展.csl
@@ -86,7 +86,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -107,7 +107,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -141,7 +141,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -162,7 +162,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -198,11 +198,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -352,7 +352,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -361,11 +361,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume" font-weight="bold"/>
+              <number variable="volume" font-weight="bold"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -378,7 +378,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -387,11 +387,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume" font-weight="bold"/>
+              <number variable="volume" font-weight="bold"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -406,7 +406,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -414,16 +414,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -451,7 +451,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <choose>
           <if type="dataset post post-weblog software webpage" match="any">
@@ -487,7 +487,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <choose>
           <if type="dataset post post-weblog software webpage" match="any">

--- a/src/生物多样性/生物多样性.csl
+++ b/src/生物多样性/生物多样性.csl
@@ -139,7 +139,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -161,11 +161,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </if>
       <else-if variable="container-title">
@@ -193,11 +193,11 @@
           <group>
             <group delimiter=", ">
               <text variable="original-container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </if>
       <else-if variable="original-container-title">
@@ -257,7 +257,7 @@
         </group>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/电子科技大学/电子科技大学.csl
+++ b/src/电子科技大学/电子科技大学.csl
@@ -53,7 +53,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -137,7 +137,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -146,10 +146,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -161,7 +161,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -230,7 +230,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <text variable="edition" suffix=". "/>
+            <number variable="edition" suffix=". "/>
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -261,7 +261,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -269,7 +269,7 @@
         <text variable="publisher-place" suffix=", "/>
         <!-- <text variable="publisher"/> -->
         <text macro="issued-year"/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -277,7 +277,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文报纸 -->
       <else-if type="article-newspaper">
@@ -285,7 +285,7 @@
           <group>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>
@@ -350,7 +350,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <text variable="edition" suffix=". "/>
+            <number variable="edition" suffix=". "/>
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -381,7 +381,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -389,7 +389,7 @@
         <text variable="publisher-place" suffix=", "/>
         <!-- <text variable="publisher"/> -->
         <text macro="issued-year"/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -397,7 +397,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文报纸 -->
       <else-if type="article-newspaper">
@@ -405,7 +405,7 @@
           <group>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>

--- a/src/皮肤性病诊疗学杂志/皮肤性病诊疗学杂志.csl
+++ b/src/皮肤性病诊疗学杂志/皮肤性病诊疗学杂志.csl
@@ -76,7 +76,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -111,11 +111,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -248,7 +248,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -257,16 +257,16 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
           <choose>
             <if variable="page">
-              <text variable="page"/>
+              <number variable="page"/>
             </if>
             <else-if type="article-journal">
-              <text variable="number"/>
+              <number variable="number"/>
             </else-if>
           </choose>
         </group>
@@ -283,7 +283,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -291,9 +291,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -321,7 +321,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/石河子大学（著者-出版年）/石河子大学（著者-出版年）.csl
+++ b/src/石河子大学（著者-出版年）/石河子大学（著者-出版年）.csl
@@ -122,7 +122,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -143,7 +143,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -177,7 +177,7 @@
         <group>
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -198,7 +198,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -234,11 +234,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -414,7 +414,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -422,11 +422,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -439,7 +439,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，卷（期）：页码[引用日期]” -->
@@ -447,11 +447,11 @@
           <group>
             <group delimiter="，">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -466,7 +466,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -474,16 +474,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -508,7 +508,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -554,7 +554,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/石河子大学（顺序编码制）/石河子大学（顺序编码制）.csl
+++ b/src/石河子大学（顺序编码制）/石河子大学（顺序编码制）.csl
@@ -79,7 +79,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -100,7 +100,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -134,7 +134,7 @@
         <group>
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -155,7 +155,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -191,11 +191,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -371,7 +371,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -380,11 +380,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -397,7 +397,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码[引用日期]” -->
@@ -406,11 +406,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -425,7 +425,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -433,16 +433,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -470,7 +470,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -525,7 +525,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/矿产勘查/矿产勘查.csl
+++ b/src/矿产勘查/矿产勘查.csl
@@ -131,7 +131,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -172,7 +172,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -207,11 +207,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -381,7 +381,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -389,11 +389,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -406,7 +406,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，卷（期）：页码［引用日期］” -->
@@ -414,11 +414,11 @@
           <group>
             <group delimiter="，">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -433,7 +433,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -441,16 +441,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -475,7 +475,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -518,7 +518,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/社会学研究/社会学研究.csl
+++ b/src/社会学研究/社会学研究.csl
@@ -141,11 +141,11 @@
     <choose>
       <if is-numeric="volume">
         <text value="第"/>
-        <text variable="volume"/>
+        <number variable="volume"/>
         <label variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -229,12 +229,12 @@
       <group>
         <choose>
           <if is-numeric="volume">
-            <text variable="volume"/>
+            <number variable="volume"/>
           </if>
         </choose>
         <choose>
           <if is-numeric="issue">
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </if>
         </choose>
       </group>
@@ -245,11 +245,11 @@
     <choose>
       <if is-numeric="issue">
         <text value="第"/>
-        <text variable="issue"/>
+        <number variable="issue"/>
         <label variable="issue"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -257,11 +257,11 @@
     <choose>
       <if is-numeric="edition">
         <text value="第"/>
-        <text variable="edition"/>
+        <number variable="edition"/>
         <label variable="edition"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>

--- a/src/福建农林大学/福建农林大学.csl
+++ b/src/福建农林大学/福建农林大学.csl
@@ -53,7 +53,7 @@
     <text variable="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -137,7 +137,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -146,10 +146,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -161,7 +161,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -230,7 +230,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <!-- <text variable="edition" suffix=". "/> -->
+            <!-- <number variable="edition" suffix=". "/> -->
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -265,7 +265,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -274,7 +274,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -282,7 +282,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文报纸 -->
       <else-if type="article-newspaper">
@@ -290,7 +290,7 @@
           <group>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>
@@ -355,7 +355,7 @@
       <else-if type="book">
         <group prefix=". ">
           <group>
-            <!-- <text variable="edition" suffix=". "/> -->
+            <!-- <number variable="edition" suffix=". "/> -->
             <text variable="publisher-place" suffix=": "/>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-year"/>
@@ -390,7 +390,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文会议集析出的文献 -->
       <else-if type="paper-conference">
@@ -399,7 +399,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 其它文献类型 -->
       <else-if type="bill standard" match="any">
@@ -407,7 +407,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文报纸 -->
       <else-if type="article-newspaper">
@@ -415,7 +415,7 @@
           <group>
             <text variable="publisher" suffix=", "/>
             <text macro="issued-date"/>
-            <text variable="page" prefix="(" suffix=")"/>
+            <number variable="page" prefix="(" suffix=")"/>
           </group>
         </group>
       </else-if>

--- a/src/福建师范大学（本科）/福建师范大学（本科）.csl
+++ b/src/福建师范大学（本科）/福建师范大学（本科）.csl
@@ -89,7 +89,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -131,7 +131,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -166,11 +166,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -356,7 +356,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -365,11 +365,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -382,7 +382,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="（" suffix="）"/>
+        <number variable="page" prefix="（" suffix="）"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码[引用日期]” -->
@@ -391,11 +391,11 @@
             <group delimiter="，">
               <text variable="container-title" form="short"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -410,7 +410,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -418,16 +418,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -455,7 +455,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -511,7 +511,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/科学学与科学技术管理/科学学与科学技术管理.csl
+++ b/src/科学学与科学技术管理/科学学与科学技术管理.csl
@@ -119,7 +119,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -140,7 +140,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -174,7 +174,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="original-title"/>
@@ -189,7 +189,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -215,11 +215,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -377,7 +377,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -385,11 +385,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -402,7 +402,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -410,11 +410,11 @@
           <group>
             <group delimiter=", ">
               <text variable="original-container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -429,7 +429,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -437,9 +437,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -464,7 +464,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -507,7 +507,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/科学学研究/科学学研究.csl
+++ b/src/科学学研究/科学学研究.csl
@@ -78,7 +78,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -109,7 +109,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -144,11 +144,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -299,7 +299,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -308,11 +308,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -325,7 +325,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -334,11 +334,11 @@
             <group delimiter=", ">
               <text variable="original-container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -353,7 +353,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -361,9 +361,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -391,7 +391,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -446,7 +446,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/科学通报（双语）/科学通报（双语）.csl
+++ b/src/科学通报（双语）/科学通报（双语）.csl
@@ -85,7 +85,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -108,7 +108,7 @@
             <choose>
               <if type="article article-journal patent standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -145,7 +145,7 @@
           <group delimiter=" ">
             <choose>
               <if type="standard">
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -168,7 +168,7 @@
               <choose>
                 <if type="article article-journal patent standard" match="none">
                   <!-- 预印本和期刊文章的编号用于其他位置 -->
-                  <text variable="number"/>
+                  <number variable="number"/>
                 </if>
               </choose>
               <choose>
@@ -208,11 +208,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -327,7 +327,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -336,11 +336,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -353,7 +353,7 @@
           <text variable="original-container-title" form="short" strip-periods="true"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -362,11 +362,11 @@
             <group delimiter=", ">
               <text variable="original-container-title" form="short" strip-periods="true"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -381,7 +381,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -389,9 +389,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -403,7 +403,7 @@
             <text macro="patent-country"/>
             <text term="patent" text-case="title"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-date"/>
         </group>
       </if>
@@ -451,7 +451,7 @@
               </group>
               <text macro="issued-year"/>
             </group>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </group>
       </else-if>
@@ -491,7 +491,7 @@
             <text macro="patent-country-ZHtoEN"/>
             <text value="Patent"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-date"/>
         </group>
       </if>
@@ -539,7 +539,7 @@
               </group>
               <text macro="issued-year"/>
             </group>
-            <text variable="page"/>
+            <number variable="page"/>
           </group>
         </group>
       </else-if>

--- a/src/管理世界/管理世界.csl
+++ b/src/管理世界/管理世界.csl
@@ -160,7 +160,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -180,7 +180,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -190,7 +190,7 @@
         <number variable="number" prefix="No."/>
       </if>
       <else>
-        <text variable="number"/>
+        <number variable="number"/>
       </else>
     </choose>
   </macro>

--- a/src/系统工程理论与实践/系统工程理论与实践.csl
+++ b/src/系统工程理论与实践/系统工程理论与实践.csl
@@ -72,7 +72,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -87,7 +87,7 @@
           <choose>
             <if type="article article-journal patent standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -120,7 +120,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="original-title"/>
@@ -129,7 +129,7 @@
           <choose>
             <if type="article article-journal patent standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -154,11 +154,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -314,7 +314,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -323,11 +323,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -340,7 +340,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -349,11 +349,11 @@
             <group delimiter=", ">
               <text variable="original-container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -368,7 +368,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -376,9 +376,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -388,7 +388,7 @@
         <group delimiter=", ">
           <group delimiter=": ">
             <text macro="patent-country"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -412,7 +412,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -449,7 +449,7 @@
         <group delimiter=", ">
           <group delimiter=": ">
             <text macro="patent-country-ZHtoEN"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -473,7 +473,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/经济学（季刊）/经济学（季刊）.csl
+++ b/src/经济学（季刊）/经济学（季刊）.csl
@@ -182,11 +182,11 @@
         <group delimiter=", ">
           <text variable="container-title" text-case="title"/>
           <date variable="issued" form="text" date-parts="year"/>
-          <text variable="volume"/>
+          <number variable="volume"/>
         </group>
-        <text variable="issue" prefix="(" suffix=")"/>
+        <number variable="issue" prefix="(" suffix=")"/>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
   </macro>
   <macro name="container-periodical-zh">
@@ -214,7 +214,7 @@
         <label variable="issue"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -226,7 +226,7 @@
         <label variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -238,7 +238,7 @@
         <label variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/经济研究/经济研究.csl
+++ b/src/经济研究/经济研究.csl
@@ -92,11 +92,11 @@
   </macro>
   <macro name="title">
     <text variable="title" text-case="title" quotes="true"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
   </macro>
   <macro name="title-zh">
     <text variable="title" prefix="《" suffix="》"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
   </macro>
   <macro name="container-contributors">
     <names variable="container-author">
@@ -113,7 +113,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -121,16 +121,16 @@
   </macro>
   <macro name="serial-information">
     <group prefix=", ">
-      <text variable="volume"/>
-      <text variable="issue" prefix="(" suffix=")"/>
+      <number variable="volume"/>
+      <number variable="issue" prefix="(" suffix=")"/>
     </group>
-    <text variable="page" prefix=", "/>
+    <number variable="page" prefix=", "/>
   </macro>
   <macro name="serial-information-zh">
     <!-- <text macro="issued-year" suffix="年"/> -->
-    <!-- <text variable="volume"/> -->
-    <text variable="issue" prefix="第" suffix="期"/>
-    <!-- <text variable="page" prefix=": "/> -->
+    <!-- <number variable="volume"/> -->
+    <number variable="issue" prefix="第" suffix="期"/>
+    <!-- <number variable="page" prefix=": "/> -->
   </macro>
   <macro name="publisher">
     <choose>
@@ -141,7 +141,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -155,7 +155,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-        <!-- <text variable="page" prefix=": "/> -->
+        <!-- <number variable="page" prefix=": "/> -->
         <text macro="issued-year" prefix="，" suffix="年"/>
       </if>
     </choose>
@@ -210,7 +210,7 @@
         <group prefix=", ">
           <text variable="publisher"/>
           <text variable="genre" prefix=" "/>
-          <text variable="number" prefix=", No. "/>
+          <number variable="number" prefix=", No. "/>
         </group>
       </else-if>
       <else-if type="article-journal article-magazine article-newspaper" match="any">

--- a/src/经济社会体制比较/经济社会体制比较.csl
+++ b/src/经济社会体制比较/经济社会体制比较.csl
@@ -84,11 +84,11 @@
   </macro>
   <macro name="title">
     <text variable="title" prefix="“" suffix=".”"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
   </macro>
   <macro name="title-zh">
     <text variable="title" quotes="true"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
   </macro>
   <macro name="container-contributors">
     <names variable="container-author">
@@ -105,7 +105,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -113,18 +113,18 @@
   </macro>
   <macro name="serial-information">
     <group delimiter=", " prefix=". ">
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="serial-information-zh">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <!-- <text variable="volume"/> -->
-      <text variable="issue"/>
+      <!-- <number variable="volume"/> -->
+      <number variable="issue"/>
     </group>
-    <text variable="page" prefix=": "/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -135,7 +135,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/经济管理/经济管理.csl
+++ b/src/经济管理/经济管理.csl
@@ -88,7 +88,7 @@
     <text variable="title" text-case="title"/>
     <choose>
       <if type="bill broadcast legal_case legislation patent report song standard" match="any">
-        <text variable="number" prefix=": "/>
+        <number variable="number" prefix=": "/>
       </if>
     </choose>
     <group delimiter="/" prefix="[" suffix="]">
@@ -147,7 +147,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -156,10 +156,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -171,7 +171,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/综合性期刊文献引证技术规范（注释）/综合性期刊文献引证技术规范（注释）.csl
+++ b/src/综合性期刊文献引证技术规范（注释）/综合性期刊文献引证技术规范（注释）.csl
@@ -224,7 +224,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -244,7 +244,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -262,7 +262,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -400,7 +400,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -522,7 +522,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -541,7 +541,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/综合性期刊文献引证技术规范（著者—出版年）/综合性期刊文献引证技术规范（著者—出版年）.csl
+++ b/src/综合性期刊文献引证技术规范（著者—出版年）/综合性期刊文献引证技术规范（著者—出版年）.csl
@@ -183,7 +183,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -203,7 +203,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -221,7 +221,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -318,7 +318,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -440,7 +440,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -459,7 +459,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/考古/考古.csl
+++ b/src/考古/考古.csl
@@ -137,7 +137,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -157,7 +157,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -167,7 +167,7 @@
         <number variable="number" prefix="No."/>
       </if>
       <else>
-        <text variable="number"/>
+        <number variable="number"/>
       </else>
     </choose>
   </macro>

--- a/src/臺大中文學報/臺大中文學報.csl
+++ b/src/臺大中文學報/臺大中文學報.csl
@@ -166,7 +166,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -178,7 +178,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -259,7 +259,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -332,7 +332,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/色谱/色谱.csl
+++ b/src/色谱/色谱.csl
@@ -82,7 +82,7 @@
               <choose>
                 <if type="article article-journal" match="none">
                   <!-- 预印本和期刊文章的编号用于其他位置 -->
-                  <text variable="number"/>
+                  <number variable="number"/>
                 </if>
               </choose>
               <choose>
@@ -105,11 +105,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -170,7 +170,7 @@
           <text variable="container-title" form="short" strip-periods="true"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -179,11 +179,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -198,7 +198,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -206,9 +206,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -228,7 +228,7 @@
               </choose>
               <text term="patent" text-case="capitalize-first"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -252,7 +252,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/营销科学学报/营销科学学报.csl
+++ b/src/营销科学学报/营销科学学报.csl
@@ -214,7 +214,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -224,27 +224,27 @@
     <group prefix=", ">
       <choose>
         <if variable="volume">
-          <text variable="volume"/>
-          <text variable="issue" prefix="(" suffix=")"/>
+          <number variable="volume"/>
+          <number variable="issue" prefix="(" suffix=")"/>
         </if>
         <else>
-          <text variable="issue"/>
+          <number variable="issue"/>
         </else>
       </choose>
     </group>
-    <text variable="page" prefix=": "/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="serial-information-zh">
     <choose>
       <if variable="volume">
-        <text variable="volume"/>
-        <text variable="issue" prefix="(" suffix=")"/>
+        <number variable="volume"/>
+        <number variable="issue" prefix="(" suffix=")"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
-    <text variable="page" prefix=": "/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -255,7 +255,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -460,7 +460,7 @@
         <group prefix=", ">
           <text variable="publisher"/>
           <text variable="genre" prefix=" "/>
-          <text variable="number" prefix=", No. "/>
+          <number variable="number" prefix=", No. "/>
           <group delimiter=" ">
             <choose>
               <if has-day="issued">

--- a/src/西北农林科技大学/西北农林科技大学.csl
+++ b/src/西北农林科技大学/西北农林科技大学.csl
@@ -152,7 +152,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
         </group>
@@ -179,7 +179,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
         </group>
@@ -206,11 +206,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -410,7 +410,7 @@
         <!-- 报纸的出处项：“刊名, 出版日期(版次): 页码” -->
         <group delimiter=", ">
           <text variable="container-title" form="short" strip-periods="true"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </if>
       <else>
@@ -419,11 +419,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -435,7 +435,7 @@
         <!-- 报纸的出处项：“刊名,出版日期(版次):页码” -->
         <group delimiter=",">
           <text variable="container-title" form="short" strip-periods="true"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </if>
       <else>
@@ -444,11 +444,11 @@
           <group>
             <group delimiter=",">
               <text variable="container-title" form="short" strip-periods="true"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -463,7 +463,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -474,7 +474,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -482,9 +482,9 @@
   <macro name="year-volume-issue">
     <group delimiter=",">
       <text macro="date-bib"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -495,7 +495,7 @@
             <text macro="patent-country-en"/>
             <text macro="patent-type-en"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </if>
       <else-if type="paper-conference">
@@ -538,14 +538,14 @@
             <text macro="patent-country-zh"/>
             <text macro="patent-type-zh"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </if>
       <else-if type="paper-conference">
         <!-- 会议论文集的格式“出版者,页码”（出版者为会议名称） -->
         <group delimiter=",">
           <text variable="publisher"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if type="book chapter periodical thesis" variable="archive archive-place publisher publisher-place page" match="any">
@@ -630,7 +630,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/西北农林科技大学（本科）/西北农林科技大学（本科）.csl
+++ b/src/西北农林科技大学（本科）/西北农林科技大学（本科）.csl
@@ -161,7 +161,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -193,7 +193,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -219,11 +219,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -308,7 +308,7 @@
         <!-- 报纸的出处项：“刊名, 出版日期(版次): 页码[引用日期]” -->
         <group delimiter=", ">
           <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </if>
       <else>
@@ -317,11 +317,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title" strip-periods="true" font-style="italic"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -336,7 +336,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -348,7 +348,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -356,9 +356,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="date"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 翻译类的出版日期 -->
   <macro name="translation-date">
@@ -377,7 +377,7 @@
             <text macro="patent-country-en"/>
             <text macro="patent-type-en"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </if>
       <else-if type="book chapter paper-conference periodical thesis" variable="archive archive-place publisher publisher-place page" match="any">
@@ -396,7 +396,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
     </choose>
@@ -409,7 +409,7 @@
             <text macro="patent-country-zh"/>
             <text macro="patent-type-zh"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
         </group>
       </if>
       <else-if type="book chapter paper-conference periodical thesis" variable="archive archive-place publisher publisher-place page" match="any">
@@ -428,7 +428,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
     </choose>

--- a/src/西北工业大学/西北工业大学.csl
+++ b/src/西北工业大学/西北工业大学.csl
@@ -63,7 +63,7 @@
     <group delimiter=", ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=": ">
@@ -91,11 +91,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -222,7 +222,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -231,11 +231,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -251,7 +251,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -259,9 +259,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -274,7 +274,7 @@
               <text macro="patent-country-en"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -302,7 +302,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -342,7 +342,7 @@
               <text macro="patent-country-zh"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -370,7 +370,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/西南交通大学（著者-出版年）/西南交通大学（著者-出版年）.csl
+++ b/src/西南交通大学（著者-出版年）/西南交通大学（著者-出版年）.csl
@@ -114,7 +114,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -149,11 +149,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -280,7 +280,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -288,11 +288,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -307,7 +307,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -315,9 +315,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -342,7 +342,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/西南交通大学（顺序编码）/西南交通大学（顺序编码）.csl
+++ b/src/西南交通大学（顺序编码）/西南交通大学（顺序编码）.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -238,7 +238,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -247,11 +247,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -266,7 +266,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -274,9 +274,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -304,7 +304,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/西南大学/西南大学.csl
+++ b/src/西南大学/西南大学.csl
@@ -78,7 +78,7 @@
   </macro>
   <macro name="title">
     <text variable="title"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
     <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-id"/>
       <choose>
@@ -140,7 +140,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -149,10 +149,10 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -164,7 +164,7 @@
             <text macro="issued-year"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>

--- a/src/西南政法大学/西南政法大学.csl
+++ b/src/西南政法大学/西南政法大学.csl
@@ -262,7 +262,7 @@
                 <!-- 若同时有期刊卷册数和年份，则将卷册数标注在期刊名称之后，随后再以括号标记年份。 -->
                 <if variable="volume">
                   <text macro="container-de"/>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                   <text macro="issuance-de" prefix="(" suffix=")"/>
                 </if>
                 <else>
@@ -359,12 +359,12 @@
                 </if>
                 <!-- 引用判例集中的判决时，标出判例集的名称、卷号 -->
                 <else>
-                  <text variable="volume"/>
+                  <number variable="volume"/>
                 </else>
               </choose>
             </group>
             <group delimiter=" ">
-              <text variable="page-first"/>
+              <number variable="page-first"/>
               <text variable="locator" prefix="(" suffix=")"/>
             </group>
           </group>
@@ -430,7 +430,7 @@
                   <text macro="title-en"/>
                   <group delimiter=" ">
                     <text value="Pub. L. No."/>
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </group>
                   <text macro="section-en"/>
                   <text macro="container-en"/>
@@ -447,7 +447,7 @@
                 </group>
               </else>
             </choose>
-            <text variable="page"/>
+            <number variable="page"/>
             <text macro="locator-en"/>
             <text macro="issuance-en" prefix="(" suffix=")"/>
           </group>
@@ -459,13 +459,13 @@
               <text macro="title-en"/>
               <group delimiter=" ">
                 <text value="No."/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
             <text macro="container-en"/>
             <group delimiter=", ">
-              <text variable="page"/>
+              <number variable="page"/>
               <text variable="locator"/>
             </group>
             <group delimiter=" " prefix="(" suffix=")">
@@ -534,7 +534,7 @@
           </choose>
           <group>
             <text value="nᵒ "/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issuance-fr"/>
           <text macro="locator-or-page-fr"/>
@@ -558,7 +558,7 @@
                   <text macro="title-en"/>
                   <group delimiter=" ">
                     <text value="Pub. L. No."/>
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </group>
                   <text macro="container-en"/>
                 </group>
@@ -569,7 +569,7 @@
                 <text macro="container-en"/>
               </else>
             </choose>
-            <text variable="page"/>
+            <number variable="page"/>
             <text macro="locator-fr"/>
             <text macro="issuance-en" prefix="(" suffix=")"/>
           </group>
@@ -581,13 +581,13 @@
               <text macro="title-en"/>
               <group delimiter=" ">
                 <text value="No."/>
-                <text variable="number"/>
+                <number variable="number"/>
               </group>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
             <text macro="container-en"/>
             <group delimiter=", ">
-              <text variable="page"/>
+              <number variable="page"/>
               <text variable="locator"/>
             </group>
             <group delimiter=" " prefix="(" suffix=")">
@@ -654,7 +654,7 @@
             <text variable="container-title"/>
             <text macro="volume-ja"/>
             <group>
-              <text variable="number"/>
+              <number variable="number"/>
               <text term="issue" form="short"/>
             </group>
             <text macro="locator-or-page-ja"/>
@@ -753,7 +753,7 @@
                 </else>
               </choose>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
             <group>
               <text macro="issuance-zh"/>
               <text value="发布"/>
@@ -777,7 +777,7 @@
                           <text value="号"/>
                         </if>
                         <else>
-                          <text variable="number"/>
+                          <number variable="number"/>
                         </else>
                       </choose>
                       <text macro="issuance-zh" prefix="（" suffix="）"/>
@@ -802,7 +802,7 @@
                         <text value="判决书"/>
                       </else>
                     </choose>
-                    <text variable="number"/>
+                    <number variable="number"/>
                   </group>
                   <text macro="issuance-zh"/>
                 </group>
@@ -929,7 +929,7 @@
         <label variable="edition" form="short" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -940,7 +940,7 @@
         <label variable="edition" form="short" prefix=" "/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -952,7 +952,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -1006,7 +1006,7 @@
       </else-if>
       <else-if type="legislation">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title"/>
         </group>
       </else-if>
@@ -1021,8 +1021,8 @@
         <group delimiter=", ">
           <text variable="container-title" text-case="title" font-style="italic"/>
           <group>
-            <text variable="volume" prefix="(" suffix=")"/>
-            <text variable="issue"/>
+            <number variable="volume" prefix="(" suffix=")"/>
+            <number variable="issue"/>
           </group>
         </group>
       </if>
@@ -1032,7 +1032,7 @@
           <group delimiter=", ">
             <text macro="editor-en"/>
             <group delimiter=" ">
-              <text variable="volume"/>
+              <number variable="volume"/>
               <text variable="container-title" text-case="title" font-style="italic"/>
             </group>
           </group>
@@ -1040,7 +1040,7 @@
       </else-if>
       <else-if type="legislation">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <number variable="volume"/>
           <text variable="container-title" text-case="title"/>
         </group>
       </else-if>
@@ -1164,7 +1164,7 @@
         <number variable="volume" form="roman" text-case="uppercase"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1189,7 +1189,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1201,7 +1201,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -1212,7 +1212,7 @@
         <number variable="issue"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1223,7 +1223,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1242,7 +1242,7 @@
         </choose>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -1426,7 +1426,7 @@
             <number variable="page"/>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>
@@ -1478,11 +1478,11 @@
         <choose>
           <if type="article-newspaper">
             <text term="at" suffix=" "/>
-            <text variable="page" form="short"/>
+            <number variable="page" form="short"/>
           </if>
           <else-if type="article-magazine">
             <label variable="page" form="short" suffix=" "/>
-            <text variable="page"/>
+            <number variable="page"/>
           </else-if>
         </choose>
       </else-if>
@@ -1495,10 +1495,10 @@
       </if>
       <else-if is-numeric="page">
         <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
+        <number variable="page"/>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -1508,11 +1508,11 @@
         <text macro="locator-ja"/>
       </if>
       <else-if is-numeric="page">
-        <text variable="page-first"/>
+        <number variable="page-first"/>
         <label variable="page" form="short"/>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -1526,11 +1526,11 @@
         <choose>
           <if is-numeric="page">
             <text value="第"/>
-            <text variable="page"/>
+            <number variable="page"/>
             <text value="版"/>
           </if>
           <else>
-            <text variable="page"/>
+            <number variable="page"/>
           </else>
         </choose>
       </else-if>

--- a/src/西南财经大学（本科）/西南财经大学（本科）.csl
+++ b/src/西南财经大学（本科）/西南财经大学（本科）.csl
@@ -159,7 +159,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -179,7 +179,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -189,7 +189,7 @@
         <number variable="number" prefix="No."/>
       </if>
       <else>
-        <text variable="number"/>
+        <number variable="number"/>
       </else>
     </choose>
   </macro>

--- a/src/西安交通大学/西安交通大学.csl
+++ b/src/西安交通大学/西安交通大学.csl
@@ -79,7 +79,7 @@
     <group delimiter=". ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=", ">
@@ -104,7 +104,7 @@
             </if>
             <else-if type="article article-journal standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </else-if>
           </choose>
           <choose>
@@ -129,11 +129,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -260,7 +260,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 普通期刊 -->
@@ -269,11 +269,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" text-case="title" strip-periods="true"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -288,7 +288,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -296,9 +296,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -327,7 +327,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/西安工程大学/西安工程大学.csl
+++ b/src/西安工程大学/西安工程大学.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -238,7 +238,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -247,11 +247,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -266,7 +266,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -274,9 +274,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -304,7 +304,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/西安建筑科技大学/西安建筑科技大学.csl
+++ b/src/西安建筑科技大学/西安建筑科技大学.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -238,7 +238,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -247,11 +247,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -266,7 +266,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -274,9 +274,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -304,7 +304,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/西安理工大学/西安理工大学.csl
+++ b/src/西安理工大学/西安理工大学.csl
@@ -78,7 +78,7 @@
     <group delimiter=", ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=": ">
@@ -93,7 +93,7 @@
           <choose>
             <if type="article article-journal patent standand" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -124,7 +124,7 @@
     <group delimiter="，">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter="：">
@@ -139,7 +139,7 @@
           <choose>
             <if type="article article-journal patent standard" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -174,11 +174,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -342,7 +342,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -351,11 +351,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year-en"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -368,7 +368,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名，年，卷（期）：页码［引用日期］” -->
@@ -377,11 +377,11 @@
             <group delimiter="，">
               <text variable="container-title"/>
               <text macro="issued-year-zh"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="（" suffix="）"/>
+            <number variable="issue" prefix="（" suffix="）"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -396,7 +396,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -404,16 +404,16 @@
   <macro name="year-volume-issue-en">
     <group delimiter=", ">
       <text macro="issued-year-en"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <macro name="year-volume-issue-zh">
     <group delimiter="，">
       <text macro="issued-year-zh"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="（" suffix="）"/>
+    <number variable="issue" prefix="（" suffix="）"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -425,7 +425,7 @@
               <text macro="patent-country-en"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -449,7 +449,7 @@
             </group>
             <text macro="issued-year-en"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-en"/>
       </else-if>
@@ -489,7 +489,7 @@
               <text macro="patent-country-zh"/>
               <text term="patent"/>
             </group>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -513,7 +513,7 @@
             </group>
             <text macro="issued-year-zh"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date-zh"/>
       </else-if>

--- a/src/西安电子科技大学/西安电子科技大学.csl
+++ b/src/西安电子科技大学/西安电子科技大学.csl
@@ -86,7 +86,7 @@
         <group delimiter=" ">
           <choose>
             <if type="standard">
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <text variable="title"/>
@@ -107,7 +107,7 @@
             <choose>
               <if type="article article-journal standard" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -143,11 +143,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -286,7 +286,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -295,11 +295,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -314,7 +314,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -322,9 +322,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -352,7 +352,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/西安电子科技大学（本科）/西安电子科技大学（本科）.csl
+++ b/src/西安电子科技大学（本科）/西安电子科技大学（本科）.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -103,11 +103,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -168,7 +168,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -177,11 +177,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -196,7 +196,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -204,9 +204,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -234,7 +234,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/计算机学报/计算机学报.csl
+++ b/src/计算机学报/计算机学报.csl
@@ -83,7 +83,7 @@
           <choose>
             <if type="article article-journal report" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -128,11 +128,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -193,7 +193,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -202,11 +202,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -221,7 +221,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -229,9 +229,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -245,7 +245,7 @@
           <group delimiter=" ">
             <text variable="publisher"/>
             <text term="preprint"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-year"/>
         </group>
@@ -265,7 +265,7 @@
                 <text term="report"/>
               </else>
             </choose>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-year"/>
         </group>
@@ -289,7 +289,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/财经研究/财经研究.csl
+++ b/src/财经研究/财经研究.csl
@@ -113,7 +113,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -148,11 +148,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -274,7 +274,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -283,11 +283,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -302,7 +302,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -310,9 +310,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -340,7 +340,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/财贸经济/财贸经济.csl
+++ b/src/财贸经济/财贸经济.csl
@@ -211,7 +211,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -223,7 +223,7 @@
         <label variable="volume" form="short"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -243,7 +243,7 @@
         <number variable="page"/>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -253,7 +253,7 @@
         <number variable="number" prefix="No."/>
       </if>
       <else>
-        <text variable="number"/>
+        <number variable="number"/>
       </else>
     </choose>
   </macro>

--- a/src/贵州大学/贵州大学.csl
+++ b/src/贵州大学/贵州大学.csl
@@ -74,11 +74,11 @@
   </macro>
   <macro name="title">
     <text variable="title"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
   </macro>
   <macro name="title-zh">
     <text variable="title"/>
-    <!-- <text variable="number" prefix=": "/> -->
+    <!-- <number variable="number" prefix=": "/> -->
   </macro>
   <macro name="container-contributors">
     <names variable="container-author">
@@ -96,7 +96,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -105,18 +105,18 @@
   <macro name="serial-information">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="serial-information-zh">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+    <number variable="issue" prefix="(" suffix=")"/>
+    <number variable="page" prefix=": "/>
   </macro>
   <macro name="publisher">
     <choose>
@@ -127,7 +127,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -218,7 +218,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文专著 -->
       <else-if type="monograph">
@@ -247,7 +247,7 @@
         <text variable="publisher-place" prefix=". " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 英文专利 -->
       <else-if type="patent">
@@ -258,7 +258,7 @@
       <else-if type="article-newspaper">
         <text variable="publisher" prefix="[N]. " suffix=", "/>
         <text macro="issued-date"/>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </else-if>
       <else>
         <text macro="publisher" prefix=". "/>
@@ -321,7 +321,7 @@
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文专著 -->
       <else-if type="monograph">
@@ -350,7 +350,7 @@
         <text variable="publisher-place" prefix=". " suffix=": "/>
         <text variable="publisher"/>
         <text macro="issued-year" prefix=", "/>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </else-if>
       <!-- 中文专利 -->
       <else-if type="patent">
@@ -361,7 +361,7 @@
       <else-if type="article-newspaper">
         <text variable="publisher" prefix="[N]. " suffix=", "/>
         <text macro="issued-date"/>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </else-if>
       <else>
         <text macro="publisher" prefix=". "/>

--- a/src/遥感学报/遥感学报.csl
+++ b/src/遥感学报/遥感学报.csl
@@ -146,7 +146,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -176,7 +176,7 @@
         <choose>
           <if type="article article-journal" match="none">
             <!-- 预印本和期刊文章的编号用于其他位置 -->
-            <text variable="number"/>
+            <number variable="number"/>
           </if>
         </choose>
         <choose>
@@ -196,11 +196,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -285,7 +285,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -293,11 +293,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -310,7 +310,7 @@
           <text variable="original-container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -318,11 +318,11 @@
           <group>
             <group delimiter=", ">
               <text variable="original-container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -337,7 +337,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -345,9 +345,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -372,7 +372,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -399,7 +399,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>

--- a/src/重庆大学（著者-出版年）/重庆大学（著者-出版年）.csl
+++ b/src/重庆大学（著者-出版年）/重庆大学（著者-出版年）.csl
@@ -120,7 +120,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
             <choose>
@@ -156,11 +156,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -299,7 +299,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 卷(期): 页码[引用日期]” -->
@@ -307,11 +307,11 @@
           <group>
             <group delimiter=", ">
               <text variable="container-title"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -326,7 +326,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -334,9 +334,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -361,7 +361,7 @@
               </else>
             </choose>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/重庆大学（顺序编码）/重庆大学（顺序编码）.csl
+++ b/src/重庆大学（顺序编码）/重庆大学（顺序编码）.csl
@@ -81,7 +81,7 @@
             <choose>
               <if type="article article-journal" match="none">
                 <!-- 预印本和期刊文章的编号用于其他位置 -->
-                <text variable="number"/>
+                <number variable="number"/>
               </if>
             </choose>
           </group>
@@ -117,11 +117,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -266,7 +266,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -275,11 +275,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -294,7 +294,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -302,9 +302,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -332,7 +332,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/重庆邮电大学/重庆邮电大学.csl
+++ b/src/重庆邮电大学/重庆邮电大学.csl
@@ -75,7 +75,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -110,11 +110,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -263,7 +263,7 @@
           </else>
         </choose>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
   </macro>
   <!-- 连续出版物中的出处项 -->
@@ -275,7 +275,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -284,11 +284,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -303,7 +303,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -311,9 +311,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -341,7 +341,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/金融研究/金融研究.csl
+++ b/src/金融研究/金融研究.csl
@@ -109,7 +109,7 @@
     <choose>
       <if variable="edition">
         <group delimiter=" ">
-          <text variable="edition"/>
+          <number variable="edition"/>
           <label variable="edition"/>
         </group>
       </if>
@@ -117,16 +117,16 @@
   </macro>
   <macro name="serial-information">
     <group prefix=", " suffix=": ">
-      <text variable="volume"/>
-      <text variable="issue" prefix="(" suffix=")"/>
+      <number variable="volume"/>
+      <number variable="issue" prefix="(" suffix=")"/>
     </group>
     <text term="page" form="short"/>
-    <text variable="page"/>
+    <number variable="page"/>
   </macro>
   <macro name="serial-information-zh">
     <group delimiter="，">
-      <text variable="issue" prefix="第" suffix="期"/>
-      <text variable="page" prefix="第" suffix="页"/>
+      <number variable="issue" prefix="第" suffix="期"/>
+      <number variable="page" prefix="第" suffix="页"/>
     </group>
   </macro>
   <macro name="publisher">
@@ -138,7 +138,7 @@
             <text variable="publisher"/>
           </group>
         </group>
-        <text variable="page" prefix=": "/>
+        <number variable="page" prefix=": "/>
       </if>
     </choose>
   </macro>
@@ -203,7 +203,7 @@
         <group prefix=", ">
           <text variable="publisher"/>
           <text variable="genre" prefix=" "/>
-          <text variable="number" prefix=", No. "/>
+          <number variable="number" prefix=", No. "/>
         </group>
       </else-if>
       <else-if type="article-journal article-magazine article-newspaper" match="any">

--- a/src/金融评论/金融评论.csl
+++ b/src/金融评论/金融评论.csl
@@ -186,7 +186,7 @@
         <number variable="volume"/>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -206,7 +206,7 @@
         </choose>
       </if>
       <else>
-        <text variable="volume"/>
+        <number variable="volume"/>
       </else>
     </choose>
   </macro>
@@ -224,7 +224,7 @@
         <label variable="edition" form="short"/>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -319,7 +319,7 @@
         <label variable="issue" form="short"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>
@@ -433,10 +433,10 @@
       <if type="article-journal article-magazine article-newspaper" match="any">
         <choose>
           <if variable="page">
-            <text variable="page"/>
+            <number variable="page"/>
           </if>
           <else>
-            <text variable="number"/>
+            <number variable="number"/>
           </else>
         </choose>
       </if>
@@ -445,7 +445,7 @@
         <number variable="page"/>
       </else-if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>
@@ -464,7 +464,7 @@
         </choose>
       </if>
       <else>
-        <text variable="page"/>
+        <number variable="page"/>
       </else>
     </choose>
   </macro>

--- a/src/钢铁研究学报/钢铁研究学报.csl
+++ b/src/钢铁研究学报/钢铁研究学报.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -238,7 +238,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -247,11 +247,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -266,7 +266,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -274,9 +274,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -304,7 +304,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/食品科学/食品科学.csl
+++ b/src/食品科学/食品科学.csl
@@ -75,7 +75,7 @@
           <choose>
             <if type="article article-journal" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -110,11 +110,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -245,7 +245,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -254,11 +254,11 @@
             <group delimiter=", ">
               <text variable="container-title"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -274,7 +274,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -282,9 +282,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -313,7 +313,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
         <text macro="accessed-date"/>
       </else-if>
@@ -354,7 +354,7 @@
           </else-if>
         </choose>
       </group>
-      <text variable="page"/>
+      <number variable="page"/>
     </group>
     <choose>
       <!-- 纯电子资源显示“更新或修改日期” -->

--- a/src/首都医科大学/首都医科大学.csl
+++ b/src/首都医科大学/首都医科大学.csl
@@ -64,7 +64,7 @@
     <group delimiter=". ">
       <choose>
         <if type="standard">
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <group delimiter=": ">
@@ -81,7 +81,7 @@
               <choose>
                 <if type="article article-journal patent standard" match="none">
                   <!-- 预印本和期刊文章的编号用于其他位置 -->
-                  <text variable="number"/>
+                  <number variable="number"/>
                 </if>
               </choose>
               <choose>
@@ -121,11 +121,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -190,7 +190,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -199,11 +199,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" strip-periods="true"/>
               <text macro="issued-year"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -218,7 +218,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -226,9 +226,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -240,7 +240,7 @@
             <text macro="patent-country"/>
             <text term="patent"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
           <text macro="issued-date"/>
         </group>
       </if>
@@ -263,7 +263,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/马克思主义研究/马克思主义研究.csl
+++ b/src/马克思主义研究/马克思主义研究.csl
@@ -66,7 +66,7 @@
         <label variable="volume"/>
       </if>
       <else>
-        <text variable="volume" prefix="（" suffix="）"/>
+        <number variable="volume" prefix="（" suffix="）"/>
       </else>
     </choose>
   </macro>
@@ -98,7 +98,7 @@
         <label variable="issue"/>
       </if>
       <else>
-        <text variable="issue"/>
+        <number variable="issue"/>
       </else>
     </choose>
   </macro>

--- a/src/高分子学报/高分子学报.csl
+++ b/src/高分子学报/高分子学报.csl
@@ -112,7 +112,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -136,7 +136,7 @@
             </choose>
             <text term="patent"/>
           </group>
-          <text variable="number"/>
+          <number variable="number"/>
         </if>
       </choose>
       <choose>
@@ -159,11 +159,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -230,7 +230,7 @@
           <text variable="container-title" form="short" font-style="italic"/>
           <text macro="issued-date" font-weight="bold"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -239,11 +239,11 @@
             <group delimiter=", ">
               <text variable="container-title" form="short" font-style="italic"/>
               <text macro="issued-year" font-weight="bold"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <number variable="issue" prefix="(" suffix=")"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -258,7 +258,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -266,9 +266,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher-en">
@@ -312,7 +312,7 @@
             </group>
             <text macro="issued-year" font-weight="bold"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">
@@ -383,7 +383,7 @@
             </group>
             <text macro="issued-year" font-weight="bold"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">

--- a/src/黑龙江大学（本科）/黑龙江大学（本科）.csl
+++ b/src/黑龙江大学（本科）/黑龙江大学（本科）.csl
@@ -72,7 +72,7 @@
           <choose>
             <if type="article article-journal patent" match="none">
               <!-- 预印本和期刊文章的编号用于其他位置 -->
-              <text variable="number"/>
+              <number variable="number"/>
             </if>
           </choose>
           <choose>
@@ -107,11 +107,11 @@
           <if is-numeric="volume">
             <group delimiter=" ">
               <label variable="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
+              <number variable="volume"/>
             </group>
           </if>
           <else>
-            <text variable="volume"/>
+            <number variable="volume"/>
           </else>
         </choose>
       </if>
@@ -235,7 +235,7 @@
           <text variable="container-title"/>
           <text macro="issued-date"/>
         </group>
-        <text variable="page" prefix="(" suffix=")"/>
+        <number variable="page" prefix="(" suffix=")"/>
       </if>
       <else>
         <!-- 期刊、杂志的出处项：“刊名, 年, 卷(期): 页码[引用日期]” -->
@@ -244,11 +244,11 @@
             <text variable="container-title"/>
             <text macro="issued-year"/>
             <group>
-              <text variable="volume"/>
-              <text variable="issue" prefix="(" suffix=")"/>
+              <number variable="volume"/>
+              <number variable="issue" prefix="(" suffix=")"/>
             </group>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else>
     </choose>
@@ -263,7 +263,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition"/>
+        <number variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -271,9 +271,9 @@
   <macro name="year-volume-issue">
     <group delimiter=", ">
       <text macro="issued-year"/>
-      <text variable="volume"/>
+      <number variable="volume"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
+    <number variable="issue" prefix="(" suffix=")"/>
   </macro>
   <!-- 出版项 -->
   <macro name="publisher">
@@ -283,7 +283,7 @@
         <group delimiter=", ">
           <group delimiter=": ">
             <text macro="patent-country"/>
-            <text variable="number"/>
+            <number variable="number"/>
           </group>
           <text macro="issued-date"/>
         </group>
@@ -307,7 +307,7 @@
             </group>
             <text macro="issued-year"/>
           </group>
-          <text variable="page"/>
+          <number variable="page"/>
         </group>
       </else-if>
       <else-if variable="URL">


### PR DESCRIPTION
## 添加 CSL Schema 

vscode-xml 可以通过添加 XSD、RNG 等文件来实现 [XML 的验证](https://github.com/redhat-developer/vscode-xml/blob/main/docs/Features/RelaxNGFeatures.md)，因此我们可以通过这个功能实现 CSL 的语法验证、悬浮提示、代码补全等。

在 https://github.com/zotero-chinese/csl-m-schema-rng 仓库实现了 CSL Schema 和 CSL-M schema 从 rnc 转为 rng。并在这个仓库添加了文件链接。

### 效果

代码补全：

![image](https://github.com/user-attachments/assets/25916b8c-f614-4f69-a58e-f3ce88f20782)

语法验证：

![image](https://github.com/user-attachments/assets/738cdb6a-8309-48ab-a5a3-32e5fe69f8f0)

### 存在问题

目前已知的问题有：

1. CSL-M 显式规定了 `style.version` 为 `1.1-mlz1`，因此现有的 `1.0` 会报错
2. 由于 CSL-M 是基于 CSL 1.0.1 的，并且它的 schema 在编写的时候，部分变量没有用合并语法（如 `variables.strings`，本应该直接使用 `csl-types.rnc` 中的并进行合并，但它却直接 [全部重新声明了](https://github.com/Juris-M/schema/blob/2feff12d4210abf11c28079090e043d37280ce0c/csl-mlz.rnc#L624-L672)），因此部分新的字段没法识别到，已知的有：`event-title`
3. term 中没能识别到 item-types
4. `<term name="citation-range-delimiter">～</term>` 无法识别，因为这个术语不在 schema 中

这些问题不影响 CSL 保存、预览构建等，只是在编辑器里有一个红色波浪线。

应该可以通过修改 schema 来修复这些问题。我将调查这个问题。


## 修改数字变量的渲染标签

根据 CSL 文档规定，`page`, `page-first`, `issue`, `number` 等数字变量在渲染时应使用 `<number>`（？）

这个是有点奇怪，因为按照文档，数字变量是标准变量的子集，`<text>` 用于标准变量，也就可以用于数字变量， schema 里也是规定 

```rnc
## cs:text Rendering Element
div {
  rendering-element.text =
    
    ## Use to call macros, render variables, terms, or verbatim text.
    element cs:text {
      text.attributes,
      affixes,
      display,
      font-formatting,
      quotes,
      strip-periods,
      text-case
    }
  text.attributes =
    
    ## Select a macro.
    attribute macro { xsd:NMTOKEN }
    | (
       ## Select a term.
       attribute term { terms },
       [ a:defaultValue = "long" ] attribute form { term.form }?,
       
       ## Specify term plurality: singular ("false") or plural ("true").
       [ a:defaultValue = "false" ] attribute plural { xsd:boolean }?)
    | 
      ## Specify verbatim text.
      attribute value { text }
    | (
       ## Select a variable.
       attribute variable { variables.standard },
       [ a:defaultValue = "long" ] attribute form { "short" | "long" }?)
}
```

```rnc
## Variables
div {
  
  ## All variables
  variables = variables.dates | variables.names | variables.standard
  
  ## Standard variables
  variables.standard =
    variables.numbers | variables.strings | variables.titles

}

```

但奇怪的地方在于 `<text veriable="" />` 在验证的时候只能识别到 `variables.strings | variables.titles`，不能识别到 `variables.numbers`

