### PR TITLE
人民出版社学术著作引证注释格式（修正版） 

### DIFF
--- a/src/人民出版社学术著作引证注释格式（修正版）/index.md
+++ b/src/人民出版社学术著作引证注释格式（修正版）/index.md
@@ -1,0 +1,591 @@
+<!-- 此文件由脚本自动生成，请勿手动修改！ -->
+<!-- markdownlint-disable -->
+<!-- prettier-ignore -->
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE FILE -->
+
+## 样式预览
+
+### 引注
+
+<sup>1</sup> [无] 库恩：《科学革命的结构：第 4 版》第2版，金吾伦、胡新和译，北京大学出版社2012年版。<br>
+<sup>2</sup> Xuetong Fan &#38; Christopher H. Sommers, <i>Food Irradiation Research and Technology</i>, Ames, Iowa: Blackwell Publishing, 2013.<br>
+<sup>3</sup> 贾东琴、柯平：《面向数字素养的高校图书馆数字服务体系研究》，中国图书馆学会主编：《中国图书馆学会年会论文集》2011 年卷，国家图书馆出版社2011年版。<br>
+<sup>4</sup> M. E. Fourney, “Advances in Holographic Photoelasticity”, in <i>Symposium on Applications of Holography in Mechanics</i>, New York: ASME, c1971.<br>
+<sup>5</sup> 武丽丽等：《“北斗一号”监控管理网设计与实现》，《测绘科学》第33卷第5期，2008年。<br>
+<sup>6</sup> Alexander A. Myburg et al., “The Genome of Eucalyptus Grandis”, in <i>Nature</i>, Vol. 510 (June 2014), pp.356-362.<br>
+<sup>7</sup> Alexander A. Myburg et al., “The Genome of Eucalyptus Grandis”, in <i>Nature</i>, Vol. 510 (June 2014), pp.356-362.<br>
+<sup>8</sup> Alexander A. Myburg et al., “The Genome of Eucalyptus Grandis”, in <i>Nature</i>, Vol. 510 (June 2014), p.357.<br>
+<sup>9</sup> Xuetong Fan &#38; Christopher H. Sommers, <i>Food Irradiation Research and Technology</i>, Ames, Iowa: Blackwell Publishing, 2013, pp.326-329.<br>
+
+
+### 参考文献表
+
+<div class="csl-bib-body maxoffset-3 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">贾东琴、柯平：《面向数字素养的高校图书馆数字服务体系研究》，中国图书馆学会主编：《中国图书馆学会年会论文集》2011 年卷，国家图书馆出版社2011年版。</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">[无] 库恩：《科学革命的结构：第 4 版》第2版，金吾伦、胡新和译，北京大学出版社2012年版。</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">武丽丽等：《“北斗一号”监控管理网设计与实现》，《测绘科学》第33卷第5期，2008年。</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">Xuetong Fan &#38; Christopher H. Sommers, <i>Food Irradiation Research and Technology</i>, Ames, Iowa: Blackwell Publishing, 2013.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">M. E. Fourney, “Advances in Holographic Photoelasticity”, in <i>Symposium on Applications of Holography in Mechanics</i>, New York: ASME, c1971.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">Alexander A. Myburg et al., “The Genome of Eucalyptus Grandis”, in <i>Nature</i>, Vol. 510, (June 2014).</div>
+  </div>
+</div>
+
+## 默认测试
+
+### 引注
+
+<sup>1</sup> Cass R. Sunstein, “Social Norms and Social Roles”, in <i>Columbia Law Review</i>, Vol. 96 (1996), p.903.<br>
+<sup>2</sup> Ian Morris, <i>Why the West Rules—for Now: The Patterns of History, and What They Reveal about the Future</i>, New York: Farrar, Straus and Giroux, 2010, p.260.<br>
+<sup>3</sup> 应松年、马怀德主编：《当代中国行政法的源流：王名扬教授九十华诞贺寿文集》，中国法制出版社2006年版。<br>
+<sup>4</sup> Ian Morris, <i>Why the West Rules—for Now: The Patterns of History, and What They Reveal about the Future</i>, New York: Farrar, Straus and Giroux, 2010, pp.326-329.<br>
+<sup>5</sup> Ian Morris, <i>Why the West Rules—for Now: The Patterns of History, and What They Reveal about the Future</i>, New York: Farrar, Straus and Giroux, 2010, pp.326-329.<br>
+<sup>6</sup> Ian Morris, <i>Why the West Rules—for Now: The Patterns of History, and What They Reveal about the Future</i>, New York: Farrar, Straus and Giroux, 2010, p.260.<br>
+<sup>7</sup> 应松年、马怀德主编：《当代中国行政法的源流：王名扬教授九十华诞贺寿文集》，中国法制出版社2006年版，第330页。<br>
+<sup>8</sup> 应松年、马怀德主编：《当代中国行政法的源流：王名扬教授九十华诞贺寿文集》，中国法制出版社2006年版，第330页。<br>
+<sup>9</sup> 应松年、马怀德主编：《当代中国行政法的源流：王名扬教授九十华诞贺寿文集》，中国法制出版社2006年版，第331页。<br>
+
+
+### GB/T 7714—2015 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<sup>1</sup> 陈登原：《国史旧闻》第 1 卷，中华书局2000年版。<br>
+<sup>2</sup> [无] 哈里森·沃尔德伦：《经济数学与金融数学》，谢远涛译，中国人民大学出版社2012年版。<br>
+<sup>3</sup> 北京市政协民族和宗教委员会、北京联合大学民族与宗教研究所：《历代王朝与民族宗教》，民族出版社2012年版。<br>
+<sup>4</sup> 全国信息与文献标准化技术委员会：《信息与文献 都柏林核心元数据元素集》，中国标准出版社2010年版。<br>
+<sup>5</sup> 徐光宪、王祥云：《物质结构》，科学出版社2010年版。<br>
+<sup>6</sup> 顾炎武：《昌平山水记：京东考古录》，北京古籍出版社1982年版。<br>
+<sup>7</sup> 王夫之：《宋论》刻本，湘乡曾国荃1865年版。<br>
+<sup>8</sup> 牛志明、斯温兰德、雷光春主编：《综合湿地管理国际研讨会论文集》，海洋出版社2012年版。<br>
+<sup>9</sup> 中国第一历史档案馆、辽宁省档案馆：《中国明朝档案总汇》，2001年。<br>
+<sup>10</sup> 杨保军：《新闻道德论》，中国人民大学出版社2012年版。<br>
+<sup>11</sup> 赵学功：《当代美国外交》，社会科学文献出版社2001年版。<br>
+<sup>12</sup> 同济大学土木工程防灾国家重点实验室：《汶川地震灾害研究》，同济大学出版社2011年版。<br>
+<sup>13</sup> 中国造纸学会：《中国造纸年鉴：2003》，中国轻工业出版社2003年版。<br>
+<sup>14</sup> Peyton Z. Peebles Jr., <i>Probability, Random Variables, and Random Signal Principles</i>, New York: McGraw-Hill, 2001.<br>
+<sup>15</sup> Sergey A. Yufin (ed.), <i>Geoecology and Computers: Proceedings of the Third International Conference on Advances of Computer Methods in Geotechnical and Geoenvironmental Engineering</i>, Rotterdam: A. A. Balkema, 2000.<br>
+<sup>16</sup> Peter Baldock, <i>Developing Early Childhood Services: Past, Present and Future</i>, Rotterdam: Open University Press, 2011.<br>
+<sup>17</sup> Xuetong Fan &#38; Christopher H. Sommers, <i>Food Irradiation Research and Technology</i>, Ames, Iowa: Blackwell Publishing, 2013.<br>
+<sup>18</sup> 王夫之主编：《周易外传：卷 5》，《船山全书》第 6 册，岳麓书社2011年版。<br>
+<sup>19</sup> 程根伟：《1998 年长江洪水的成因与减灾对策》，许厚泽、赵其国主编：《长江流域洪涝灾害与科技对策》，科学出版社1999年版。<br>
+<sup>20</sup> 陈晋镳等：《蓟县震旦亚界的研究》，中国地质科学院天津地质矿产研究所主编：《中国震旦亚界》，天津科学技术出版社1980年版。<br>
+<sup>21</sup> 马克思：《政治经济学批判》，马克思、恩格斯主编：《马克思恩格斯全集》第 35 卷，人民出版社2013年版。<br>
+<sup>22</sup> 贾东琴、柯平：《面向数字素养的高校图书馆数字服务体系研究》，中国图书馆学会主编：《中国图书馆学会年会论文集》2011 年卷，国家图书馆出版社2011年版。<br>
+<sup>23</sup> L. Weinstein &#38; M. N. Swartz, “Pathogenic Properties of Invading Microorganisms”, in Sodeman, William A., Jr. and Sodeman, William A. (eds.), <i>Pathologic Physiology: Mechanisms of Disease</i>, Philadelphia: Saunders, 1974.<br>
+<sup>24</sup> J. Alan Roberson &#38; Eric G. Burneson, “Drinking Water Standards, Regulations, and Goals”, in American Water Works Association (ed.), <i>Water Quality &#38; Treatment: A Handbook on Drinking Water</i>, New York: McGraw-Hill, 2011.<br>
+<sup>25</sup> 中华医学会湖北分会：《临床内科杂志》第1卷，中华医学会湖北分会1984年版。<br>
+<sup>26</sup> 中国图书馆学会：《图书馆学通讯》，北京图书馆1957年版。<br>
+<sup>27</sup> American Association for the Advancement of Science, <i>Science</i>, vol. 1, Washington, D.C.: American Association for the Advancement of Science, 1883.<br>
+<sup>28</sup> 袁训来等：《蓝田生物群：一个认识多细胞生物起源和早期演化的新窗口》，《科学通报》第57卷第34期，2012年。<br>
+<sup>29</sup> 余建斌：《我们的科技一直在追赶：访中国工程院院长周济》，《人民日报》2013年1月12日。<br>
+<sup>30</sup> 李炳穆：《韩国图书馆法》，《图书情报工作》第52卷第6期，2008年。<br>
+<sup>31</sup> 李幼平、王莉：《循证医学研究方法：附视频》，《中华移植杂志（电子版）》第4卷第3期，2010年。<br>
+<sup>32</sup> 武丽丽等：《“北斗一号”监控管理网设计与实现》，《测绘科学》第33卷第5期，2008年。<br>
+<sup>33</sup> H. Kanamori, “Shaking without Quaking”, in <i>Science</i>, Vol. 279, No.5359 (1998), p.2063.<br>
+<sup>34</sup> Priscilla Caplan, “Cataloging Internet Resources”, in <i>The Public-Access Computer Systems Review</i>, Vol. 4, No.2 (1993), pp.61-66.<br>
+<sup>35</sup> Karen S. Frese, Hugo A. Katus, &#38; Benjamin Meder, “Next-Generation Sequencing: From Understanding Biology to Personalized Medicine”, in <i>Biology</i>, Vol. 2, No.1 (2013), pp.378-398.<br>
+<sup>36</sup> Alexander A. Myburg et al., “The Genome of Eucalyptus Grandis”, in <i>Nature</i>, Vol. 510 (June 2014), pp.356-362.<br>
+<sup>37</sup> 邓一刚：《全智能节电器》，2006年版。<br>
+<sup>38</sup> 西安电子科技大学：《光折变自适应光外差探测方法》，2002年版。<br>
+<sup>39</sup> Ryuki Tachibana et al., <i>Electronic Watermarking Method and System</i>, US, 2005.<br>
+<sup>40</sup> 中国互联网络信息中心：《第 29 次中国互联网络发展状况统计报告》，2012年版。<br>
+<sup>41</sup> 北京市人民政府办公厅：《关于转发北京市企业投资项目核准暂行实施办法的通知》，2005年版。<br>
+<sup>42</sup> D. Bawden, Origins and Concepts of Digital Literacy, 2008, <a href="http://www.soi.city.ac.uk/~dbawden/digital%20literacy%20chapter.pdf">http://www.soi.city.ac.uk/~dbawden/digital%20literacy%20chapter.pdf</a>, March 8, 2013.<br>
+<sup>43</sup> Online Computer Library Center, Inc., About OCLC: History of Cooperation, <a href="http://www.oclc.org/about/cooperation.en.html">http://www.oclc.org/about/cooperation.en.html</a>, March 27, 2012.<br>
+<sup>44</sup> A. Hopkinson, UNIMARC and Metadata: Dublin Core, 2009, <a href="http://archive.ifla.org/IV/ifla64/138-161e.htm">http://archive.ifla.org/IV/ifla64/138-161e.htm</a>, March 27, 2013.<br>
+<sup>45</sup> “Coffee Drinking and Cancer of the Pancreas”, in <i>British Medical Journal</i>, Vol. 283, No.6292 (1981), p.628.<br>
+<sup>46</sup> 刘乃安：《生物质材料热解失重动力学及其分析方法研究》，中国科学技术大学2000年版。<br>
+<sup>47</sup> William Deverell &#38; David Igler (eds.), <i>A Companion to California History</i>, New York: John Wiley &#38; Sons, 2013.<br>
+<sup>48</sup> S. K. Baker &#38; M. E. Jackson, <i>The Future of Resource Sharing</i>, New York: The Haworth Press, 1995.<br>
+<sup>49</sup> B. E. Chernik, <i>Introduction to Library Services for Library Technicians</i>, Littleton, Colo.: Libraries Unlimited, Inc., 1982.<br>
+<sup>50</sup> [无] 尼葛洛庞帝：《数字化生存》，胡泳、范海燕译，海南出版社1996年版。<br>
+<sup>51</sup> 汪冰：《电子图书馆理论与实践研究》，北京图书馆出版社1997年版。<br>
+<sup>52</sup> 杨宗英：《电子图书馆的现实模型》，《中国图书馆学报》1996年第2期。<br>
+<sup>53</sup> Lawrence Dowler, “The Research University’s Dilemma: Resource Sharing and Research in a Transinstitutional Environment”, in <i>Journal of Library Administration</i>, Vol. 21, No.1/2 (1995), pp.5-26.<br>
+<sup>54</sup> Cass R. Sunstein, “Social Norms and Social Roles”, in <i>Columbia Law Review</i>, Vol. 96 (1996), p.903.<br>
+<sup>55</sup> Ian Morris, <i>Why the West Rules—for Now: The Patterns of History, and What They Reveal about the Future</i>, New York: Farrar, Straus and Giroux, 2010.<br>
+<sup>56</sup> [无] 罗杰斯：《西方文明史：问题与源头》，潘惠霞、魏婧、杨艳、汤玲译，东北财经大学出版社2011年版。<br>
+<sup>57</sup> 陈登原：《国史旧闻》第 1 卷，中华书局2000年版。<br>
+<sup>58</sup> Diana Crane, <i>Invisible College</i>, Chicago: Univ. of Chicago Press, 1972.<br>
+<sup>59</sup> Margaret F. Stieg, “The Information Needs of Historians”, in <i>College &#38; Research Libraries</i>, Vol. 42, No.6 (1981), pp.549-560.<br>
+<sup>60</sup> 王临惠、支建刚、王忠一：《天津方言的源流关系刍议》，《山西师范大学学报（社会科学版）》第37卷第4期，2010年。<br>
+<sup>61</sup> 王临惠：《从几组声母的演变看天津方言形成的自然条件和历史背景》，曹志耘主编：《汉语方言的地理语言学研究》，商务印书馆2010年版。<br>
+<sup>62</sup> William James Kennedy &#38; Robert E. Garrison, “Morphology and Genesis of Nodular Chalks and Hardgrounds in the Upper Cretaceous of Southern England”, in <i>Sedimentology</i>, Vol. 22 (1975), p.311.<br>
+<sup>63</sup> William James Kennedy &#38; Robert E. Garrison, “Morphology and Genesis of Nodular Phosphates in the Cenomanian Glauconitic Marl of South-East England”, in <i>Lethaia</i>, Vol. 8, No.4 (October 1975), pp.339-360.<br>
+<sup>64</sup> 张忠智：《科技书刊的总编（主编）的角色要求》，中国科学技术期刊编辑学会主编：《中国科学技术期刊编辑学会建会十周年学术研讨会论文汇编》，中国科学技术期刊编辑学会学术委员会1997年版。<br>
+<sup>65</sup> 中国社会科学院语言研究所词典编辑室：《现代汉语词典》修订本，商务印书馆1996年版。<br>
+<sup>66</sup> 刘彻东：《中国的青年刊物：个性特色为本仁》，《中国出版》1998年第5期。<br>
+<sup>67</sup> 裴丽生：《在中国科协学术期刊编辑工作经验交流会上的讲话》，中国科学技术协会主编：《中国科协学术期刊编辑工作经验交流会资料选》，中国科学技术协会学会工作部1981年版。<br>
+<sup>68</sup> 张伯伟：《全唐五代诗格汇考》，江苏古籍出版社2002年版。<br>
+<sup>69</sup> 皮锡瑞：《师伏堂日记》第 4 册，国家图书馆2009年版。<br>
+<sup>70</sup> 胡承正、周详、缪灵：《理论物理概论》上，武汉大学出版社2010年版。<br>
+<sup>71</sup> [无] 美国妇产科医师学会：《新生儿脑病和脑性瘫痪：发病机制与病理生理》，段涛、杨慧霞译，人民卫生出版社2010年版。<br>
+<sup>72</sup> 《康熙字典：巳集上：水部》同文书局影印本，中华书局1962年版。<br>
+<sup>73</sup> 汪昂：《增订本草备要》刻本四卷，老二酉堂1881年版。<br>
+<sup>74</sup> 蒋有绪等：《中国森林群落分类及其群落特征》，科学出版社1998年版。<br>
+<sup>75</sup> 中国企业投资协会、台湾并购与私募股权协会、汇盈国际投资集团：《投资台湾：大陆企业赴台投资指南》，九州出版社2013年版。<br>
+<sup>76</sup> [无] 罗斯基：《战前中国经济的增长》，唐巧天、毛立坤、姜修宪译，浙江大学出版社2009年版。<br>
+<sup>77</sup> [无] 库恩：《科学革命的结构：第 4 版》第2版，金吾伦、胡新和译，北京大学出版社2012年版。<br>
+<sup>78</sup> 侯文顺：《高分子物理：高分子材料分析、选择与改性》，化学工业出版社2010年版。<br>
+<sup>79</sup> Walt Crawford &#38; Michael Gorman, <i>Future Libraries: Dreams, Madness, &#38; Reality</i>, Chicago: American Library Association, 1995.<br>
+<sup>80</sup> International Federation of Library Association and Institutions, <i>Names of Persons: National Usages for Entry in Catalogues</i>, London: IFLA International Office for UBC, 1977.<br>
+<sup>81</sup> J. A. O’Brien, <i>Introduction to Information Systems</i>, Burr Ridge, IL: Irwin, 1994.<br>
+<sup>82</sup> A. Kinchy, <i>Seeds, Sciences, and Struggle: The Global Politics of Transgenic Crops</i>, Cambridge, Mass.: MIT Press, 2012.<br>
+<sup>83</sup> Adrian Praetzellis, <i>Death by Theory: A Tale of Mystery and Archaeological Theory</i>, Rowman &#38; Littlefield Publishing Group, Inc., 2011.<br>
+<sup>84</sup> 中国职工教育研究会主编：《职工教育研究论文集》，人民教育出版社1985年版。<br>
+<sup>85</sup> 中国社会科学院台湾史研究中心主编：《台湾光复六十五周年暨抗战史实学术研讨会论文集》，九州出版社2012年版。<br>
+<sup>86</sup> 雷光春主编：《综合湿地管理：综合湿地管理国际研讨会论文集》，海洋出版社2012年版。<br>
+<sup>87</sup> 陈志勇主编：《中国财税文化价值研究：“中国财税文化国际学术研讨会”论文集》，经济科学出版社2011年版。<br>
+<sup>88</sup> B. V. Babu et al. (eds.), <i>Proceedings of the Second International Conference on Soft Computing for Problem Solving</i>, New Delhi: Springer, 2014.<br>
+<sup>89</sup> 中华人民共和国国务院新闻办公室：《国防白皮书：中国武装力量的多样化运用》，2013年版。<br>
+<sup>90</sup> 汤万金等：《人体安全重要技术标准研制最终报告》，2013年版。<br>
+<sup>91</sup> D. Calkin, A. Ager, &#38; M. Thompson, “A Comparative Risk Assessment Framework for Wildland Fire Management: The 2010 Cohesive Strategy Science Report”, 2011.<br>
+<sup>92</sup> U.S. Department of Transportation Federal Highway Administration, “Guidelines for Handling Excavated Acid-Producing Material”, Springfield: U.S. Department of Commerce National Information Service, 1990.<br>
+<sup>93</sup> World Health Organization, “Factors Regulating the Immune Response: Report of WHO Scientific Group”, Geneva: WHO, 1970.<br>
+<sup>94</sup> 马欢：《人类活动影响下海河流域典型区水循环变化分析》，清华大学2011年版。<br>
+<sup>95</sup> 吴云芳：《面向中文信息处理的现代汉语并列结构研究》，北京大学2003年版。<br>
+<sup>96</sup> Bruce Richard Cairns, “Infrared Spectroscopic Studies on Solid Oxygen”, Doctoral Dissertation, Univ. of California, 1965.<br>
+<sup>97</sup> 张凯军：《轨道火车及高速轨道火车紧急安全制动辅助装置》，2012年版。<br>
+<sup>98</sup> 河北绿洲生态环境科技有限公司：《一种荒漠化地区生态植被综合培育种植方法》，2001年版。<br>
+<sup>99</sup> Akira Koseki et al., <i>Compiler</i>, US, 2002.<br>
+<sup>100</sup> 全国信息与文献标准化技术委员会：《文献著录：第 4 部分 非书资料》，中国标准出版社2010年版。<br>
+<sup>101</sup> 全国广播电视标准化技术委员会：《广播电视音像资料编目规范：第 2 部分 广播资料》，国家广播电影电视总局广播电视规划院2007年版。<br>
+<sup>102</sup> 国家环境保护局科技标准司：《土壤环境质量标准》，中国标准出版社1996年版。<br>
+<sup>103</sup> <i>Information and Documentation—The Dublin Core Metadata Element Set</i>.<br>
+<sup>104</sup> 《卷 39 乞致仕第一》，《苏魏公文集》下册，中华书局1988年版。<br>
+<sup>105</sup> 白书农：《植物开花研究》，李承森主编：《植物科学进展》，高等教育出版社1998年版。<br>
+<sup>106</sup> 汪学军：《中国农业转基因生物研究进展与安全管理》，国家环境保护总局生物安全管理办公室主编：《中国国家生物安全框架实施国际合作项目研讨会论文集》，中国环境科学出版社2002年版。<br>
+<sup>107</sup> 国家标准局信息分类编码研究所：《世界各国和地区名称代码》，中国标准出版社1988年版。<br>
+<sup>108</sup> 《宋史卷三：本纪第三》，《宋史》第 1 册，中华书局1977年版。<br>
+<sup>109</sup> 楼梦鳞、杨燕：《汶川地震基岩地震动特征分析》，同济大学土木工程防灾国家重点实验室主编：《汶川地震震害研究》，同济大学出版社2011年版。<br>
+<sup>110</sup> Peter R. Buseck, Gordon L. Nord Jr., &#38; David R. Veblen, “Subsolidus Phenomena in Pyroxenes”, in <i>Pyroxenes</i>, Washington, D.C.: Mineralogical Society of America, c1980.<br>
+<sup>111</sup> M. E. Fourney, “Advances in Holographic Photoelasticity”, in <i>Symposium on Applications of Holography in Mechanics</i>, New York: ASME, c1971.<br>
+<sup>112</sup> 杨洪升：《四库馆私家抄校书考略》，《文献》2013年第1期。<br>
+<sup>113</sup> 李炳穆：《韩国图书馆法》，《图书情报工作》第52卷第6期，2008年。<br>
+<sup>114</sup> 于潇等：《互联网药品可信交易环境中主体资质审核备案模式》，《清华大学学报（自然科学版）》第52卷第11期，2012年。<br>
+<sup>115</sup> 陈建军：《从数字地球到智慧地球》，《国土资源导刊》第7卷第10期，2010年。<br>
+<sup>116</sup> David J. Des Marais et al., “Carbon Isotope Evidence for the Stepwise Oxidation of the Proterozoic Environment”, in <i>Nature</i>, Vol. 359, No.6396 (October 1992), pp.605-609.<br>
+<sup>117</sup> M. Saito &#38; K. Miyazaki, “Jadeite-Bearing Metagabbro in Serpentinite Mélange of the ‘Kurosegawa Belt’ in Izumi Town, Yatsushiro City, Kumamoto Prefecture, Central Kyushu”, in <i>Bulletin of the Geological Survey of Japan</i>, Vol. 57, No.5/6 (2006), pp.169-176.<br>
+<sup>118</sup> Susan C. Walls, William J. Barichivich, &#38; Mary E. Brown, “Drought, Deluge and Declines: The Impact of Precipitation Extremes on Amphibians in a Changing Climate”, in <i>Biology</i>, Vol. 2, No.1 (2013), pp.399-418.<br>
+<sup>119</sup> Annaliese K. Franz et al., “Phenotypic Screening with Oleaginous Microalgae Reveals Modulators of Lipid Productivity”, in <i>ACS Chemical Biology</i>, Vol. 8 (2013), pp.1053-1062.<br>
+<sup>120</sup> Jung-Ran Park &#38; Yuji Tosaka, “Metadata Quality Control in Digital Repositories and Collections: Criteria, Semantics, and Mechanisms”, in <i>Cataloging &#38; Classification Quarterly</i>, Vol. 48, No.8 (2010), pp.696-715.<br>
+<sup>121</sup> 丁文详：《数字革命与竞争国际化》，《中国青年报》2000年11月20日。<br>
+<sup>122</sup> 张田勘：《罪犯 DNA 库与生命伦理学计划》，《大众科技报》2000年11月12日。<br>
+<sup>123</sup> 傅刚、赵承、李佳路：《大风沙过后的思考》，《北京青年报》2000年1月12日。<br>
+<sup>124</sup> 刘裕国等：《雾霾来袭，如何突围？》，《人民日报》2013年1月12日。<br>
+<sup>125</sup> 萧钰：《出版业信息化迈入快车道》，2001年12月19日，<a href="http://www.creader.com/news/20011219/200112190019.html">http://www.creader.com/news/20011219/200112190019.html</a>，2002年4月15日。<br>
+<sup>126</sup> 李强：《化解医患矛盾需釜底抽薪》，2012年5月3日，<a href="http://wenku.baidu.com/view/47e4f206b52acfc789ebc92f.html">http://wenku.baidu.com/view/47e4f206b52acfc789ebc92f.html</a>，2013年3月25日。<br>
+<sup>127</sup> Commonwealth Libraries Bureau of Library Development. Pennsylvania Department of Education Office, Pennsylvania Library Laws, <a href="http://www.racc.edu/yocum/pdf/PALibraryLaws.pdf">http://www.racc.edu/yocum/pdf/PALibraryLaws.pdf</a>, March 24, 2013.<br>
+<sup>128</sup> Dublin Core Metadata Element Set: Version 1.1, 2012, <a href="http://dublincore.org/documents/dces/">http://dublincore.org/documents/dces/</a>, June 11, 2014.<br>
+
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《心理学报》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<sup>1</sup> 张三：《中国心理学的过去与未来》，《心理学报》第40卷，2008年。<br>
+<sup>2</sup> 张三、李四：《中国心理学的过去与未来》，《心理学报》第40卷，2008年。<br>
+<sup>3</sup> Weimin Mou &#38; Timothy P. McNamara, “Intrinsic Frames of Reference in Spatial Memory”, in <i>Journal of Experimental Psychology: Learning, Memory, and Cognition</i>, Vol. 28 (2002), pp.162-170.<br>
+<sup>4</sup> 赵一等：《中国心理学的过去与未来》，《心理学报》第40卷，2008年。<br>
+<sup>5</sup> Weimin Mou, Kan Zhang, &#38; Timothy P. McNamara, “Frames of Reference in Spatial Memories Acquired from Language”, in <i>Journal of Experimental Psychology: Learning, Memory, and Cognition</i>, Vol. 30 (2004), pp.171-180.<br>
+<sup>6</sup> 赵一一等：《中国心理学的过去与未来》，《心理学报》第40卷，2008年。<br>
+<sup>7</sup> S. A. Wolchik et al., “An Experimental Evaluation of Theory-Based Mother and Mother-Child Programs for Children of Divorce”, in <i>Journal of Consulting and Clinical Psychology</i>, Vol. 68, No.5 (October 2000), pp.843-856.<br>
+<sup>8</sup> 张三、李四：《中国心理学的过去与未来》，《心理学报》出版时间不详。<br>
+<sup>9</sup> Sujata M. Huestegge, Tim Raettig, &#38; Lynn Huestegge, “Are Face-Incongruent Voices Harder to Process? Effects of Face–Voice Gender Incongruency on Basic Cognitive Information Processing”, in <i>Experimental Psychology</i> (2019).<br>
+<sup>10</sup> Dalila Burin et al., “Body Ownership Increases the Interference between Observed and Executed Movements”, in <i>PLOS ONE</i>, Vol. 14, No.1 (2019).<br>
+<sup>11</sup> 张三：《中国心理学的过去与未来》，《心理学报》第40卷增刊，2008年。<br>
+<sup>12</sup> 张三：《心理学史》，未名出版社2008年版。<br>
+<sup>13</sup> 张三主编：《心理学史》，未名出版社2008年版。<br>
+<sup>14</sup> Jewelle Taylor Gibbs &#38; Larke Nahme Huang (eds.), <i>Children of Color: Psychological Interventions with Minority Youth</i>, Hoboken, NJ, US: Jossey-Bass, 1989.<br>
+<sup>15</sup> Pierre-Simon Laplace, <i>A Philosophical Essay on Probabilities</i>, Truscott, F. W. &#38; Emory, F. L. (trans.), Dover, 1951.<br>
+<sup>16</sup> [无] 拉普拉斯, Pierre-Simon：《概率哲学》，张三、李四译，未名出版社1951年版。<br>
+<sup>17</sup> Roberta Klatzky, “Allocentric and Egocentric Spatial Representations: Definitions, Distinctions, and Interconnections”, in Freksa, C., Habel, C., and Wender, K. F. (eds.), <i>Lecture Notes in Artificial Intelligence: Vol. 1404: Spatial Cognition: An Interdisciplinary Approach to Representing and Processing Spatial Knowledge</i>, Springer-Verlag, 1998.<br>
+<sup>18</sup> Deng Feng Wang &#38; Hong Cui, “Theoretical Analysis of the Seven Factor Model of Chinese Personality”, in Wang, Deng Feng and Hou, Yu Bo (eds.), <i>Selected Papers on Personality and Social Psychology</i>, Beijing: Peking University Press, 2004.<br>
+<sup>19</sup> 王登峰、崔红：《中国人“大七”人格结构的理论分析》，王登峰、侯玉波主编：《人格与社会心理学论丛》第1卷，北京大学出版社2004年版。<br>
+<sup>20</sup> John S. Auerbach, “The Origins of Narcissism and Narcissistic Personality Disorder: A Theoretical and Empirical Reformulation”, in Bornstein, M. F. (ed.), <i>Handbook of Child Psychology: Vol. 4. Socialization, Personality, and Social Development</i>, Washington, DC, US: Wiley, 1993.<br>
+<sup>21</sup> Kenneth L. Lichstein &#38; Ronald S. Johnson, “Relaxation Therapy for Polypharmacy Use in Elderly Insomniacs and Noninsomniacs”, in <i>Reducing Medication in Geriatric Populations</i>, Uppsala, Sweden, 1990.<br>
+<sup>22</sup> Cheryl B. Lanktree &#38; John N. Briere, “Early Data on the Trauma Symptom Checklist for Children (TSC-C)”, San Diego, CA, 1991.<br>
+<sup>23</sup> John Ruby &#38; Cain Fulton, “Beyond Redlining: Editing Software That Works”, Washington, DC, 1993.<br>
+<sup>24</sup> Australian Bureau of Statistics, “Estimated Resident Population by Age and Sex in Statistical Local Areas, New South Wales, June 1990”, Canberra, Australian Capital Territory: Author, 1991.<br>
+<sup>25</sup> Terence R. Mitchell &#38; James R. Larson, <i>People in Organizations: An Introduction to Organizational Behavior</i>, New York: McGraw-Hill, 1987.<br>
+<sup>26</sup> P. G. Bergmann, <i>Relativity</i>, vol. 26, New York: Encyclopedia Britannica, 1993.<br>
+<sup>27</sup> Stanley Sadie (ed.), <i>The New Grove Dictionary of Music and Musicians</i>, London : New York: Macmillan, 1980.<br>
+<sup>28</sup> 李行健主编：《现代汉语规范辞典》，外语教学与研究出版社2004年版。<br>
+<sup>29</sup> 《现代汉语频率词典》，北京语言学院出版社1986年版。<br>
+<sup>30</sup> Lin Yu, “Phonological Representation and Processing in Chinese Spoken Language Production”, Unpublished Doctorial Dissertation, Beijing Normal University, 2000.<br>
+<sup>31</sup> 余林：《汉语语言产生中的语音表征与加工》，北京师范大学2000年版。<br>
+<sup>32</sup> 邱颖文：《遗传与语言学习》，华东师范大学2009年版。<br>
+<sup>33</sup> 张三、李四：《中国心理学与奥林匹克》，《新华日报》2008年8月8日。<br>
+
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《中国社会科学》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<sup>1</sup> 赵景深：《文坛忆旧》，北新书局1948年版。<br>
+<sup>2</sup> 谢兴尧整理：《荣庆日记》，西北大学出版社1986年版。<br>
+<sup>3</sup> 蒋大兴：《公司法的展开与评判——方法·判例·制度》，法律出版社2001年版。<br>
+<sup>4</sup> 任继愈主编：《中国哲学发展史（先秦卷）》，人民出版社1983年版。<br>
+<sup>5</sup> [无] 实藤惠秀：《中国人留学日本史》，谭汝谦、林启彦译，香港中文大学出版社1982年版。<br>
+<sup>6</sup> 金冲及主编：《周恩来传》，人民出版社、中央文献出版社1989年版。<br>
+<sup>7</sup> 佚名：《晚清洋务运动事类汇钞五十七种》上册，全国图书馆文献缩微复制中心1998年版。<br>
+<sup>8</sup> 狄葆贤：《平等阁笔记》，有正书局出版时间不详。<br>
+<sup>9</sup> 《马克思恩格斯全集》第31卷，人民出版社1998年版。<br>
+<sup>10</sup> 杜威·佛克马：《走向新世界主义》，王宁、薛晓源主编：《全球化与后殖民批评》，中央编译出版社1999年版。<br>
+<sup>11</sup> 鲁迅：《中国小说的历史的变迁》，《鲁迅全集》第9册，人民文学出版社1981年版。<br>
+<sup>12</sup> 唐振常：《师承与变法》，《识史集》，上海古籍出版社1997年版。<br>
+<sup>13</sup> 李鹏程：《当代文化哲学沉思》，人民出版社1994年版。<br>
+<sup>14</sup> 楼适夷：《读家书，想傅雷（代序）》，傅敏主编：《傅雷家书》增补本，三联书店1998年版。<br>
+<sup>15</sup> 黄仁宇：《为什么称为“中国大历史”？——中文版自序》，《中国大历史》，三联书店1997年版。<br>
+<sup>16</sup> 姚际恒：《古今伪书考》光绪三年苏州文学山房活字本第3卷。<br>
+<sup>17</sup> 毛祥麟：《墨余录》，上海古籍出版社1985年版。<br>
+<sup>18</sup> 杨钟羲：《雪桥诗话续集》影印本第5卷，辽沈书社1991年版。<br>
+<sup>19</sup> 《太平御览》影印本第690卷，中华书局1985年版。<br>
+<sup>20</sup> 管志道：《答屠仪部赤水丈书》，齐鲁书社1997年版。<br>
+<sup>21</sup> 《嘉定县志》第12卷。<br>
+<sup>22</sup> 《上海县续志》第1卷。<br>
+<sup>23</sup> 《广东通志》，中国书店1992年版。<br>
+<sup>24</sup> 《旧唐书》标点本第9卷，中华书局1975年版。<br>
+<sup>25</sup> 《方苞集》标点本第6卷，上海古籍出版社1983年版。<br>
+<sup>26</sup> 《清德宗实录》影印本第435卷，中华书局1987年版。<br>
+<sup>27</sup> 何龄修：《读顾诚〈南明史〉》，《中国史研究》1998年第3期。<br>
+<sup>28</sup> 汪疑今：《江苏的小农及其副业》，《中国经济》第4卷第6期，1936年6月15日。<br>
+<sup>29</sup> 魏丽英：《论近代西北人口波动的若干主要原因》，《社会科学》（兰州）1990年第6期。<br>
+<sup>30</sup> 费成康：《葡萄牙人如何进入澳门问题辨正》，《社会科学》1999年第9期。<br>
+<sup>31</sup> 黄义豪：《评黄龟年四劾秦桧》，《福建论坛》（文史哲版）1997年第3期。<br>
+<sup>32</sup> 倪素香：《德育学科的比较研究与理论探索》，《武汉大学学报》（社会科学版）2002年第4期。<br>
+<sup>33</sup> 李眉：《李劼人轶事》，《四川工人日报》1986年8月22日。<br>
+<sup>34</sup> 伤心人（麦孟华）：《说奴隶》，《清议报》第69册，光绪二十六年十一月二十一日。<br>
+<sup>35</sup> 《四川会议厅暂行章程》，《广益丛报》第8年第19期，1910年9月3日，“新章”。<br>
+<sup>36</sup> 《上海各路商界总联合会致外交部电》，《民国日报》（上海）1925年8月14日。<br>
+<sup>37</sup> 《西南中委反对在宁召开五全会》，《民国日报》（上海）1933年8月11日。<br>
+<sup>38</sup> 方明东：《罗隆基政治思想研究（1913—1949）》，北京师范大学历史系2000年版。<br>
+<sup>39</sup> 任东来：《对国际体制和国际制度的理解和翻译》，全球化与亚太区域化国际研讨会论文，天津，2000年6月。<br>
+<sup>40</sup> 《傅良佐致国务院电》，1917年9月15日，北洋档案 1011—5961，中国第二历史档案馆藏。<br>
+<sup>41</sup> 《党外人士座谈会记录》，1950年7月，李劼人档案，中共四川省委统战部档案室藏。<br>
+<sup>42</sup> 王明亮：《关于中国学术期刊标准化数据库系统工程的进展》，1998年8月16日，<a href="http://www.cajcd.cn/pub/wml.txt/980810-2.html">http://www.cajcd.cn/pub/wml.txt/980810-2.html</a>，1998年10月4日。<br>
+<sup>43</sup> 扬之水：《两宋茶诗与茶事》，《文学遗产通讯》（网络版试刊）2006年第1期，<a href="http://www.literature.org.cn/Article.asp?ID=199">http://www.literature.org.cn/Article.asp?ID=199</a>，2007年9月13日。<br>
+<sup>44</sup> Peter Brooks, <i>Troubling Confessions: Speaking Guilt in Law and Literature</i>, Chicago: University of Chicago Press, 2000.<br>
+<sup>45</sup> Marco Polo, <i>The Travels of Marco Polo</i>, Marsden, William (trans.), Hertfordshire: Cumberland House, 1997.<br>
+<sup>46</sup> Heath B. Chamberlain, “On the Search for Civil Society in China”, in <i>Modern China</i>, Vol. 19, No.2 (April 1993), pp.199-215.<br>
+<sup>47</sup> R. S. Schfield, “The Impact of Scarcity and Plenty on Population Change in England”, in Rotberg, R. I. and Rabb, T. K. (eds.), <i>Hunger and History: The Impact of Changing Food Production and Consumption Pattern on Society</i>, Cambridge, Mass.: Cambridge University Press, 1983.<br>
+<sup>48</sup> Nixon to Kissinger, February 1, 1969, Box 1032, NSC Files, Nixon Presidential Material Project (NPMP), National Archives II, College Park, MD.<br>
+
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《法学引注手册》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<sup>1</sup> 王名扬：《美国行政法》，北京大学出版社2007年版。<br>
+<sup>2</sup> 张新宝：《侵权责任法》第4版，中国人民大学出版社2016年版。<br>
+<sup>3</sup> 高鸿钧、程汉大主编：《英美法原论》，北京大学出版社2013年版。<br>
+<sup>4</sup> [无] [美]富勒：《法律的道德性》，郑戈译，商务印书馆2005年版。<br>
+<sup>5</sup> 季卫东：《法律程序的意义：对中国法制建设的另一种思考》，《中国社会科学》1993年第1期。<br>
+<sup>6</sup> 王保树：《股份有限公司机关构造中的董事和董事会》，梁慧星主编：《民商法论丛》第1卷，法律出版社1994年版。<br>
+<sup>7</sup> [无] [德]莱纳·沃尔夫：《风险法的风险》，陈霄译，刘刚主编：《风险规制：德国的理论与实践》，法律出版社2012年版。<br>
+<sup>8</sup> 何海波：《判决书上网》，《法制日报》2000年5月21日。<br>
+<sup>9</sup> 汪波：《哈尔滨市政法机关正对“宝马案”认真调查复查》，人民网，2004年1月10日，<a href="http://www.people.com.cn/GB/shehui/1062/2289764.html">http://www.people.com.cn/GB/shehui/1062/2289764.html</a>，2022年5月3日。<br>
+<sup>10</sup> 《被告人李宁、张磊贪污案一审开庭》，新华网，<a href="http://www.xinhuanet.com/legal/2019-12/31/c_1125406056.htm">http://www.xinhuanet.com/legal/2019-12/31/c_1125406056.htm</a>。<br>
+<sup>11</sup> 赵耀彤：《一名基层法官眼里好律师的样子》，中国法律评论，2018年12月1日，<a href="http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm">http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm</a>，2022年5月3日。<br>
+<sup>12</sup> 《法国行政法院网站》，<a href="http://english.conseil-etat.fr/Judging">http://english.conseil-etat.fr/Judging</a>，2016年12月18日。<br>
+<sup>13</sup> 李松锋：《游走在上帝与凯撒之间：美国宪法第一修正案中的政教关系研究》，中国政法大学2015年版。<br>
+<sup>14</sup> 《民法总则》，出版时间不详。<br>
+<sup>15</sup> 国务院：《国务院关于在全国建立农村最低生活保障制度的通知》，2007年版。<br>
+<sup>16</sup> 《包郑照诉苍南县人民政府强制拆除房屋案》，出版时间不详。<br>
+<sup>17</sup> 《陆红霞诉南通市发改委政府信息公开案》，2015年版。<br>
+<sup>18</sup> Charles A. Reich, “The New Property”, in <i>Yale Law Journal</i>, Vol. 73, No.5 (1964), pp.733-787.<br>
+<sup>19</sup> Louis D. Brandeis, “What Publicity Can Do”, in <i>Harper’s Weekly</i> (December 1913), p.10.<br>
+<sup>20</sup> William Alford, <i>To Steal a Book Is an Elegant Offense: Intellectual Property Law in Chinese Civilization</i>, Stanford University Press, 1995.<br>
+<sup>21</sup> 应松年、马怀德主编：《当代中国行政法的源流：王名扬教授九十华诞贺寿文集》，中国法制出版社2006年版。<br>
+<sup>22</sup> <i>R. v. Panel on Take-Overs and Mergers</i>, vol. 815, 1987.<br>
+<sup>23</sup> 罗豪才、袁曙宏、李文栋：《现代行政法的理论基础——论行政机关与相对一方的权利义务平衡》，《中国法学》1993年第1期。<br>
+<sup>24</sup> 夏新华等：《近代中国宪政历程》，中国政法大学出版社2004年版。<br>
+<sup>25</sup> 邓小平：《精简机构是一场革命》，《邓小平文选》第2版第2卷，人民出版社1994年版。<br>
+<sup>26</sup> [无] [英]劳特派特：《奥本海国际法》第8版上卷第一分册，王铁崖、陈体强译，商务印书馆1971年版。<br>
+<sup>27</sup> 瞿同祖：《中国法律与中国社会》，商务印书馆2010年版。<br>
+<sup>28</sup> 崔国斌：《知识产权法官造法批判》，《中国法学》2006年第1期。<br>
+<sup>29</sup> 全国人大常委会：《中华人民共和国刑法修正案（十）》，2017年版。<br>
+<sup>30</sup> 全国人大常委会：《中华人民共和国公司法》2005年修订，2005年版。<br>
+<sup>31</sup> 全国人大常委会：《中华人民共和国公司法》2013年修正，2013年版。<br>
+<sup>32</sup> 最高人民法院、最高人民检察院：《最高人民法院、最高人民检察院关于依法严惩破坏计划生育犯罪活动的通知》，1993年版。<br>
+<sup>33</sup> 全国人大常委会：《全国人民代表大会常务委员会关于严禁卖淫嫖娼的决定》，1991年版。<br>
+<sup>34</sup> 国务院：《国务院关于在全国建立农村最低生活保障制度的通知》，2007年版。<br>
+<sup>35</sup> 最高人民法院：《最高人民法院关于适用〈中华人民共和国行政诉讼法〉的解释》，2018年版。<br>
+<sup>36</sup> 国务院：《国务院关于印发打赢蓝天保卫战三年行动计划的通知》，2018年版。<br>
+<sup>37</sup> 国家质量监督检验检疫总局、中国国家标准化管理委员会：《信息与文献 参考文献著录规则》，2015年版。<br>
+<sup>38</sup> 信春鹰：《关于《中华人民共和国行政诉讼法修正案（草案）》的说明》，2013年版。<br>
+<sup>39</sup> 中国共产党中央委员会：《中共中央关于全面推进依法治国若干重大问题的决定》，2014年版。<br>
+<sup>40</sup> 《荣宝英诉王阳、永诚财产保险股份有限公司江阴支公司机动车交通事故责任纠纷案》，2013年版。<br>
+<sup>41</sup> 《榆林市凯奇莱能源投资有限公司诉陕西省地质矿产勘查开发局西安地质矿产勘查开发院合作勘查合同纠纷上诉案》，2017年版。<br>
+<sup>42</sup> Barbara Ward, “Progress for a Small Planet”, in <i>Harvard Business Review</i>, No.Sep.-Oct. (1979), p.89.<br>
+<sup>43</sup> Andrew Rosenthal, “White House Tutors Kremlin in How a Presidency Works”, in <i>New York Times</i> (June 1990), p.A1.<br>
+<sup>44</sup> Jürgen Habermas, <i>Between Facts and Norms: Contributions to a Discourse Theory of Law and Democracy</i>, Rehg, William (trans.), MIT Press, 1996.<br>
+<sup>45</sup> Jamie Horsley, “Rule of Law in China: Incremental Progress”, in Bergsten, C. Fred, Gill, Bates, Lardy, Nicholas R., and Mitchell, Derek (eds.), <i>China: The Balance Sheet</i>, Public Affairs Press, 2006.<br>
+<sup>46</sup> <i>Department of Transportation Act</i>, vol. 80, 1966.<br>
+<sup>47</sup> <i>Administrative Procedure Act § 6</i>, vol. 5, 2006.<br>
+<sup>48</sup> <i>Natural Resources Defense Council <span style="font-style:normal;">v.</span> Gorsuch</i>, vol. 685, 1982.<br>
+<sup>49</sup> <i>Chevron U.S.A., Inc. <span style="font-style:normal;">v.</span> Natural Resources Defense Council</i>, vol. 467, 1984.<br>
+<sup>50</sup> <i>Roe <span style="font-style:normal;">v.</span> Wade</i>, vol. 410, 1973.<br>
+<sup>51</sup> <i>United States <span style="font-style:normal;">v.</span> Dino Nastasi et Al.</i><br>
+<sup>52</sup> Stephen McDonell, When China Began Streaming Trials Online, BBC News, 2016, <a href="https://www.bbc.com/news/blogs-china-blog-37515399">https://www.bbc.com/news/blogs-china-blog-37515399</a>, July 26, 2022.<br>
+<sup>53</sup> Marc Chevallier, <i>L’État de droit</i>, Paris: Montchrestien, 2003.<br>
+<sup>54</sup> Marc Poisson, “Le droit de la mer”, in <i>RGDIP</i> (2015), pp.15-47.<br>
+<sup>55</sup> Claire Badiou-Monferran, “La promotion esthétique du pathétique dans la seconde moitié du XVIIe siècle”, in <i>La Licorne</i>, No.43 (1997), pp.75-94.<br>
+<sup>56</sup> Marc Poisson, “Le droit de la mer”, in <i>Le droit des Océans</i>, 2015.<br>
+<sup>57</sup> Marc Poisson, “Le droit de la mer en Méditerranée”, Congrès de Marseille, 2016.<br>
+<sup>58</sup> Marc Poisson, “Le droit de la mer en Méditerranée”, 2016.<br>
+<sup>59</sup> Marc Poisson, “Le droit de la mer appliqué à la Méditerranée”, Thèse de doctorat, l’Université de Marseille, 2016.<br>
+<sup>60</sup> Béatrice Joyeux-Prunel, L’histoire de l’art et le quantitatif, Histoire &#38; mesure, vol. XXIII, n° 2, 2008, <a href="http://histoiremesure.revues.org/index3543.html">http://histoiremesure.revues.org/index3543.html</a>, March 17, 2010.<br>
+<sup>61</sup> Benjamin Vogel, “Rechtsgüterschutz und Normgeltung”, in <i>Zeitschrift für die gesamte Strafrechtswissenschaft</i>, Vol. 129, No.3 (December 2017), pp.629-649.<br>
+<sup>62</sup> Markus Würdinger, “Über Radarwarngeräte und die Zukunft des Europäischen Privatrechts”, in <i>Juristische Schulung</i>, No.3 (2012), pp.234-240.<br>
+<sup>63</sup> Thomas Fischer, “Absurdes Spektakel um den Tod”, in <i>Die Zeit</i> (September 2015).<br>
+<sup>64</sup> Claus Roxin, <i>Strafrecht Allgemeiner Teil</i>, vol. 1, C. H. Beck, 2006.<br>
+<sup>65</sup> Ralf Dreier &#38; Stanley Paulson (eds.), <i>Rechtsphilosophie Studienausgabe</i>, Heidelberg: UTB Uni-Taschenbücher Verlag, 2003.<br>
+<sup>66</sup> Martin Schwab, in <i>Münchener Kommentar BGB</i>, 2013.<br>
+<sup>67</sup> Arthur Kaufmann, “Bemerkungen zur Reform des § 218 StGB aus rechtsphilosophischer Sicht”, in Baumann, Jürgen (ed.), <i>Das Abtreibungsverbot des § 218 StGB</i>, 1972.<br>
+<sup>68</sup> Claus-Wilhelm Canaris, “Gesamtunwirksamkeit und Teilgültigkeit rechtsgeschäftlicher Regelungen”, 1990.<br>
+<sup>69</sup> <i>StGB</i>.<br>
+<sup>70</sup> <i>StPO</i>.<br>
+<sup>71</sup> <i>GG</i>.<br>
+<sup>72</sup> <i>Strauß-Karikatur, Kunstfreiheit</i>, vol. 75.<br>
+<sup>73</sup> 1999.<br>
+<sup>74</sup> 2000.<br>
+<sup>75</sup> Martin Meidenbauer, Wissenschaftliches Publizieren, <a href="https://www.clio-online.de/sites/files/clio/portal-archiv/site/lang_de/40208143/Default-2.html">https://www.clio-online.de/sites/files/clio/portal-archiv/site/lang_de/40208143/Default-2.html</a>, October 10, 2017.<br>
+<sup>76</sup> 我妻栄, 新訂担保物権法, 有斐閣, 1971.<br>
+<sup>77</sup> 我妻栄 &#38; 有泉亨, 民法総則物権法, 日本評論社, 1950.<br>
+<sup>78</sup> 於保不二雄, “付加物及び従物と抵当権”, in 民商法雑誌, Vol. 29, No.5 (1954), p.1.<br>
+<sup>79</sup> 佐藤英明, “一時所得の要件に関する覚書”, in 金子宏, 中里実, and J.マーク・ラムザイヤー (eds.), 租税法と市場, 有斐閣, 2014.<br>
+<sup>80</sup> 信玄公旗掛松事件, vol. 25, 1919.<br>
+<sup>81</sup> 約束手形金, 36卷6号, 1982.<br>
+<sup>82</sup> 動産及び債権の譲渡の対抗要件に関する民法の特例に関する法律.<br>
+<sup>83</sup> <i>平成26年版犯罪白書</i>.<br>
+<sup>84</sup> ジュリスト, <a href="http://www.yuhikaku.co.jp/jurist">http://www.yuhikaku.co.jp/jurist</a>, September 1, 2022.<br>
+<sup>85</sup> [无] 欧中坦：《千方百计上京城：清朝的京控》，谢鹏程译，高道蕴、高鸿钧、贺卫方主编：《美国学者论中国法律传统》，中国政法大学出版社1994年版。<br>
+<sup>86</sup> 《温家宝主持国务院会议 研究房地产业健康发展措施》，新华网，<a href="http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm">http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm</a>。<br>
+
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### APA 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<sup>1</sup> Stewart M. McCauley &#38; Morten H. Christiansen, “Language Learning as Language Use: A Cross-Linguistic Model of Child Language Development”, in <i>Psychological Review</i>, Vol. 126, No.1 (2019), pp.1-51.<br>
+<sup>2</sup> E. Ahmann et al., “A Descriptive Review of ADHD Coaching Research: Implications for College Students”, in <i>Journal of Postsecondary Education and Disability</i>, Vol. 31, No.1 (2018), pp.17-39.<br>
+<sup>3</sup> M. Anderson, “Getting Consistent with Consequences”, in <i>Educational Leadership</i>, Vol. 76, No.1 (2018), pp.26-33.<br>
+<sup>4</sup> C. Goldman, “The Complicated Calibration of Love, Especially in Adoption”, in <i>Chicago Tribune</i> (November 2018).<br>
+<sup>5</sup> E. Kalnay et al., “The NCEP/NCAR 40-Year Reanalysis Project”, in <i>Bulletin of the American Meteorological Society</i>, Vol. 77, No.3 (January 1996), pp.437-471.<br>
+<sup>6</sup> R. De Vries et al., “What Does It Take to Have a Strong and Independent Profession of Midwifery? Lessons from the Netherlands”, in <i>Midwifery</i>, Vol. 29, No.10 (2013), pp.1122-1128.<br>
+<sup>7</sup> D. Burin et al., “Body Ownership Increases the Interference between Observed and Executed Movements”, in <i>PLOS ONE</i>, Vol. 14, No.1 (2019).<br>
+<sup>8</sup> Sujata M. Huestegge, Tim Raettig, &#38; Lynn Huestegge, “Are Face-Incongruent Voices Harder to Process? Effects of Face–Voice Gender Incongruency on Basic Cognitive Information Processing”, in <i>Experimental Psychology</i> (2019).<br>
+<sup>9</sup> T. Pachur &#38; B. Scheibehenne, “Unpacking Buyer-Seller Differences in Valuation from Experience: A Cognitive Modeling Approach”, in <i>Psychonomic Bulletin &#38; Review</i>.<br>
+<sup>10</sup> V. Chaves-Morillo et al., “Sensorineural Anosmia: Relationship between Subtype, Recognition Time, and Age”, in <i>Clínica y Salud</i>, Vol. 28, No.3 (2018), pp.155-161.<br>
+<sup>11</sup> J. Piaget, “Intellectual Evolution from Adolescence to Adulthood”, Bliss, J. &#38; Furth, H. (trans.), in <i>Human Development</i>, Vol. 15, No.1 (1972), pp.1-12.<br>
+<sup>12</sup> M. F. Shore, “Marking Time in the Land of Plenty: Reflections on Mental Health in the United States”, in <i>American Journal of Orthopsychiatry</i>, Vol. 84, No.6 (2014), pp.611-618.<br>
+<sup>13</sup> “Marking Time in the Land of Plenty: Reflections on Mental Health in the United States”, in <i>American Journal of Orthopsychiatry</i>, Vol. 51, No.3 (1981), pp.391-402.<br>
+<sup>14</sup> S. O. Lilienfeld (ed.), <i>Archives of Scientific Psychology</i>, vol. 6, 2018.<br>
+<sup>15</sup> S. H. McDaniel, E. Salas, &#38; A. E. Kazak (eds.), <i>American Psychologist</i>, vol. 73, 2018.<br>
+<sup>16</sup> J. Mehrholz et al., “Electromechanical and Robot-Assisted Arm Training for Improving Activities of Daily Living, Arm Function, and Arm Muscle Strength after Stroke”, in <i>Cochrane Database of Systematic Reviews</i> (2018).<br>
+<sup>17</sup> M. C. Morey, “Physical Activity and Exercise in Older Adults”, in <i>UpToDate</i> (2019).<br>
+<sup>18</sup> S. Bergeson, “Really Cool Neutral Plasmas”, in <i>Science</i>, Vol. 363, No.6422 (January 2019), pp.33-34.<br>
+<sup>19</sup> M. Bustillos, “On Video Games and Storytelling: An Interview with Tom Bissell”, in <i>The New Yorker</i> (March 2013).<br>
+<sup>20</sup> K. Weir, “Forgiveness Can Improve Mental and Physical Health”, in <i>Monitor on Psychology</i>, Vol. 48, No.1 (January 2017), p.30.<br>
+<sup>21</sup> B. Guarino, “How Will Humanity React to Alien Life? Psychologists Have Some Predictions”, in <i>The Washington Post</i> (December 2017).<br>
+<sup>22</sup> A. Hess, “Cats Who Take Direction”, in <i>The New York Times</i> (January 2019), p.C1.<br>
+<sup>23</sup> M. Klymkowsky, Can We Talk Scientifically about Free Will?, Sci-Ed, 2018, <a href="https://blogs.plos.org/scied/2018/09/15/can-we-talk-scientifically-about-free-will/">https://blogs.plos.org/scied/2018/09/15/can-we-talk-scientifically-about-free-will/</a>.<br>
+<sup>24</sup> KS in NJ, “From This Article, It Sounds like Men Are Figuring Something out That Women Have Known Forever. I Know of Many”, in <i>The Washington Post</i> (January 2019).<br>
+<sup>25</sup> A. Author, “How Workout Buddies Can Help Stave off Loneliness”, in <i>The Washington Post</i> (January 2019).<br>
+<sup>26</sup> N. G. Cuellar, “Study Abroad Programs”, in <i>Journal of Transcultural Nursing</i>, Vol. 27, No.3 (2016), p.209.<br>
+<sup>27</sup> L. S. Brown, <i>Feminist Therapy</i>, American Psychological Association, 2018.<br>
+<sup>28</sup> R. Burgess, <i>Rethinking Global Health: Frameworks of Power</i>, Routledge, 2019.<br>
+<sup>29</sup> S. Cain, <i>Quiet: The Power of Introverts in a World That Can’t Stop Talking</i>, Random House Audio, 2012.<br>
+<sup>30</sup> B. Christian &#38; T. Griffiths, <i>Algorithms to Live by: The Computer Science of Human Decisions</i>, Henry Holt and Co., 2016.<br>
+<sup>31</sup> D. H. Meadows, <i>Thinking in Systems: A Primer</i>, Chelsea Green Publishing, 2008.<br>
+<sup>32</sup> Henry-James Schmid (ed.), <i>Entrenchment and the Psychology of Language Learning: How We Reorganize and Adapt Linguistic Knowledge</i>, American Psychological Association; De Gruyter Mouton, 2017.<br>
+<sup>33</sup> J. Hacker Hughes (ed.), <i>Military Veteran Psychological Health and Social Care: Contemporary Approaches</i>, Routledge, 2017.<br>
+<sup>34</sup> K. F. Pridham, R. Limbo, &#38; M. Schroeder (eds.), <i>Guided Participation in Pediatric Nursing Practice: Relationship-Based Teaching and Learning with Parents, Children and Adolescents</i>, Springer Publishing Company, 2018.<br>
+<sup>35</sup> N. Amano &#38; H. Kondo, <i>Lexical Characteristics of Japanese Language</i>, vol. 7, Sansei-do, 2000.<br>
+<sup>36</sup> J. Piaget &#38; B. Inhelder, <i>The Psychology of the Child</i>, Quadrige, 1966.<br>
+<sup>37</sup> J. Piaget &#38; B. Inhelder, <i>The Psychology of the Child</i>, Weaver, H. (trans.), Basic Books, 1969.<br>
+<sup>38</sup> S. Freud, <i>The Interpretation of Dreams: The Complete and Definitive Text</i>, Strachey, J. (trans.), Basic Books, 2010.<br>
+<sup>39</sup> J. K. Rowling, <i>Harry Potter and the Sorceror’s Stone</i>, Pottermore Publishing, 2015.<br>
+<sup>40</sup> S. T. Fiske, D. T. Gilbert, &#38; G. Lindzey, <i>Handbook of Social Psychology</i>, vol. 1, John Wiley &#38; Sons, 2010.<br>
+<sup>41</sup> C. B. Travis &#38; J. W. White (eds.), <i>APA Handbook of the Psychology of Women</i>, vol. 1, American Psychological Association, 2018.<br>
+<sup>42</sup> S. Madigan, <i>Narrative Therapy</i>, American Psychological Association, 2019.<br>
+<sup>43</sup> American Psychiatric Association, “Diagnostic and Statistical Manual of Mental Disorders”, American Psychiatric Association, 2013.<br>
+<sup>44</sup> World Health Organization, “International Statistical Classification of Diseases and Related Health Problems”, World Health Organization, 2019.<br>
+<sup>45</sup> American Psychological Association, <i>APA Dictionary of Psychology</i>.<br>
+<sup>46</sup> Merriam-Webster, <i>Merriam-Webster.Com Dictionary</i>.<br>
+<sup>47</sup> E. N. Zalta (ed.), <i>The Stanford Encyclopedia of Philosophy</i>, Stanford University, 2019.<br>
+<sup>48</sup> M. Gold (ed.), <i>The Complete Social Scientist: A Kurt Lewin Reader</i>, American Psychological Association, 1999.<br>
+<sup>49</sup> <i>King James Bible</i>, King James Bible Online, 2017.<br>
+<sup>50</sup> <i>The Qur’an</i>, Abdel Haleem, M. A. S. (trans.), Oxford University Press, 2004.<br>
+<sup>51</sup> <i>The Torah: The Five Books of Moses</i>, The Jewish Publication Society, 2015.<br>
+<sup>52</sup> Aristotle, <i>Poetics</i>, Butcher, S. H. (trans.), The Internet Classics Archive, 1994.<br>
+<sup>53</sup> W. Shakespeare, <i>Much Ado about Nothing</i>, Washington Square Press, 1995.<br>
+<sup>54</sup> K. F. Balsam et al., “Affirmative Cognitive Behavior Therapy with Sexual and Gender Minority People”, in Iwamasa, G. Y. and Hays, P. A. (eds.), <i>Culturally Responsive Cognitive Behavior Therapy: Practice and Supervision</i>, American Psychological Association, 2019.<br>
+<sup>55</sup> R. Weinstock, G. B. Leong, &#38; J. A. Silva, “Defining Forensic Psychiatry: Roles and Responsibilities”, in Rosner, R. (ed.), <i>Principles and Practise of Forensic Psychiatry</i>, CRC Press, 2003.<br>
+<sup>56</sup> N. Tafoya &#38; A. Del Vecchio, “Back to the Future: An Examination of the Native American Holocaust Experience”, in McGoldrick, M., Giordano, J., and Garcia-Preto, N. (eds.), <i>Ethnicity and Family Therapy</i>, Guilford Press, 2005.<br>
+<sup>57</sup> N. Carcavilla González, “Auditory Sensory Therapy: Brain Activation through Music”, in Garcia Meilán, J. J. (ed.), <i>Guía Práctica de Terapias Estimulativas En El Alzhéimer</i>, Editorial Síntesis, 2015.<br>
+<sup>58</sup> M. Heidegger, “On the Essence of Truth”, Sallis, J. (trans.), in Krell, D. F. (ed.), <i>Basic Writings</i>, Harper Perennial Modern Thought, 2008.<br>
+<sup>59</sup> C. Sacchett &#38; G. W. Humphreys, “Calling a Squirrel and Squirrel but a Canoe a Wigwam: A Category-Specific Deficit for Artefactual Objects and Body Parts”, in Balota, D. A. and Marsh, E. J. (eds.), <i>Cognitive Psychology: Key Readings in Cognition</i>, Psychology Press, 2004.<br>
+<sup>60</sup> C. Sacchett &#38; G. W. Humphreys, “Calling a Squirrel and Squirrel but a Canoe a Wigwam: A Category-Specific Deficit for Artefactual Objects and Body Parts”, in <i>Cognitive Neuropsychology</i>, Vol. 9, No.1 (1992), pp.73-86.<br>
+<sup>61</sup> U. Bronfenbrenner, “The Social Ecology of Human Development: A Retrospective Conclusion”, in Bronfenbrenner, U. (ed.), <i>Making Human Beings Human: Bioecological Perspectives on Human Development</i>, SAGE Publications, 2005.<br>
+<sup>62</sup> F. Richardson (ed.), <i>Brain and Intelligence: The Ecology of Child Development</i>, National Educational Press, 1973.<br>
+<sup>63</sup> S. Goldin-Meadow, “Gesture and Cognitive Development”, in Liben, L. S. and Mueller, U. (eds.), <i>Handbook of Child Psychology and Developmental Science</i>, John Wiley &#38; Sons, 2015.<br>
+<sup>64</sup> K. Lewin, “Group Decision and Social Change”, in Gold, M. (ed.), <i>The Complete Social Scientist: A Kurt Lewin Reader</i>, American Psychological Association, 1999.<br>
+<sup>65</sup> American Psychological Association, <i>Positive Transference</i>.<br>
+<sup>66</sup> Merriam-Webster, <i>Self-Report</i>.<br>
+<sup>67</sup> G. Graham, <i>Behaviorism</i>, Stanford University, 2019.<br>
+<sup>68</sup> <i>List of Oldest Companies</i>, 2019.<br>
+<sup>69</sup> Australian Government Productivity Commission &#38; New Zealand Productivity Commission, “Strengthening Trans-Tasman Economic Relations”, 2012.<br>
+<sup>70</sup> Canada Council for the Arts, “What We Heard: Summary of Key Findings: 2013 Canada Council’s Inter-Arts Office Consultation”, 2013.<br>
+<sup>71</sup> National Cancer Institute, “Facing Forward: Life after Cancer Treatment”, U.S. Department of Health and Human Services, National Institutes of Health, 2018.<br>
+<sup>72</sup> D. Fried &#38; A. Polyakova, “Democratic Defense against Disinformation”, Atlantic Council, 2018.<br>
+<sup>73</sup> A. Segaert &#38; A. Bauer, “The Extent and Nature of Veteran Homelessness in Canada”, Employment and Social Development Canada, 2015.<br>
+<sup>74</sup> D. L. Blackwell, J. W. Lucas, &#38; T. C. Clarke, “Summary Health Statistics for U.S. Adults: National Health Interview Survey, 2012”, Centers for Disease Control and Prevention, 2014.<br>
+<sup>75</sup> British Cardiovascular Society Working Group, “British Cardiovascular Society Working Group Report: Out-of-Hours Cardiovascular Care: Management of Cardiac Emergencies and Hospital in-Patients”, British Cardiovascular Society, 2016.<br>
+<sup>76</sup> U.S. Securities and Exchange Commission, “Agency Financial Report: Fiscal Year 2017”, 2017.<br>
+<sup>77</sup> American Counseling Association, “2014 ACA Code of Ethics”, 2014.<br>
+<sup>78</sup> American Nurses Association, “Code of Ethics for Nurses with Interpretive Statements”, 2015.<br>
+<sup>79</sup> American Psychological Association, “Ethical Principles of Psychologists and Code of Conduct”, 2017.<br>
+<sup>80</sup> C. B. Blair, “Stress, Self-Regulation and Psychopathology in Middle Childhood”, Eunice Kennedy Shriver National Institute of Child Health &#38; Human Development, 2015–2020.<br>
+<sup>81</sup> J. Lichtenstein, “Profile of Veteran Business Owners: More Young Veterans Appear to Be Starting Businesses”, U.S. Small Business Administration, Office of Advocacy, 2013.<br>
+<sup>82</sup> M. Harwell, “Don’t Expect Too Much: The Limited Usefulness of Common SES Measures and a Prescription for Change”, National Education Policy Center, 2018.<br>
+<sup>83</sup> U.S. Food and Drug Administration, “FDA Authorizes First Interoperable Insulin Pup Intended to Allow Patients to Customize Treatment through Their Individual Diabetes Management Devices”, U.S. Food and Drug Administration, 2019.<br>
+<sup>84</sup> A. Fistek, E. Jester, &#38; K. Sonnenberg, <i>Everybody’s Got a Little Music in Them: Using Music Therapy to Connect, Engage, and Motivate</i>, Milwaukee, WI, United States, 2017.<br>
+<sup>85</sup> S. Maddox et al., <i>If Mama Ain’t Happy, Nobody’s Happy: The Effect of Parental Depression on Mood Dysregulation in Children</i>, New Orleans, LA, United States, 2016.<br>
+<sup>86</sup> J. Pearson, <i>Fat Talk and Its Effects on State-Based Body Image in Women</i>, Sydney, NSW, Australia, 2018.<br>
+<sup>87</sup> D. De Boer &#38; T. LaFavor, <i>The Art and Significance of Successfully Identifying Resilient Individuals A Person-Focused Approach</i>, Portland, OR, United States, 2018.<br>
+<sup>88</sup> L. Harris, “Instructional Leadership Perceptions and Practices of Elementary School Leaders”, Unpublished Doctoral Dissertation, University of Virginia, 2014.<br>
+<sup>89</sup> M. M. Hollander, “Resistance to Authority: Methodological Innovations and New Lessons from the Milgram Experiment”, Doctoral Dissertation, University of Wisconsin–Madison, 2017.<br>
+<sup>90</sup> V. H. Hutcheson, “Dealing with Dual Differences: Social Coping Strategies of Gifted and Lesbian, Gay, Bisexual, Transgender, and Queer Adolescents”, Master’s Thesis, The College of William &#38; Mary, 2012.<br>
+<sup>91</sup> L. A. Mirabito &#38; N. C. Heck, “Bringing LGBTQ Youth Theater into the Spotlight”, in <i>Psychology of Sexual Orientation and Gender Diversity</i>, Vol. 3, No.4 (2016), pp.499-500.<br>
+<sup>92</sup> <i>The Year We Thought about Love</i>, 2016.<br>
+<sup>93</sup> F. Santos, “Reframing Refugee Children’s Stories”, in <i>The New York Times</i> (January 2019).<br>
+<sup>94</sup> M. Yousafzai, <i>We Are Displaced: My Journey and Stories from Refugee Girls around the World</i>, 2016.<br>
+<sup>95</sup> D. Perkins, <i>The Good Place</i> Ends Its Remarkable Second Season with Irrational Hope, Unexpected Gifts, and a Smile, 2018, <a href="https://www.avclub.com/the-good-place-ends-its-remarkable-second-season-with-i-1822649316">https://www.avclub.com/the-good-place-ends-its-remarkable-second-season-with-i-1822649316</a>.<br>
+<sup>96</sup> <i>Somewhere Else</i>, 2018.<br>
+<sup>97</sup> J. Yoo et al., Linking Positive Affect to Blood Lipids: A Cultural Perspective, 2016, Department of Psychology, University of Wisconsin-Madison.<br>
+<sup>98</sup> M. O’Shea, Understanding Proactive Behavior in the Workplace as a Function of Gender, 2018, Department of Management, University of Kansas.<br>
+<sup>99</sup> T. Lippincott &#38; E. K. Poindexter, Emotion Recognition as a Function of Facial Cues: Implications for Practice, 2019, Department of Psychology, University of Washington.<br>
+<sup>100</sup> C. Leuker et al., <i>When Money Talks: Judging Risk and Coercion in High-Paying Clinical Trials</i>, PsyArXiv, 2018.<br>
+<sup>101</sup> M. A. Stults-Kolehmainen &#38; R. Sinha, <i>The Effects of Stress on Physical Activity and Exercise</i>, PubMed Central, 2015.<br>
+<sup>102</sup> H. K. Ho, <i>Teacher Preparation for Early Childhood Special Education in Taiwan</i>, ERIC, 2014.<br>
+<sup>103</sup> A. D’Souza &#38; M. Wiseheart, <i>Cognitive Effects of Music and Dance Training in Children</i>, ICPSR, 2018.<br>
+<sup>104</sup> National Center for Education Statistics, <i>Fast Response Survey System (FRSS): Teacher’s Use of Educational Technology in U.S. Public Schools, 2009</i>, National Archive of Data on Arts and Culture, 2016.<br>
+<sup>105</sup> Pew Research Center, <i>American Trends Panel Wave 26</i>, 2018.<br>
+<sup>106</sup> R. A. Baer, <i>Unpublished Raw Data on the Correlations between the Five Facet Mindfulness Questionnaire and the Kentucky Inventory of Mindfulness Skills</i>, University of Kentucky, 2015.<br>
+<sup>107</sup> Oregan Youth Authority, <i>Recidivism Outcomes</i>, 2011.<br>
+<sup>108</sup> M. Borenstein et al., Comprehensive Meta-Analysis, 2014, <a href="https://www.meta-analysis.com/">https://www.meta-analysis.com/</a>.<br>
+<sup>109</sup> SR Research, Eyelink 1000 Plus, 2016, <a href="https://www.sr-research.com/eyelink1000plus.html">https://www.sr-research.com/eyelink1000plus.html</a>.<br>
+<sup>110</sup> Tactile Labs, Latero Tactile Display, 2015, <a href="https://www.tactilelabs.com/products/haptics/latero-tactile-display/">https://www.tactilelabs.com/products/haptics/latero-tactile-display/</a>.<br>
+<sup>111</sup> Epocrates, Epocrates Medical References, 2019, <a href="https://itunes.apple.com/us/app/epocrates/id281935788?mt=8">https://itunes.apple.com/us/app/epocrates/id281935788?mt=8</a>.<br>
+<sup>112</sup> Epocrates, <i>Interaction Check: Aspirin + Sertraline</i>, Google Play Store, 2019.<br>
+<sup>113</sup> A. Tellegen &#38; Y. S. Ben-Porath, “Minnesota Multiphasic Personality Inventory-2 Restructured Form (MMPI-2-RF): Technical Manual”, Pearson, 2011.<br>
+<sup>114</sup> Project Implicit, <i>Gender-Science IAT</i>.<br>
+<sup>115</sup> J. Alonso-Tapia et al., <i>Situated Goals Questionnaire for University Students (SGQ-U, CMS-U)</i>, PsycTESTS, 2018.<br>
+<sup>116</sup> D. Cardoza et al., <i>Acculturative Stress Inventory (ASI)</i>, ETS TestLink, 2000.<br>
+<sup>117</sup> <i>One Flew over the Cuckoo’s Nest</i>, United Artists, 1975.<br>
+<sup>118</sup> <i>Accelerated Experiental Dynamic Psychotherapy (AEDP) Supervision</i>, American Pychological Association, 2017.<br>
+<sup>119</sup> <i>The Lord of the Rings: The Fellowship of the Ring</i>, WingNut Films; The Saul Zaentz Company, 2001.<br>
+<sup>120</sup> <i>Goodbye Children</i>, Nouvelles Éditions de Films, 1987.<br>
+<sup>121</sup> <i>The Wire</i>, Blown Deadline Productions; HBO, 2002–2008.<br>
+<sup>122</sup> <i>Lemons</i>, Wilmore Films; Artists First; Cinema Gypsy Productions; ABC Studios, 2017.<br>
+<sup>123</sup> <i>Who Shot Mr. Burns? (Part One)</i>, Gracie Films; Twentieth Century Fox Film Corporation, 1995.<br>
+<sup>124</sup> <i>Why You Should Make Useless Things</i>, TED Conferences, 2018.<br>
+<sup>125</sup> <i>Brené Brown: Listening to Shame</i>, YouTube, 2012.<br>
+<sup>126</sup> <i>Evaluating Adverse Drug Effects</i>, American Psychiatric Association, 2018.<br>
+<sup>127</sup> <i>Happiness</i>, Vimeo, 2017.<br>
+<sup>128</sup> <i>How to Diagram a Sentence (Absolute Basics)</i>, YouTube, 2016.<br>
+<sup>129</sup> <i>How Do Geckos Walk on Water?</i>, YouTube, 2016.<br>
+<sup>130</sup> <i>The Brandenburg Concertos: Concertos BVW 1043 &#38; 1060</i>, Decca, 2010.<br>
+<sup>131</sup> D. Bowie, <i>Blackstar</i>, Columbia, 2016.<br>
+<sup>132</sup> <i>Symphony No. 3 in E-Flat Major</i>, Brilliant Classics, 2012.<br>
+<sup>133</sup> Beyoncé, <i>Formation</i>, Parkwood; Columbia, 2016.<br>
+<sup>134</sup> Childish Gambino, <i>This Is America</i>, mcDJ; RCA, 2018.<br>
+<sup>135</sup> K. Lamar, <i>Humble</i>, Aftermath Entertainment; Interscope Records; Top Dawg Entertainment, 2017.<br>
+<sup>136</sup> S. Vedantam, <i>Hidden Brain</i>, NPR, 2015.<br>
+<sup>137</sup> I. Glass, <i>Amusement Park</i>, WBEZ Chicago, 2011.<br>
+<sup>138</sup> S. de Beauvoir, <i>Simone de Beauvoir Discusses the Art of Writing</i>, 1960.<br>
+<sup>139</sup> M. L. King Jr., <i>I Have a Dream</i>, American Rhetoric, 1963.<br>
+<sup>140</sup> E. Delacroix, <i>Faust Attempts to Seduce Marguerite</i>, 1826–1827.<br>
+<sup>141</sup> G. Wood, <i>American Gothic</i>, 1930.<br>
+<sup>142</sup> GDJ, <i>Neural Network Deep Learning Prismatic</i>, 2018.<br>
+<sup>143</sup> J. Rossman &#38; R. Palmer, <i>Sorting through Our Space Junk</i>, 2015.<br>
+<sup>144</sup> D. Cable, <i>The Racial Dot Map</i>, University of Virginia: Weldon Cooper Center for Public Service, 2013.<br>
+<sup>145</sup> Google, <i>Google Maps Directions for Driving from La Paz, Bolivia, to Lima, Peru</i>.<br>
+<sup>146</sup> S. McCurry, <i>Afghan Girl</i>, 1985.<br>
+<sup>147</sup> Jessica Rinaldi, <i>Photograph Series of a Boy Who Finds His Footing after Abuse by Those He Trusted</i>, 2016.<br>
+<sup>148</sup> E. Canan &#38; J. Vasilev, Lecture Notes on Resource Allocation, May 22, 2019, Department of Management Control and Information Systems, University of Chile.<br>
+<sup>149</sup> Brian Housand, Game on! Integrating Games and Simulations in the Classroom, 2016, SlideShare.<br>
+<sup>150</sup> R. Mack &#38; G. Spake, Citing Open Source Images and Formatting References for Presentations, 2018, Canvas@FNU.<br>
+<sup>151</sup> APA Education [@APAEducation], College Students Are Forming Mental-Health Clubs—and They’re Making a Difference @washingtonpost [Thumbnail with Link Attached], Twitter, 2018, <a href="https://twitter.com/apaeducation/status/1012810490530140161">https://twitter.com/apaeducation/status/1012810490530140161</a>.<br>
+<sup>152</sup> Badlands National Park [@BadlandsNPS], Biologists Have Identified More than 400 Different Plant Species Growing in @BadlandsNPS #DYK #biodoversity, Twitter, 2018, <a href="https://twitter.com/BadlandsNPS/status/968196500412133379">https://twitter.com/BadlandsNPS/status/968196500412133379</a>.<br>
+<sup>153</sup> B. White, I Treasure Every Minute We Spent Together #koko [Image Attached], Twitter, 2018, <a href="https://twitter.com/BettyMWhite/status/1009951892846227456">https://twitter.com/BettyMWhite/status/1009951892846227456</a>.<br>
+<sup>154</sup> APA Style [@APA_Style], Tweets, Twitter, <a href="https://twitter.com/APA_Style">https://twitter.com/APA_Style</a>, November 1, 2019.<br>
+<sup>155</sup> N. Gaiman, 100,000+ Rohingya Refugees Could Be at Serious Risk during Bangladesh’s Monsoon Season. My Fellow UNHCR Goodwill Ambassador Cate Blanchett Is [Image Attached], Facebook, 2018, <a href="http://bit.ly/2JQxPAD">http://bit.ly/2JQxPAD</a>.<br>
+<sup>156</sup> National Institute of Mental Health, Suicide Affects All Ages, Genders, Races, and Ethnicities. Check out These 5 Action Steps for Helping Someone in Emotional Pain, Facebook, 2018, <a href="http://bit.ly/321Qstq">http://bit.ly/321Qstq</a>.<br>
+<sup>157</sup> News From Science, These Frogs Walk Instead of Hop. Https://Scimag.2KlriwH, Facebook, 2018, <a href="https://www.facebook.com/ScienceNOW/videos/10155508587605108">https://www.facebook.com/ScienceNOW/videos/10155508587605108</a>.<br>
+<sup>158</sup> Smithsonian’s National Zoo and Conservation Biology Institute, Home, Facebook, <a href="https://www.facebookcom/nationalzoo">https://www.facebookcom/nationalzoo</a>, July 22, 2019.<br>
+<sup>159</sup> Zeitz MOCAA [@zeitzmocaa], Grade 6 Learners from Parkfields Primary School in Hanover Park Visited the Museum for a Tour and Workshop Hosted By, Instagram, 2018, <a href="https://www.instagram.com/p/BqpHpjFBs3b">https://www.instagram.com/p/BqpHpjFBs3b</a>.<br>
+<sup>160</sup> The New York Public Library [@nypl], The Raven, Instagram, <a href="https://bitly.com/2FV8bu3">https://bitly.com/2FV8bu3</a>, April 16, 2019.<br>
+<sup>161</sup> National Aeronautics and Space Administration [@nasa], I’m NASA Astronaut Scott Tingle. Ask Me Anything about Adjusting to Being Back on Earth after My First Spaceflight!, Reddit, 2018, <a href="https://www.reddit.com/r/IAmA/comments/9fagqy/im_nasa_astronaut_scott_tingle_ask_me_anything/">https://www.reddit.com/r/IAmA/comments/9fagqy/im_nasa_astronaut_scott_tingle_ask_me_anything/</a>.<br>
+<sup>162</sup> N. Avramova, The Secret to a Long, Happy, Health Life? Think Age-Positive, CNN, 2019, <a href="https://www.cnn.com/2019/01/03/health/respect-towards-elderly-leads-to-long-life-intl/index.html">https://www.cnn.com/2019/01/03/health/respect-towards-elderly-leads-to-long-life-intl/index.html</a>.<br>
+<sup>163</sup> C. Bologna, What Happens to Your Mind and Body When You Feel Homesick?, HuffPost, 2018, <a href="https://www.huffingtonpost.com/entry/what-happens-mind-body-homesick_us_5b201ebde4b09d7a3d77eee1">https://www.huffingtonpost.com/entry/what-happens-mind-body-homesick_us_5b201ebde4b09d7a3d77eee1</a>.<br>
+<sup>164</sup> Centers for Disease Control and Prevention, People at High Risk of Developing Flu-Related Complications, 2018, <a href="https://www.cdc.gov/flu/about/disease/high_risk.htm">https://www.cdc.gov/flu/about/disease/high_risk.htm</a>.<br>
+<sup>165</sup> World Health Organization, Questions and Answers on Immunization and Vaccine Safety, 2018, <a href="https://www.who.int/features/qa/84/en/">https://www.who.int/features/qa/84/en/</a>.<br>
+<sup>166</sup> C. M. Martin Lillie, Be Kind to Yourself: How Self-Compassion Can Improve Your Resiliency, Mayo Clinic, 2016, <a href="https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/self-compassion-can-improve-your-resiliency/art-20267193">https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/self-compassion-can-improve-your-resiliency/art-20267193</a>.<br>
+<sup>167</sup> J. Boddy et al., Ethics Principles, The research ethics guidebook: A resource for social scientists, <a href="http://www.ethicsguidebook.ac.uk/EthicsPrinciples">http://www.ethicsguidebook.ac.uk/EthicsPrinciples</a>.<br>
+<sup>168</sup> National Nurses United, What Employers Should Do to Protect Nurses from Zika, <a href="https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika">https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika</a>.<br>
+<sup>169</sup> U.S. Census Bureau, U.S. and World Population Clock, U.S. Department of Commerce, <a href="https://www.census.gov/popclock/">https://www.census.gov/popclock/</a>, July 3, 2019.<br>
+<sup>170</sup> <i>Brown v. Board of Education</i>, vol. 347, 1954.<br>
+<sup>171</sup> <i>Obergefell v. Hodges</i>, vol. 576, 2015.<br>
+<sup>172</sup> <i>Daubert v. Merrell Dow Pharmaceuticals, Inc.</i>, vol. 951, 1991.<br>
+<sup>173</sup> <i>Burriola v. Greater Toledo YMCA</i>, vol. 133, 2001.<br>
+<sup>174</sup> <i>Durflinger v. Artiles</i>, vol. 563, 1984.<br>
+<sup>175</sup> <i>Tarasoff v. Regents of the University of California</i>, vol. 17, 1976.<br>
+<sup>176</sup> <i>Texas v. Morales</i>, vol. 826, 1992.<br>
+<sup>177</sup> <i>American With Disabilities Act of 1990</i>, vol. 42, 1990.<br>
+<sup>178</sup> <i>Civil Rights Act of 1964</i>, vol. 78, 1964.<br>
+<sup>179</sup> <i>Every Student Succeeds Act</i>, vol. 20, 2015.<br>
+<sup>180</sup> <i>Lilly Leadbetter Fair Play Act of 2009</i>, vol. 123, 2009.<br>
+<sup>181</sup> <i>Patsy Mink Equal Opportunity in Education Act</i>, vol. 20, 1972.<br>
+<sup>182</sup> <i>Florida Mental Health Act</i>, 2009.<br>
+<sup>183</sup> <i>Federal Real Property Reform: How Cutting Red Tape and Better Management Count Achieve Billions in Savings, U.S. Senate Committee on Homeland Security and Governmental Affairs</i>, 2016.<br>
+<sup>184</sup> <i>Strengthening the Federal Student Loan Program for Borrowers: Hearing before the U.S. Senate Committee on Health, Education, Labor &#38; Pensions</i>, 2014.<br>
+<sup>185</sup> <i>Mental Health on Campus Improvement Act</i>, 2013.<br>
+<sup>186</sup> <i>S. Res. 438</i>, vol. 162, 2016.<br>
+<sup>187</sup> “H.R. Rep. No. 114-358”, 2015.<br>
+<sup>188</sup> <i>Protection of Human Subjects</i>, vol. 45, 2009.<br>
+<sup>189</sup> <i>Defining and Delimiting the Exemptions for Executive, Administrative, Professional, Outside Sales and Computer Employees</i>, vol. 81, 2016.<br>
+<sup>190</sup> <i>Exec. Order No. 13,676</i>, vol. 3, 2014.<br>
+<sup>191</sup> S. C. Hiremath et al., <i>Using Metaphors to Present Concepts across Different Intellectual Domains</i>, U.S., 2016.<br>
+<sup>192</sup> <i>U.S. Const. Art. I, § 3</i>.<br>
+<sup>193</sup> <i>S.C. Const. Art. XI, § 3</i>.<br>
+<sup>194</sup> <i>U.S. Const. Amend. XIX</i>.<br>
+<sup>195</sup> <i>U.S. Const. Amend. XVIII (Repealed 1933)</i>.<br>
+<sup>196</sup> <i>U.S. Const. Amend. I-X</i>.<br>
+<sup>197</sup> <i>U.N. Charter Art. 1, Para. 3</i>.<br>
+<sup>198</sup> <i>United Nations Convention on the Rights of the Child</i>, 1989.<br>
+
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->

