### PR TITLE
北航参考文献格式中名字缩写不带点

### DIFF
--- a/src/北京航空航天大学/北京航空航天大学.csl
+++ b/src/北京航空航天大学/北京航空航天大学.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=". " page-range-format="expanded" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " page-range-format="expanded" default-locale="en-US">
   <info>
     <title>北京航空航天大学</title>
     <title-short>BUAA</title-short>


### PR DESCRIPTION
[附件1：北京航空航天大学研究生学位论文撰写规范.docx](https://github.com/user-attachments/files/21180761/1.docx)
参考规范第三章中的示例。另外，[GB/7714-2015](https://zh.wikipedia.org/wiki/GB/T_7714#%E8%B4%A3%E4%BB%BB%E8%80%85)中，名字缩写后边也是不带点的。