--- a/src/人民出版社学术著作引证注释格式（修正版）/metadata.json
+++ b/src/人民出版社学术著作引证注释格式（修正版）/metadata.json
@@ -1,0 +1,33 @@
+{
+  "dir": "人民出版社学术著作引证注释格式（修正版）",
+  "file": "人民出版社学术著作引证注释格式（修正版） .csl",
+  "style_class": "note",
+  "title": "人民出版社学术著作引证注释格式（修正版）",
+  "id": "http://www.zotero.org/styles/人民出版社学术著作引证注释格式",
+  "link_self": "http://www.zotero.org/styles/人民出版社学术著作引证注释格式",
+  "link_template": "https://www.zotero-chinese.com/styles/人民出版社",
+  "link_documentation": "http://www.pph166.com/",
+  "author": [
+    {
+      "name": "Zeping Lee"
+    }
+  ],
+  "contributor": [
+    {
+      "name": "Hongzuan Lyu"
+    }
+  ],
+  "citation_format": "note",
+  "field": "generic-base",
+  "summary": "最后一名英文作者用连接、英文的主编、翻译标签使用括号、引注有页码，参考文献没有页码，标注中文翻译译著的原作者国籍，析出文献前加入in",
+  "updated": "2025-09-08T15:30:31+08:00",
+  "citations": "<sup>1</sup> [无] 库恩：《科学革命的结构：第 4 版》第2版，金吾伦、胡新和译，北京大学出版社2012年版。<br>\n<sup>2</sup> Xuetong Fan &#38; Christopher H. Sommers, <i>Food Irradiation Research and Technology</i>, Ames, Iowa: Blackwell Publishing, 2013.<br>\n<sup>3</sup> 贾东琴、柯平：《面向数字素养的高校图书馆数字服务体系研究》，中国图书馆学会主编：《中国图书馆学会年会论文集》2011 年卷，国家图书馆出版社2011年版。<br>\n<sup>4</sup> M. E. Fourney, “Advances in Holographic Photoelasticity”, in <i>Symposium on Applications of Holography in Mechanics</i>, New York: ASME, c1971.<br>\n<sup>5</sup> 武丽丽等：《“北斗一号”监控管理网设计与实现》，《测绘科学》第33卷第5期，2008年。<br>\n<sup>6</sup> Alexander A. Myburg et al., “The Genome of Eucalyptus Grandis”, in <i>Nature</i>, Vol. 510 (June 2014), pp.356-362.<br>\n<sup>7</sup> Alexander A. Myburg et al., “The Genome of Eucalyptus Grandis”, in <i>Nature</i>, Vol. 510 (June 2014), pp.356-362.<br>\n<sup>8</sup> Alexander A. Myburg et al., “The Genome of Eucalyptus Grandis”, in <i>Nature</i>, Vol. 510 (June 2014), p.357.<br>\n<sup>9</sup> Xuetong Fan &#38; Christopher H. Sommers, <i>Food Irradiation Research and Technology</i>, Ames, Iowa: Blackwell Publishing, 2013, pp.326-329.<br>\n",
+  "bibliography": "<div class=\"csl-bib-body maxoffset-3 second-field-align-flush hangingindent-false\">\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[1]</div><div class=\"csl-right-inline\">贾东琴、柯平：《面向数字素养的高校图书馆数字服务体系研究》，中国图书馆学会主编：《中国图书馆学会年会论文集》2011 年卷，国家图书馆出版社2011年版。</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[2]</div><div class=\"csl-right-inline\">[无] 库恩：《科学革命的结构：第 4 版》第2版，金吾伦、胡新和译，北京大学出版社2012年版。</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[3]</div><div class=\"csl-right-inline\">武丽丽等：《“北斗一号”监控管理网设计与实现》，《测绘科学》第33卷第5期，2008年。</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[4]</div><div class=\"csl-right-inline\">Xuetong Fan &#38; Christopher H. Sommers, <i>Food Irradiation Research and Technology</i>, Ames, Iowa: Blackwell Publishing, 2013.</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[5]</div><div class=\"csl-right-inline\">M. E. Fourney, “Advances in Holographic Photoelasticity”, in <i>Symposium on Applications of Holography in Mechanics</i>, New York: ASME, c1971.</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[6]</div><div class=\"csl-right-inline\">Alexander A. Myburg et al., “The Genome of Eucalyptus Grandis”, in <i>Nature</i>, Vol. 510, (June 2014).</div>\n  </div>\n</div>",
+  "tags": [
+    "姓名小写",
+    "有标题",
+    "期刊全称",
+    "无URL",
+    "无DOI"
+  ]
+}

--- a/src/人民出版社学术著作引证注释格式（修正版）/人民出版社学术著作引证注释格式（修正版） .csl
+++ b/src/人民出版社学术著作引证注释格式（修正版）/人民出版社学术著作引证注释格式（修正版） .csl
@@ -1,0 +1,653 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" name-as-sort-order="all" sort-separator=", " initialize="false" initialize-with=". " page-range-format="expanded" default-locale="en-US" default-locale-sort="zh-CN">
+  <info>
+    <title>人民出版社学术著作引证注释格式（修正版）</title>
+    <id>http://www.zotero.org/styles/人民出版社学术著作引证注释格式</id>
+    <link href="http://www.zotero.org/styles/人民出版社学术著作引证注释格式" rel="self"/>
+    <link href="https://www.zotero-chinese.com/styles/人民出版社" rel="template"/>
+    <link href="https://www.zotero-chinese.com/styles/中国社会科学" rel="template"/>
+    <link href="http://www.pph166.com/" rel="documentation"/>
+    <author>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </author>
+    <contributor>
+      <name>Hongzuan Lyu</name>
+      <email>hongzuanlv@gmail.com</email>
+    </contributor>
+    <summary>最后一名英文作者用连接、英文的主编、翻译标签使用括号、引注有页码，参考文献没有页码，标注中文翻译译著的原作者国籍，析出文献前加入in</summary>
+    <category citation-format="note"/>
+    <category field="generic-base"/>
+    <updated>2025-09-08T15:30:31+08:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <style-options punctuation-in-quote="false"/>
+    <terms>
+      <!-- 英文页码之间连字符用半字线 -->
+      <term name="page-range-delimiter">-</term>
+      <term name="translator" form="short">trans.</term>
+    </terms>
+  </locale>
+  <locale xml:lang="zh">
+    <terms>
+      <term name="anonymous">佚名</term>
+      <term name="edition" form="short">版</term>
+      <term name="ibid">同上</term>
+      <term name="in">载</term>
+      <term name="no date">出版时间不详</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <!-- 中文页码之间连字符用一字线。 -->
+      <term name="page-range-delimiter">&#8212;</term>
+      <term name="editor" form="short">主编</term>
+      <term name="compiler" form="short">整理</term>
+    </terms>
+  </locale>
+  <macro name="author-en">
+    <names variable="author">
+      <!-- 最后一名英文作者名字前使用& -->
+      <name and="symbol" name-as-sort-order="last" et-al-min="4" et-al-use-first="1"/>
+      <!--使用括号包裹主编标签-->
+      <label form="short" prefix=" (" suffix=")" />
+      <substitute>
+        <names variable="editor"/>
+        <names variable="compiler"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-zh">
+    <!--补充译著的原作者国籍-->
+    <choose>
+      <if variable="translator">
+        <choose>
+          <if variable="archive_location" match="none">
+            <text value="无"  prefix="[" suffix="] "/>
+          </if>
+          <else>
+            <text variable="archive_location" prefix="[" suffix="] "/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+    <names variable="author">
+      <name delimiter="、" et-al-min="4" et-al-use-first="1" />
+      <label form="short"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="compiler"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="volume-en">
+    <choose>
+      <if is-numeric="volume">
+        <label variable="volume" form="short" suffix=" "/>
+        <number variable="volume"/>
+      </if>
+      <else>
+        <text variable="volume"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-zh">
+    <choose>
+      <if is-numeric="volume">
+        <text value="第"/>
+        <number variable="volume"/>
+        <label variable="volume" form="short"/>
+      </if>
+      <else>
+        <text variable="volume"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition-zh">
+    <choose>
+      <if is-numeric="edition">
+        <text value="第"/>
+        <number variable="edition"/>
+        <label variable="edition" form="short"/>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 年代（年号）或年月甲子 -->
+  <macro name="original-date-zh">
+    <date variable="original-date">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="title-en">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper chapter paper-conference report" match="any">
+        <text variable="title" text-case="title" quotes="true"/>
+      </if>
+      <else-if type="thesis">
+        <group delimiter=", ">
+          <!-- 《规定》中未要求，但是按照 ASA 样式学位论文使用引号 -->
+          <text variable="title" text-case="title" quotes="true"/>
+          <choose>
+            <if variable="genre">
+              <text variable="genre" text-case="title"/>
+            </if>
+            <else>
+              <text value="Ph.D. Dissertation"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+      <else-if type="collection manuscript personal_communication post post-weblog software webpage" match="any">
+        <text variable="title" text-case="title"/>
+      </else-if>
+      <else>
+        <group delimiter=", ">
+          <text variable="title" text-case="title" font-style="italic"/>
+          <text macro="volume-en"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-zh">
+    <text variable="title" prefix="《" suffix="》"/>
+    <choose>
+      <if variable="container-title" match="none">
+        <text macro="edition-zh"/>
+        <text macro="volume-zh"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="translator-en">
+    <names variable="translator">
+      <!-- 最后一名英文作者名字前使用& 与前文一致-->
+      <name and="symbol"/>
+      <!--使用括号包裹译者标签-->
+      <label form="short" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="translator-zh">
+    <names variable="translator">
+      <name delimiter="、"/>
+      <label form="short"/>
+    </names>
+  </macro>
+  <macro name="date-en">
+    <choose>
+      <if type="collection manuscript personal_communication" match="any">
+        <date variable="issued" form="text"/>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper" match="any">
+        <!--析出文献（连续出版物）的日期在卷号、期号之后的括号内-->
+        <date variable="issued" form="text" date-parts="year-month" prefix=" (" suffix=")"/>
+      </else-if>
+      <else>
+        <date variable="issued" form="text" date-parts="year"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-zh">
+    <choose>
+      <if variable="issued">
+        <choose>
+          <if type="article-journal article-magazine" match="any">
+            <date variable="issued" form="text" date-parts="year"/>
+          </if>
+          <else-if type="article-newspaper collection manuscript personal_communication post post-weblog software webpage" match="any">
+            <date variable="issued" form="text"/>
+          </else-if>
+          <else>
+            <date variable="issued" form="text" date-parts="year"/>
+            <text term="edition" form="short"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="article-newspaper" variable="original-date" match="all">
+        <text macro="original-date-zh"/>
+      </else-if>
+      <else-if type="classic post post-weblog software webpage" match="none">
+        <text term="no date"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue-zh">
+    <choose>
+      <if is-numeric="issue">
+        <text value="第"/>
+        <number variable="issue"/>
+        <label variable="issue" form="short"/>
+      </if>
+      <else>
+        <text variable="issue"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-periodical-en">
+  <!--析出文献名前要加入in-->
+    <text value="in "/>
+    <group delimiter=", ">
+      <text variable="container-title" text-case="title" font-style="italic"/>
+      <group>
+        <label variable="volume" form="short" text-case="capitalize-first" suffix=" "/>
+        <number variable="volume"/>
+      </group>
+      <group>
+        <label variable="issue" form="short" text-case="capitalize-first"/>
+        <number variable="issue"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-periodical-zh">
+    <text variable="container-title" prefix="《" suffix="》"/>
+    <text variable="section" prefix="（" suffix="）"/>
+    <text variable="publisher-place" prefix="（" suffix="）"/>
+    <choose>
+      <if variable="volume">
+        <group delimiter="，">
+          <group>
+            <text macro="volume-zh"/>
+            <text macro="issue-zh"/>
+          </group>
+          <date variable="issued" form="text"/>
+        </group>
+      </if>
+      <else>
+        <text macro="date-zh"/>
+        <text macro="issue-zh"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-newspaper-zh">
+    <text variable="container-title" prefix="《" suffix="》"/>
+    <text variable="publisher-place" prefix="（" suffix="）"/>
+    <group delimiter="，">
+      <group>
+        <text macro="volume-zh"/>
+        <text macro="issue-zh"/>
+      </group>
+      <text macro="date-zh"/>
+      <text variable="section" quotes="true"/>
+    </group>
+  </macro>
+  <macro name="container-booklike-en">
+    <choose>
+      <if variable="container-title">
+        <group delimiter=" ">
+          <text term="in"/>
+          <group delimiter=", ">
+            <names variable="editor">
+              <name and="text"/>
+              <label form="short" prefix=" (" suffix=")" />
+            </names>
+            <text variable="container-title" text-case="title" font-style="italic"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-booklike-zh">
+    <group delimiter="：">
+      <names variable="editor">
+        <name delimiter="、"/>
+        <label form="short"/>
+      </names>
+      <group>
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title" prefix="《" suffix="》"/>
+            <text macro="edition-zh"/>
+            <text macro="volume-zh"/>
+          </if>
+          <else-if type="paper-conference" variable="event-title" match="all">
+            <text variable="event-title"/>
+            <text value="论文"/>
+          </else-if>
+        </choose>
+      </group>
+    </group>
+  </macro>
+  <macro name="publisher-en">
+    <choose>
+      <if type="thesis">
+        <text variable="publisher"/>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-zh">
+    <!--这里把if简化掉了-->
+    <text variable="publisher"/>
+  </macro>
+  <macro name="event-zh">
+    <choose>
+      <if variable="container-title" match="none">
+        <group delimiter="，">
+          <group>
+            <text variable="event-title"/>
+            <text value="论文"/>
+          </group>
+          <names variable="organizer">
+            <name delimiter="、"/>
+            <substitute>
+              <!-- 用户填写在错误字段的情况 -->
+              <text variable="publisher"/>
+              <text variable="publisher-place"/>
+            </substitute>
+          </names>
+          <choose>
+            <if variable="event-date">
+              <date variable="event-date" form="text"/>
+            </if>
+            <else>
+              <date variable="issued" form="text"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="archive-en">
+    <group delimiter=", ">
+      <!-- 档案的卷宗号 -->
+      <text variable="archive_location"/>
+      <text variable="archive_collection"/>
+      <text variable="archive"/>
+      <choose>
+        <if variable="archive-place">
+          <!-- 档案的馆藏地以及收藏机构或单位 -->
+          <text variable="archive-place"/>
+        </if>
+        <else>
+          <text variable="publisher-place"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="archive-zh">
+    <group delimiter="，">
+      <group>
+        <text variable="archive_collection"/>
+        <!-- 档案的卷宗号 -->
+        <text variable="archive_location"/>
+      </group>
+      <group>
+        <text variable="archive"/>
+        <text value="藏"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="access-en">
+    <choose>
+      <if type="post post-weblog software webpage" match="any">
+      <!--这里的分隔符应该是半角-->
+        <group delimiter=", ">
+          <text variable="URL"/>
+          <date variable="accessed" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="access-zh">
+    <choose>
+      <if type="post post-weblog software webpage" match="any">
+        <group delimiter="，">
+          <text variable="URL"/>
+          <date variable="accessed" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="page-en">
+    <choose>
+      <if is-numeric="page">
+        <label variable="page" form="short"/>
+        <number variable="page"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator-en">
+    <choose>
+      <if is-numeric="locator">
+        <label variable="locator" form="short"/>
+        <number variable="locator"/>
+      </if>
+      <else>
+        <text variable="locator"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator-zh">
+    <choose>
+      <if is-numeric="locator">
+        <text value="第"/>
+        <number variable="locator"/>
+        <!--删除对报纸文章locator的if判断-->
+        <label variable="locator" form="short"/>
+      </if>
+      <else>
+        <text variable="locator"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator-or-page-en">
+    <choose>
+      <if variable="locator">
+        <text macro="locator-en"/>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="page-en"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="entry-layout-en-citation">
+    <group delimiter=", ">
+      <text macro="author-en"/>
+      <text macro="title-en"/>
+      <text macro="translator-en"/>
+      <choose>
+        <if type="article-journal article-magazine article-newspaper" match="any">
+        <!--英文析出文献的日期与期号之间为空格-->
+          <group delimiter=" ">
+            <text macro="container-periodical-en"/>
+            <text macro="date-en"/>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="container-booklike-en"/>
+          <text macro="publisher-en"/>
+          <text macro="date-en"/>
+        </else-if>
+        <else-if type="collection manuscript personal_communication" match="any">
+          <text macro="date-en"/>
+          <text macro="archive-en"/>
+        </else-if>
+        <else-if type="post post-weblog software webpage" match="any">
+          <text variable="container-title"/>
+          <text macro="date-en"/>
+        </else-if>
+        <else>
+          <text macro="publisher-en"/>
+          <text macro="date-en"/>
+        </else>
+      </choose>
+      <text macro="access-en"/>
+      <text macro="locator-or-page-en"/>
+    </group>
+  </macro>
+  <macro name="entry-layout-en-bibliography">
+    <group delimiter=", ">
+      <text macro="author-en"/>
+      <text macro="title-en"/>
+      <text macro="translator-en"/>
+      <choose>
+        <if type="article-journal article-magazine article-newspaper" match="any">
+        <!--英文析出文献的日期与期号之间为空格-->
+          <text macro="container-periodical-en"/>
+          <text macro="date-en"/>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="container-booklike-en"/>
+          <text macro="publisher-en"/>
+          <text macro="date-en"/>
+        </else-if>
+        <else-if type="collection manuscript personal_communication" match="any">
+          <text macro="date-en"/>
+          <text macro="archive-en"/>
+        </else-if>
+        <else-if type="post post-weblog software webpage" match="any">
+          <text variable="container-title"/>
+          <text macro="date-en"/>
+        </else-if>
+        <else>
+          <text macro="publisher-en"/>
+          <text macro="date-en"/>
+        </else>
+      </choose>
+      <text macro="access-en"/>
+    </group>
+  </macro>
+  <macro name="entry-layout-zh-citation">
+    <group delimiter="：">
+      <text macro="author-zh"/>
+      <group delimiter="，">
+        <text macro="title-zh"/>
+        <text macro="translator-zh"/>
+        <choose>
+          <if type="article-journal article-magazine" match="any">
+            <text macro="container-periodical-zh"/>
+          </if>
+          <else-if type="article-newspaper">
+            <text macro="container-newspaper-zh"/>
+          </else-if>
+          <else-if type="chapter">
+            <text macro="container-booklike-zh"/>
+            <group>
+              <text macro="publisher-zh"/>
+              <text macro="date-zh"/>
+            </group>
+            <text macro="locator-zh"/>
+          </else-if>
+          <else-if type="paper-conference">
+            <choose>
+              <if variable="container-title">
+                <text macro="container-booklike-zh"/>
+                <group>
+                  <text macro="publisher-zh"/>
+                  <text macro="date-zh"/>
+                </group>
+              </if>
+              <else>
+                <text macro="event-zh"/>
+              </else>
+            </choose>
+            <text macro="locator-zh"/>
+          </else-if>
+          <else-if type="collection manuscript personal_communication" match="any">
+            <text macro="date-zh"/>
+            <text macro="archive-zh"/>
+            <text macro="locator-zh"/>
+          </else-if>
+          <else-if type="post post-weblog software webpage" match="any">
+            <text variable="container-title"/>
+            <text macro="date-zh"/>
+          </else-if>
+          <else>
+            <group>
+              <text macro="publisher-zh"/>
+              <text macro="date-zh"/>
+            </group>
+            <text macro="locator-zh"/>
+          </else>
+        </choose>
+        <text macro="access-zh"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="entry-layout-zh-bibliography">
+    <group delimiter="：">
+      <text macro="author-zh"/>
+      <group delimiter="，">
+        <text macro="title-zh"/>
+        <text macro="translator-zh"/>
+        <choose>
+          <if type="article-journal article-magazine" match="any">
+            <text macro="container-periodical-zh"/>
+          </if>
+          <else-if type="article-newspaper">
+            <text macro="container-newspaper-zh"/>
+          </else-if>
+          <else-if type="chapter">
+            <text macro="container-booklike-zh"/>
+            <group>
+              <text macro="publisher-zh"/>
+              <text macro="date-zh"/>
+            </group>
+          </else-if>
+          <else-if type="paper-conference">
+            <choose>
+              <if variable="container-title">
+                <text macro="container-booklike-zh"/>
+                <group>
+                  <text macro="publisher-zh"/>
+                  <text macro="date-zh"/>
+                </group>
+              </if>
+              <else>
+                <text macro="event-zh"/>
+              </else>
+            </choose>
+          </else-if>
+          <else-if type="collection manuscript personal_communication" match="any">
+            <text macro="date-zh"/>
+            <text macro="archive-zh"/>
+          </else-if>
+          <else-if type="post post-weblog software webpage" match="any">
+            <text variable="container-title"/>
+            <text macro="date-zh"/>
+          </else-if>
+          <else>
+            <group>
+              <text macro="publisher-zh"/>
+              <text macro="date-zh"/>
+            </group>
+          </else>
+        </choose>
+        <text macro="access-zh"/>
+      </group>
+    </group>
+  </macro>
+  <citation>
+    <layout delimiter="；" suffix="。" locale="zh">
+      <text macro="entry-layout-zh-citation"/>
+    </layout>
+    <layout delimiter="; " suffix=".">
+      <text macro="entry-layout-en-citation"/>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" second-field-align="flush">
+    <sort>
+      <!-- 在中英文的参考文献中，请按照拼音字母顺序排序 -->
+      <key macro="author-en"/>
+      <key variable="issued"/>
+    </sort>
+    <layout locale="zh">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout-zh-bibliography" suffix="。"/>
+    </layout>
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout-en-bibliography" suffix="."/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
修正了人民出版社原版本的部分问题，如英文作者用符号连接，英文专著的译者和主编标签、析出文献的年月份放入括号，英文析出文献使用in，中文译著的原作者标注国籍，引用条目显示页码但参考文献不显示。