### PR TITLE
添加东北大学生命科学与健康学院本科生 CSL 样式 

### DIFF
--- a/src/东北大学-生命科学与健康学院（本科）/index.md
+++ b/src/东北大学-生命科学与健康学院（本科）/index.md
@@ -1,0 +1,1615 @@
+<!-- 此文件由脚本自动生成，请勿手动修改！ -->
+<!-- markdownlint-disable -->
+<!-- prettier-ignore -->
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE FILE -->
+
+## 样式预览
+
+### 引注
+
+<sup>[1-8]</sup>
+
+### 参考文献表
+
+<div class="csl-bib-body maxoffset-3 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">扬奎斯特，萨金特．递归宏观经济理论[M]．杨斌，王忠玉，陈彦斌，等，译．2 版．北京：中国人民大学出版社，2010：798．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">Praetzellis A. Death by theory: a tale of mystery and archaeological theory[M/OL]. Rev. ed. Rowman &#38; Littlefield Publishing Group, Inc., 2011: 13[2012-07-26]. <a href="http://lib.myilibrary.com/Open.aspx?id=293666">http://lib.myilibrary.com/Open.aspx?id=293666</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">于潇，刘义，柴跃廷，等．互联网药品可信交易环境中主体资质审核备案模式[J]．清华大学学报（自然科学版），2012，52(11)：1518-1523．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">Veen P H van der, Muller M, Vincken K L, et al. Longitudinal changes in brain volumes and cerebrovascular lesions on MRI in patients with manifest arterial disease: the SMART-MR study[J/OL]. Journal of the Neurological Sciences, 2014, 337(1/2): 112-118[2025-12-02]. <a href="https://pubmed.ncbi.nlm.nih.gov/24314719/">https://pubmed.ncbi.nlm.nih.gov/24314719/</a>. DOI:<a href="https://doi.org/10.1016/j.jns.2013.11.029">10.1016/j.jns.2013.11.029</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">汪学军．中国农业转基因生物研发进展与安全管理[C]//国家环境保护总局生物安全管理办公室．中国国家生物安全框架实施国际合作项目研讨会论文集．北京：中国环境科学出版社，2005：22-25．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">Wang S. Application of improved SOM neural network in intelligent auditing of hospital financial vouchers[C/OL]//2022 6th Asian Conference on Artificial Intelligence Technology (ACAIT). 2022: 2[2025-12-02]. <a href="https://ieeexplore.ieee.org/document/10137867">https://ieeexplore.ieee.org/document/10137867</a>. DOI:<a href="https://doi.org/10.1109/ACAIT56212.2022.10137867">10.1109/ACAIT56212.2022.10137867</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[7]</div><div class="csl-right-inline">肖玲，张雪，王永．数据要素的统计测算方法探究[A/OL]．PSSXiv，2024[2024-09-30]．<a href="https://zsyyb.cn/abs/202408.01096">https://zsyyb.cn/abs/202408.01096</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[8]</div><div class="csl-right-inline">Jenkins S D, Ruostekoski J. Controlled manipulation of light by cooperative response of atoms in an optical lattice[A/OL]. arXiv, 2012[2020-06-24]. <a href="https://doi.org/10.48550/arXiv.1112.6136">https://doi.org/10.48550/arXiv.1112.6136</a>.</div>
+  </div>
+</div>
+
+## 默认测试
+
+### 引注
+
+<sup>[1]</sup><br>
+<sup>[2]</sup><br>
+<sup>[3]</sup><br>
+<sup>[1,3]</sup><br>
+<sup>[1,2,4]</sup><br>
+<sup>[1-3]</sup><br>
+
+
+### GB/T 7714—2025 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-5 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">张伯伟．全唐五代诗格汇考[M]．南京：江苏古籍出版社，2002：288．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">曹凌．中国佛教疑伪经综录[M]．上海：上海古籍出版社，2011：19．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">陈登原．国史旧闻：卷 1[M]．北京：中华书局，2000：29．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">王夫之．宋论[M]．刻本．金陵：湘乡曾国荃，1865．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">顾炎武．昌平山水记；京东考古录[M]．北京：北京古籍出版社，1980．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">钱学森．创建系统学[M]．太原：山西科学技术出版社，2001：序2-3．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[7]</div><div class="csl-right-inline">冯友兰．冯友兰自选集[M]．2 版．北京：首都师范大学出版社，2008：第1版自序．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[8]</div><div class="csl-right-inline">康熙字典：巳集上 水部[M]．同文书局影印本．北京：中华书局，1962：50．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[9]</div><div class="csl-right-inline">战德臣，张丽杰．大学计算机：计算思维与信息素养[M]．3 版．北京：高等教育出版社，2019．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[10]</div><div class="csl-right-inline">哈里森，沃尔德伦．经济数学与金融数学[M]．谢远涛，译．北京：中国人民大学出版社，2012：235-236．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[11]</div><div class="csl-right-inline">牛永敢，孔晓，王阳，等．鼻整形应用解剖学[M]．北京：人民卫生出版社，2019：65-66．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[12]</div><div class="csl-right-inline">扬奎斯特，萨金特．递归宏观经济理论[M]．杨斌，王忠玉，陈彦斌，等，译．2 版．北京：中国人民大学出版社，2010：798．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[13]</div><div class="csl-right-inline">云南省企业联合会，云南省企业家协会，云南民族新闻文化发展研究院．改革开放三十年：云南企业家奋斗史[M]．芒市：德宏民族出版社，2009．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[14]</div><div class="csl-right-inline">赵学功．当代美国外交[M/OL]．北京：社会科学文献出版社，2001[2014-06-11]．<a href="http://www.cadal.zju.edu.cn/book/trySinglePage/33023884/1">http://www.cadal.zju.edu.cn/book/trySinglePage/33023884/1</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[15]</div><div class="csl-right-inline">中国造纸学会．中国造纸年鉴：2003[M/OL]．北京：中国轻工业出版社，2003[2014-04-25]．<a href="http://www.cadal.zju.edu.cn/book/view/25010080">http://www.cadal.zju.edu.cn/book/view/25010080</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[16]</div><div class="csl-right-inline">博伯尔．银行业的未来与人工智能[M]．徐超，译．北京：清华大学出版社，2023：35．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[17]</div><div class="csl-right-inline">図書館用語辞典編集委員会．最新図書館用語大辞典[M]．東京：柏書房株式会社，2004：154．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[18]</div><div class="csl-right-inline">Peebles P Z Jr. Probability, random variable, and random signal principles[M]. 4th ed. New York: McGraw-Hill, 2001.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[19]</div><div class="csl-right-inline">Sadock B J, Sadock V A, Ruiz P, et al. Kaplan &#38; Sadock’s comprehensive textbook of psychiatry: Vol. 1[M]. 9th ed. Philadelphia: Wolters Kluwer Health/Lippincott Williams &#38; Wilkins, 2009.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[20]</div><div class="csl-right-inline">Institute For Art And Architecture, Academy Of Fine Arts Vienna. Wiener Hitze: architecture and storytelling in times of heat[M]. Zürich: Park Books, 2023: 78.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[21]</div><div class="csl-right-inline">Kinchy A. Seeds, sciences, and struggle: the global politics of transgenic crops[M/OL]. Cambridge, Mass.: MIT Press, 2012: 50[2013-07-14]. <a href="http://lib.myilibrary.com?ID=381443">http://lib.myilibrary.com?ID=381443</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[22]</div><div class="csl-right-inline">Praetzellis A. Death by theory: a tale of mystery and archaeological theory[M/OL]. Rev. ed. Rowman &#38; Littlefield Publishing Group, Inc., 2011: 13[2012-07-26]. <a href="http://lib.myilibrary.com/Open.aspx?id=293666">http://lib.myilibrary.com/Open.aspx?id=293666</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[23]</div><div class="csl-right-inline">Torres L, Salisbury F, Yazbeck B, et al. Connecting the library to the curriculum[M/OL]. Singapore: Springer Nature, 2021: 97[2025-12-02]. <a href="https://link.springer.com/10.1007/978-981-16-3868-8">https://link.springer.com/10.1007/978-981-16-3868-8</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[24]</div><div class="csl-right-inline">Boobier T. AI and the future of banking[M]. Chichester: John Wiley &#38; Sons, 2020: 35.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[25]</div><div class="csl-right-inline">Deverell W, Igler D. A companion to California history[M/OL]. New York: John Wiley &#38; Sons, 2013: 21-22[2014-06-24]. <a href="http://onlinelibrary.wiley.com/doi/10.1002/9781444305036/summary">http://onlinelibrary.wiley.com/doi/10.1002/9781444305036/summary</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[26]</div><div class="csl-right-inline">阿扬．谈谈记忆：与诺贝尔获奖得者埃里克·坎德尔的问答[M]．姜海伦，译//《环球科学》杂志社．认识记忆力：关于学习、思考与遗忘的脑科学．北京：机械工业出版社，2023：15-18．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[27]</div><div class="csl-right-inline">周易外传：卷5[M]//王夫之．船山全书：第1册．修订版．长沙：岳麓书社，2011：983-1029．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[28]</div><div class="csl-right-inline">程根伟．1998年长江洪水的成因与减灾对策[M]//许厚泽，赵其国．长江流域洪涝灾害与科技对策．北京：科学出版社，1999：32-36．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[29]</div><div class="csl-right-inline">李约瑟．题词[M]//苏克福，管成学，邓明鲁．苏颂与《本草图经》研究．长春：长春出版社，1991：扉页．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[30]</div><div class="csl-right-inline">陈晋镳，张惠民，朱士兴，等．蓟县震旦亚界的研究[M]//中国地质科学院天津地质矿产研究所．中国震旦亚界．天津：天津科学技术出版社，1980：56-114．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[31]</div><div class="csl-right-inline">马克思．政治经济学批判[M]//马克思，恩格斯．马克思恩格斯全集：卷 35．2 版．北京：人民出版社，2013：302．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[32]</div><div class="csl-right-inline">大黄[M]//国家药典委员会．中华人民共和国药典：一部．2020版．北京：中国医药科技出版社，2020：24-25．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[33]</div><div class="csl-right-inline">楼梦麟，杨燕．汶川地震基岩地震动特征分析[M/OL]//同济大学土木工程防灾国家重点实验室．汶川地震震害研究．上海：同济大学出版社，2011：11-12[2013-05-09]．<a href="http://apabi.lib.pku.edu.cn/usp/pku/pub.mvc?pid=book.detail&#38;metaid=m.20120406-YPT-889-0010">http://apabi.lib.pku.edu.cn/usp/pku/pub.mvc?pid=book.detail&#38;metaid=m.20120406-YPT-889-0010</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[34]</div><div class="csl-right-inline">Weinstein L, Swartz M N. Pathogenic properties of invading microorganisms[M]//Sodeman W A Jr, Sodeman W A. Pathologic physiology: mechanisms of disease. 5th ed. Philadelphia: Saunders, 1974: 457-472.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[35]</div><div class="csl-right-inline">Roberson J A, Burneson E G. Drinking water standards, regulations and goals[M/OL]//American Water Works Association. Water quality &#38; treatment: a handbook on drinking water. 6th ed. New York: McGraw-Hill, 2011: 1.1-1.36[2012-12-10]. <a href="http://lib.myilibrary.com/Open.aspx?id=291430">http://lib.myilibrary.com/Open.aspx?id=291430</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[36]</div><div class="csl-right-inline">中华医学会湖北分会．临床内科杂志[J]．1984，1984，1（1）—．武汉：中华医学会湖北分会，1984．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[37]</div><div class="csl-right-inline">中国图书馆学会．图书馆学通讯[J]．1957-[1990]，1957（1）—1990（4）．北京：北京图书馆，1957-1990．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[38]</div><div class="csl-right-inline">American Association for the Advancement of Science. Science[J]. 1883, 1883，1（1）—. Washington, D.C.: American Association for the Advancement of Science, 1883.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[39]</div><div class="csl-right-inline">Public library quarterly[J/OL]. 1979, 1979，1（1）—. Philadelphia: Taylor &#38; Francis, 1979[2025-02-28]. <a href="http://www.tandfonline.com/loi/wplq">http://www.tandfonline.com/loi/wplq</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[40]</div><div class="csl-right-inline">杨洪升．四库馆私家抄校书考略[J]．文献，2013(1)：56-75．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[41]</div><div class="csl-right-inline">丁文详．数字革命与竞争国际化[N]．中国青年报，2000-11-20(15)．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[42]</div><div class="csl-right-inline">于潇，刘义，柴跃廷，等．互联网药品可信交易环境中主体资质审核备案模式[J]．清华大学学报（自然科学版），2012，52(11)：1518-1523．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[43]</div><div class="csl-right-inline">久保智康．花枝蝶鸟方镜的镜范：以平安后期的铜镜制作工艺为中心[J]．东方博物，2009(1)：85-92．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[44]</div><div class="csl-right-inline">陈建军．从数字地球到智慧地球[J/OL]．国土资源导刊，2010，7(10)：93[2013-03-20]．<a href="http://d.g.wanfangdata.com.cn/Periodical_hunandz201010038.aspx">http://d.g.wanfangdata.com.cn/Periodical_hunandz201010038.aspx</a>．DOI:<a href="https://doi.org/10.3969/j.issn.1672-5603.2010.10.038">10.3969/j.issn.1672-5603.2010.10.038</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[45]</div><div class="csl-right-inline">陈缮真．探索微观世界的无穷奥秘（科技大观）[N/OL]．人民日报，2022-08-16(17)[2015-02-28]．<a href="http://paper.people.com.cn/rmrb/html/2022-08/16/nw.D110000renmrb_20220816_3-17.htm">http://paper.people.com.cn/rmrb/html/2022-08/16/nw.D110000renmrb_20220816_3-17.htm</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[46]</div><div class="csl-right-inline">李幼平，王莉．循证医学研究方法：附视频[J/OL]．中华移植杂志（电子版），2010，4(3)：225-228[2014-06-09]．<a href="http://www.cqvip.com/Read/Read.aspx?id=36658332">http://www.cqvip.com/Read/Read.aspx?id=36658332</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[47]</div><div class="csl-right-inline">张群，程志宝，石志飞．惯性增强动力吸振器-浮置板轨道低频减振性能研究[J/OL]．铁道学报，2024[2025-02-28]．<a href="http://kns.cnki.net/kcms/detail/11.2104.u.20240507.1737.002.html">http://kns.cnki.net/kcms/detail/11.2104.u.20240507.1737.002.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[48]</div><div class="csl-right-inline">张群，程志宝，石志飞．惯性增强动力吸振器-浮置板轨道低频减振性能研究[J]．铁道学报，2024，46(8)：102-111．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[49]</div><div class="csl-right-inline">徐建委．历史的起点：《史记》中的时间设置及其意义[J/OL]．北京大学学报（哲学社会科学版），2025，62(2)：117-127[2025-12-02]．<a href="https://ncpssd.org/Literature/articleinfo?id=BJDXXBZXSHKXB2025002012&#38;synUpdateType=&#38;type=journalArticle&#38;typename=%E4%B8%AD%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&#38;nav=1&#38;langType=1&#38;pageUrl=https%253A%252F%252Fncpssd.org%252Fjournal%252Fdetails%253Fgch%253D81274X%2526nav%253D1%2526langType%253D1">https://ncpssd.org/Literature/articleinfo?id=BJDXXBZXSHKXB2025002012&#38;synUpdateType=&#38;type=journalArticle&#38;typename=%E4%B8%AD%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&#38;nav=1&#38;langType=1&#38;pageUrl=https%253A%252F%252Fncpssd.org%252Fjournal%252Fdetails%253Fgch%253D81274X%2526nav%253D1%2526langType%253D1</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[50]</div><div class="csl-right-inline">王利平，王福新，刘洪．过冷大水滴环境粒径分布模拟方法研究进展[J]．航空学报，2024，45(增刊1)：730570．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[51]</div><div class="csl-right-inline">Caplan P. Cataloging internet resources[J]. The Public-Access Computer Systems Review, 1993, 4(2): 61-66.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[52]</div><div class="csl-right-inline">Saito M, Miyazaki K. Jadeite-bearing metagabbro in serpentinite melange of the “Kurosegawa Belt” in Izumi Town, Yatsushiro City, Kumamoto Prefecture, central Kyushu[J]. Bulletin of the Geological Survey of Japan, 2006, 57(5/6): 169-176.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[53]</div><div class="csl-right-inline">Des Marais D J, Strauss H, Summons R E, et al. Carbon isotope evidence for the stepwise oxidation of the Proterozoic environment[J]. Nature, 1992, 359: 605-609.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[54]</div><div class="csl-right-inline">Park J R, Tosaka Y. Metadata quality control in digital repositories and collections: criteria, semantics, and mechanisms[J/OL]. Cataloging &#38; Classification Quarterly, 2010, 48(8): 696-715[2013-09-05]. <a href="https://www.tandfonline.com/doi/full/10.1080/01639374.2010.508711">https://www.tandfonline.com/doi/full/10.1080/01639374.2010.508711</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[55]</div><div class="csl-right-inline">Frese K S, Katus H A, Meder B. Next-generation sequencing: from understanding biology to personalized medicine[J/OL]. Biology, 2013, 2(1): 378-398[2013-03-19]. <a href="http://www.mdpi.com/2079-7737/2/1/378">http://www.mdpi.com/2079-7737/2/1/378</a>. DOI:<a href="https://doi.org/10.3390/biology2010378">10.3390/biology2010378</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[56]</div><div class="csl-right-inline">Myburg A A, Grattapaglia D, Tuskan G A, et al. The genome of <i>Eucalyptus grandis</i>[J/OL]. Nature, 2014, 510: 356-362[2014-06-25]. <a href="https://www.nature.com/articles/nature13308.pdf">https://www.nature.com/articles/nature13308.pdf</a>. DOI:<a href="https://doi.org/10.1038/nature13308">10.1038/nature13308</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[57]</div><div class="csl-right-inline">Santer R D, Akanyeti O. Using artificial neural networks to explain the attraction of jewel beetles (Coleoptera: Buprestidae) to colored traps[J/OL]. Insect science, 2025[2025-02-28]. <a href="https://webofscience.clarivate.cn/wos/woscc/full-record/WOS:001398099800001">https://webofscience.clarivate.cn/wos/woscc/full-record/WOS:001398099800001</a>. DOI:<a href="https://doi.org/10.1111/1744-7917.13496">10.1111/1744-7917.13496</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[58]</div><div class="csl-right-inline">Shinotsuka H, Nagata K, Siriwardana M, et al. Sample structure prediction from measured XPS data using Bayesian estimation and SESSA simulator[J/OL]. Journal of electron spectroscopy and related phenomena, 2023, 267: 147370[2025-02-28]. <a href="https://doi.org/10.1016/j.elspec.2023.147370">https://doi.org/10.1016/j.elspec.2023.147370</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[59]</div><div class="csl-right-inline">Veen P H van der, Muller M, Vincken K L, et al. Longitudinal changes in brain volumes and cerebrovascular lesions on MRI in patients with manifest arterial disease: the SMART-MR study[J/OL]. Journal of the Neurological Sciences, 2014, 337(1/2): 112-118[2025-12-02]. <a href="https://pubmed.ncbi.nlm.nih.gov/24314719/">https://pubmed.ncbi.nlm.nih.gov/24314719/</a>. DOI:<a href="https://doi.org/10.1016/j.jns.2013.11.029">10.1016/j.jns.2013.11.029</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[60]</div><div class="csl-right-inline">李妍，王莹．医疗机构保洁人员“一前五后”手卫生干预效果研究[C]//中华预防医学会医院感染控制分会第31次全国医院感染学术年会．2022：2．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[61]</div><div class="csl-right-inline">牛志明，Swingland I R，雷光春．综合湿地管理：综合湿地管理国际研讨会论文集[M]．北京：海洋出版社，2012．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[62]</div><div class="csl-right-inline">中国社会科学院台湾史研究中心．台湾光复六十五周年暨抗战史实学术研讨会论文集[M]．北京：九州出版社，2012．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[63]</div><div class="csl-right-inline">肖希明，石庆功，刘奕．民国图书馆学教育的社会贡献[C]//纪念北京大学图书馆学教育100周年研讨会论文集．北京：北京大学信息管理系，2024：134-147．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[64]</div><div class="csl-right-inline">汪学军．中国农业转基因生物研发进展与安全管理[C]//国家环境保护总局生物安全管理办公室．中国国家生物安全框架实施国际合作项目研讨会论文集．北京：中国环境科学出版社，2005：22-25．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[65]</div><div class="csl-right-inline">贾东琴，柯平．面向数字素养的高校图书馆数字服务体系研究[C]//中国图书馆学会．中国图书馆学会年会论文集：2011年卷．北京：国家图书馆出版社，2011：45-52．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[66]</div><div class="csl-right-inline">陈志勇．中国财税文化价值研究：“中国财税文化国际学术研讨会”论文集[M/OL]．北京：经济科学出版社，2011[2013-10-14]．<a href="http://apabi.lib.pku.edu.cn/usp/pku/pub.mvc?pid=book.detail&#38;metaid=m.20110628-BPO-889-0135&#38;cult=CN">http://apabi.lib.pku.edu.cn/usp/pku/pub.mvc?pid=book.detail&#38;metaid=m.20110628-BPO-889-0135&#38;cult=CN</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[67]</div><div class="csl-right-inline">Wang S. Application of improved SOM neural network in intelligent auditing of hospital financial vouchers[C/OL]//2022 6th Asian Conference on Artificial Intelligence Technology (ACAIT). 2022: 2[2025-12-02]. <a href="https://ieeexplore.ieee.org/document/10137867">https://ieeexplore.ieee.org/document/10137867</a>. DOI:<a href="https://doi.org/10.1109/ACAIT56212.2022.10137867">10.1109/ACAIT56212.2022.10137867</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[68]</div><div class="csl-right-inline">Yu Y, Pan E, Wang X, et al. Unmixing before fusion: a generalized paradigm for multi-source-based hyperspectral image synthesis[C/OL]//CVPR. 2024: 4[2025-12-02]. <a href="https://openaccess.thecvf.com/content/CVPR2024/html/Yu_Unmixing_Before_Fusion_A_Generalized_Paradigm_for_Multi-Source-based_Hyperspectral_Image_CVPR_2024_paper.html">https://openaccess.thecvf.com/content/CVPR2024/html/Yu_Unmixing_Before_Fusion_A_Generalized_Paradigm_for_Multi-Source-based_Hyperspectral_Image_CVPR_2024_paper.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[69]</div><div class="csl-right-inline">Yufin S A. Geoecology and computers: proceedings of the Third International Conference on Advances of Computer Methods in Geotechnical and Geoenvironmental Engineering, Moscow, Russia, 1-4 February 2000[M]. Rotterdam: A. A. Balkema, 2000.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[70]</div><div class="csl-right-inline">Babu B V, Nagar A, Deep K, et al. Proceedings of the Second International Conference on Soft Computing for Problem Solving (SocProS 2012), December 28-30, 2012[M]. New Delhi: Springer, 2014.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[71]</div><div class="csl-right-inline">Fourney M E. Advances in holographic photoelasticity[C]//Gottenberg W G. Symposium on Applications of Holography in Mechanics, August 23-25, 1971, University of Southern California, Los Angeles, California. New York: ASME, 1971: 17-38.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[72]</div><div class="csl-right-inline">王琦．融合星载GNSS-R和SAR数据的高时空分辨率土壤湿度反演方法研究[D]．武汉：武汉大学，2022：87．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[73]</div><div class="csl-right-inline">金燕萍．社交媒体时代的虚假信息研究[D/OL]．温州：温州大学，2020：16[2025-12-02]．<a href="https://d.wanfangdata.com.cn/thesis/D02216281">https://d.wanfangdata.com.cn/thesis/D02216281</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[74]</div><div class="csl-right-inline">何筱梅．新媒体时代原生广告的策略与发展研究[D/OL]．武汉：武汉大学，2016：24-25[2025-02-28]．<a href="http://paperright.lib.whu.edu.cn/read/pdfindex1.jsp?fid=2f1d8c4e156d9863466de341e4790782">http://paperright.lib.whu.edu.cn/read/pdfindex1.jsp?fid=2f1d8c4e156d9863466de341e4790782</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[75]</div><div class="csl-right-inline">井丽南．支持状态可编程的SDN交换机关键技术研究[D/OL]．北京：中国科学院大学，2022：43[2025-12-02]．<a href="http://dpaper.las.ac.cn/Dpaper/detail/detailNew?paperID=20209289">http://dpaper.las.ac.cn/Dpaper/detail/detailNew?paperID=20209289</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[76]</div><div class="csl-right-inline">Cairns B R. Infrared spectroscopic studies on solid oxygen[D]. Berkeley: University of California, 1965: 15.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[77]</div><div class="csl-right-inline">Christou A. Improving knowledge graph understanding with contextual views[D/OL]. Ohio: Wright State University, 2024: 18[2025-02-28]. <a href="http://rave.ohiolink.edu/etdc/view?acc_num=wright1715878159408301">http://rave.ohiolink.edu/etdc/view?acc_num=wright1715878159408301</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[78]</div><div class="csl-right-inline">中国互联网络信息中心．第29次中国互联网络发展状况统计报告[R/OL]．(2012-01-16)[2013-03-26]．<a href="https://www.cnnic.net.cn/NMediaFile/old_attach/P020120612484958777344.pdf">https://www.cnnic.net.cn/NMediaFile/old_attach/P020120612484958777344.pdf</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[79]</div><div class="csl-right-inline">汤万金，杨跃翔，刘文，等．人体安全重要技术标准研制最终报告：7178999X-2006BAK04A10/10.2013[R/OL]．(2013-09-30)[2014-06-24]．<a href="http://www.nstrs.cn/xiangxiBG.aspx?id=41707">http://www.nstrs.cn/xiangxiBG.aspx?id=41707</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[80]</div><div class="csl-right-inline">中国信息通信研究院，中国电信股份有限公司研究院，中国移动通信研究院，等．电信业发展白皮书：2023：新时代高质量发展探索[R/OL]．(2023-12-28)[2025-02-28]．<a href="http://www.caict.ac.cn/kxyj/qwfb/bps/202312/P020240326615399026294.pdf">http://www.caict.ac.cn/kxyj/qwfb/bps/202312/P020240326615399026294.pdf</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[81]</div><div class="csl-right-inline">Calkin D E, Ager A A, Thompson M P. A comparative risk assessment framework for wildland fire management: the 2010 cohesive strategy science report: RMRS-GTR-262[R/OL]. 2011: 8-9[2025-12-02]. <a href="https://www.fs.usda.gov/rm/pubs/rmrs_gtr262.pdf">https://www.fs.usda.gov/rm/pubs/rmrs_gtr262.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[82]</div><div class="csl-right-inline">U.S. Department of Transportation Federal Highway Administration. Guidelines for handling excavated acid-producing material: PB 91-194001[R]. Springfield: U.S. Department of Commerce National Information Service, 1990: 25.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[83]</div><div class="csl-right-inline">United Nations Department of Economic and Social Affairs. United Nations e-government survey 2024: accelerating digital transformation for sustainable development[R/OL]. [2025-02-28]. <a href="https://publicadministration.un.org/egovkb/en-us/Reports/UN-E-Government-Survey-2024">https://publicadministration.un.org/egovkb/en-us/Reports/UN-E-Government-Survey-2024</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[84]</div><div class="csl-right-inline">全国信息与文献标准化技术委员会．信息与文献 资源描述：GB/T 3792—2021[S]．2021．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[85]</div><div class="csl-right-inline">全国信息技术标准化技术委员会．信息技术 先进音视频编码 第16部分：广播电视视频：GB/T 20090.16—2016[S]．2016．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[86]</div><div class="csl-right-inline">工业和信息化部．信息技术  中文编码字符集：GB 18030—2022[S/OL]．(2022-07-19)[2025-12-02]．<a href="http://c.gb688.cn/bzgk/gb/showGb?type=online&#38;hcno=A1931A578FE14957104988029B0833D3">http://c.gb688.cn/bzgk/gb/showGb?type=online&#38;hcno=A1931A578FE14957104988029B0833D3</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[87]</div><div class="csl-right-inline">国家能源局．水电工程水温实时监测系统技术规范：NB/T 10386—2020[S]．2020．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[88]</div><div class="csl-right-inline">ISO. Audit data collection: ISO 21378:2019[S]. 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[89]</div><div class="csl-right-inline">International Electrotechnical Commission (IEC). Software interface for maintenance information collection and analysis (SIMICA): exchanging test results and session information via the eXtensible Markup Language (XML): IEC/IEEE 61636-1:2021[S]. New York: IEEE, 2021.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[90]</div><div class="csl-right-inline">IEEE approved draft standard for information technology--telecommunications and information exchange between systems local and metropolitan area networks--specific requirements Part 11: wireless LAN Medium Access Control (MAC) and Physical Layer (PHY) specifications amendment 3: wake-up radio operation: IEEE P802.11ba/D8.0-2020[S]. New York: IEEE, 2020.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[91]</div><div class="csl-right-inline">American Institute of Aeronautics and Astronautics (AIAA). Guide to lithium battery safety for space applications: AIAA G-136-2022[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[92]</div><div class="csl-right-inline">Explosive atmospheres — Part 20-2: Material characteristics — Combustible dusts test methods: ISO/IEC 80079-20-2:2016(en)[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[93]</div><div class="csl-right-inline">Atmosphères explosives — Partie 20-2: Caractéristiques des produits — Méthodes d’essai des poussières combustibles：ISO/IEC 80079-20-2:2016(fr)[S]．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[94]</div><div class="csl-right-inline">邓一刚．全智能节电器：CN101106276A[P]．2008-01-16．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[95]</div><div class="csl-right-inline">张凯军，赵永杰，陈朝岗．轨道火车及高速轨道火车紧急安全制动辅助装置：CN202827616U[P]．2013-03-27．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[96]</div><div class="csl-right-inline">李华，王昊，康佐．一种拼接式桥梁模型：CN218214474U[P/OL]．2023-01-03[2025-02-28]．<a href="http://patentscope2.wipo.int/search/en/detail.jsf?docId=CN390029302&#38;_cid=JP1-MAY1P5-04922-1">http://patentscope2.wipo.int/search/en/detail.jsf?docId=CN390029302&#38;_cid=JP1-MAY1P5-04922-1</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[97]</div><div class="csl-right-inline">石顺祥，许海平，孙艳玲，等．光折变自适应光外差探测方法：CN1338652A[P/OL]．2002-03-06[2002-05-28]．<a href="http://211.152.9.47/sipoasp/zljs/hyjs-yx-new.asp?recid=01128777.2&#38;leixin=0">http://211.152.9.47/sipoasp/zljs/hyjs-yx-new.asp?recid=01128777.2&#38;leixin=0</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[98]</div><div class="csl-right-inline">冀超．一种荒漠化地区生态植被综合培育种植方法：CN1318281A[P/OL]．2001-10-24[2002-05-28]．<a href="http://211.152.9.47/sipoasp/zlijs/hyjs-yx-new.asp?recid=01129210.5&#38;leixin=0">http://211.152.9.47/sipoasp/zlijs/hyjs-yx-new.asp?recid=01129210.5&#38;leixin=0</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[99]</div><div class="csl-right-inline">史国华，樊金宇，何益，等．光コヒーレンス断層拡張現実に基づく手術顕微鏡撮像システム及び方法：JP2022539784A[P/OL]．2022-09-13[2025-02-28]．<a href="https://pss-system.cponline.cnipa.gov.cn/documents/detail?prevPageTit=changgui">https://pss-system.cponline.cnipa.gov.cn/documents/detail?prevPageTit=changgui</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[100]</div><div class="csl-right-inline">Tachibana R, Shimizu S, Kobayashi S, et al. Electronic watermarking method and system: US2002061118A1[P/OL]. 2001-06-28[2013-11-11]. <a href="https://worldwide.espacenet.com/patent/search/family/018694900/publication/US2002061118A1?q=US89404301A">https://worldwide.espacenet.com/patent/search/family/018694900/publication/US2002061118A1?q=US89404301A</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[101]</div><div class="csl-right-inline">Tristram M, Skarshewski P, Tristram I, et al. Storage and delivery system: AU2022228203A1[P/OL]. 2022-10-06[2025-02-28]. <a href="https://worldwide.espacenet.com/patent/search/family/061561249/publication/AU2022228203A1?q=AU2022228203A">https://worldwide.espacenet.com/patent/search/family/061561249/publication/AU2022228203A1?q=AU2022228203A</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[102]</div><div class="csl-right-inline">中国科学院文献情报中心．中国科学院科技论文预发布平台[EB/OL]．[2025-03-06]．<a href="https://chinaxiv.org/home.htm">https://chinaxiv.org/home.htm</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[103]</div><div class="csl-right-inline">北京鲁迅博物馆．北京鲁迅博物馆志愿服务章程[EB/OL]．(2021-04-21)[2023-05-02]．<a href="http://www.luxunmuseum.com.cn/html/202104/a11310.htm">http://www.luxunmuseum.com.cn/html/202104/a11310.htm</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[104]</div><div class="csl-right-inline">杨立华．《庄子》读不懂？看完这一篇“导读”就明白了[Z/OL]．(2022-10-26)[2023-05-02]．<a href="https://www.bilibili.com/video/BV1t84y1B7vv/">https://www.bilibili.com/video/BV1t84y1B7vv/</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[105]</div><div class="csl-right-inline">高等教育文献保障系统．馆际互借与文献传递服务[EB/OL]．[2025-06-21]．<a href="http://home.calis.edu.cn/pages/list.html?id=4101e184-7f64-4798-a5e1-8e37aa6994fc">http://home.calis.edu.cn/pages/list.html?id=4101e184-7f64-4798-a5e1-8e37aa6994fc</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[106]</div><div class="csl-right-inline">许振超．“好好干，当一个好工人”[EB/OL]．(2025-02-17)[2025-06-22]．<a href="https://cpc.people.com.cn/n1/2025/0217/c443712-40419790.html">https://cpc.people.com.cn/n1/2025/0217/c443712-40419790.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[107]</div><div class="csl-right-inline">[《昨日之歌》图书封面][Z/OL]．(2023-03-06)[2025-06-22]．<a href="http://www.luxunmuseum.com.cn/uploads/allimg/150813/1-150Q31952110-L.jpg">http://www.luxunmuseum.com.cn/uploads/allimg/150813/1-150Q31952110-L.jpg</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[108]</div><div class="csl-right-inline">仉尚航．开放世界中的实体基础模型[EB/OL]．(2024-12-24)[2025-01-02]．<a href="https://www.ppthub.com.cn/view/19309">https://www.ppthub.com.cn/view/19309</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[109]</div><div class="csl-right-inline">西黄丸[EB/OL]．(2023-10-07)[2025-08-26]．<a href="https://ydz.chp.org.cn/#/item?bookId=1&#38;entryId=1154">https://ydz.chp.org.cn/#/item?bookId=1&#38;entryId=1154</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[110]</div><div class="csl-right-inline">Library of Congress[EB/OL]. [2020-06-12]. <a href="https://www.loc.gov/">https://www.loc.gov/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[111]</div><div class="csl-right-inline">International Organization for Standardization. ISO homepage[EB/OL]. [2020-10-06]. <a href="https://www.iso.org/home.html">https://www.iso.org/home.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[112]</div><div class="csl-right-inline">António M，Pepper L．Histórias de Portugal: livros caídos[EB/OL]．(2019-07-13)[2025-01-02]．<a href="https://arquivo.pt/wayback/20190905210731/http://publico.pt/2019/07/13/sociedade/noticia/podcast-historias-portugal-cuidadores-1879731">https://arquivo.pt/wayback/20190905210731/http://publico.pt/2019/07/13/sociedade/noticia/podcast-historias-portugal-cuidadores-1879731</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[113]</div><div class="csl-right-inline">Bevington D, Brown J R. William Shakespeare[EB/OL]. (2025-01-01)[2025-01-03]. <a href="https://www.britannica.com/biography/William-Shakespeare">https://www.britannica.com/biography/William-Shakespeare</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[114]</div><div class="csl-right-inline">Zotero. [Zotero download][EB/OL]. [2024-04-08]. <a href="https://www.zotero.org/download/">https://www.zotero.org/download/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[115]</div><div class="csl-right-inline">李鸿章．奏请上海道库洋务外销要款无款可筹仍拨药厘接济事：04-01-35-0399-039[A]．1887．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[116]</div><div class="csl-right-inline">湖北省建设厅．湖北省建设厅关于检发实业部农工矿业团体登记规则的布告、训令及湖北省政府的训令[Z/OL]．1931[2025-02-28]．<a href="https://www.hbda.gov.cn/pdf/LS031-001-0001-001.PDF.PDF">https://www.hbda.gov.cn/pdf/LS031-001-0001-001.PDF.PDF</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[117]</div><div class="csl-right-inline">中国人民解放军武汉市军事管制委员会接管国立武汉大学的文告[Z/OL]．1949[2025-02-28]．<a href="https://archive.whu.edu.cn/index/forwardView/20/51">https://archive.whu.edu.cn/index/forwardView/20/51</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[118]</div><div class="csl-right-inline">Fitzwilliam H. [Letter to Bess of Hardwick][A/OL]. (1570-07-28)[2025-02-28]. <a href="https://www.bessofhardwick.org/letter.jsp?letter=25">https://www.bessofhardwick.org/letter.jsp?letter=25</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[119]</div><div class="csl-right-inline">胡健民．东南极拉斯曼丘陵地区地质图[CM]．北京：科学出版社，2021．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[120]</div><div class="csl-right-inline">刘祥沈．沈阳市政区图[CM]．武汉：武汉大学出版社，2016．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[121]</div><div class="csl-right-inline">中工武大设计研究有限公司．阳新县标准地名图[CM]．武汉：武汉大学出版社，2019．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[122]</div><div class="csl-right-inline">吴自银，温珍河．中国南部海域海底地形图[CM]．北京：科学出版社，2019．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[123]</div><div class="csl-right-inline">国家测绘地理信息局．一带一路经济走廊及其途经城市分布地势图[CM/OL]．[2025-12-02]．<a href="http://ydyl.china.com.cn/2016-10/27/content_39582227.htm">http://ydyl.china.com.cn/2016-10/27/content_39582227.htm</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[124]</div><div class="csl-right-inline">訾冬梅，高秀静．内蒙古自治区地图册[CM]．新版．北京：中国地图出版社，2006．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[125]</div><div class="csl-right-inline">谭其骧．中国历史地图集：第2册[CM]．北京：地图出版社，1982：6．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[126]</div><div class="csl-right-inline">童世亨．京兆直隶图[CM/OL]．上海：商务印书馆，1926[2025-02-28]．<a href="http://gdt-lib-whu-edu-cn.vpn.whu.edu.cn:8118/imginfo.html?ty%3Dmap%26id%3D4861">http://gdt-lib-whu-edu-cn.vpn.whu.edu.cn:8118/imginfo.html?ty%3Dmap%26id%3D4861</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[127]</div><div class="csl-right-inline">Cribb R. Historical atlas of Indonesia[CM]. Abingdon: Routledge, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[128]</div><div class="csl-right-inline">Coastal wetlands map of China continent[CM]. Beijing: China Ocean Press, 2024: 50.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[129]</div><div class="csl-right-inline">彭守璋．1901—2023年中国1km分辨率逐月降水量数据集[DS/OL]．西北农林科技大学水土保持研究所，2024[2024-11-25]．<a href="https://www.geodata.cn/main/face_science_detail?guid=192891852410344&#38;typeName=face_science">https://www.geodata.cn/main/face_science_detail?guid=192891852410344&#38;typeName=face_science</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[130]</div><div class="csl-right-inline">刘时银，郭万钦，许君利．中国第二次水川编目科学数据：2006-2011[DS/OL]．中国科学院寒区早区环境与工程研究所冰冻圈科学国家重点实验室，2012[2024-11-25]．<a href="https://data.tpdc.ac.cn/zh-hans/data/f92a4346-a33f-497d-9470-2b357ccb4246/">https://data.tpdc.ac.cn/zh-hans/data/f92a4346-a33f-497d-9470-2b357ccb4246/</a>．DOI:<a href="https://doi.org/10.3972/glacier001.2013.db">10.3972/glacier001.2013.db</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[131]</div><div class="csl-right-inline">周壮，李盛阳，吴薇，等．天宫二号遥感图像自然景物分类数据集[DS/OL]．国家基础学科公共科学数据中心，2023[2025-07-15]．<a href="https://www.nbsdc.cn/general/dataLinks/CSTR:16666.11.nbsdc.tfpbwtqf">https://www.nbsdc.cn/general/dataLinks/CSTR:16666.11.nbsdc.tfpbwtqf</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[132]</div><div class="csl-right-inline">郑涵，于贵瑞，朱先进，等．2000—2010年中国典型陆地生态系统实际蒸散量和水分利用效率数据[DS/OL]．Science Data Bank，2018[2025-02-14]．<a href="https://cstr.cn/31253.11.sciencedb.610">https://cstr.cn/31253.11.sciencedb.610</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[133]</div><div class="csl-right-inline">黄土高原科学数据中心（西北农林科技大学水土保持研究所）．青海省县域教育、卫生发展指标（2001—2022年）[DS/OL]．国家地理资源科学数据中心-黄土高原分中心，2024[2025-07-10]．<a href="https://loess.geodata.cn/data/datadetails.html?dataguid=58691800703558">https://loess.geodata.cn/data/datadetails.html?dataguid=58691800703558</a>．DOI:<a href="https://doi.org/10.12041/geodata.58691800703558.ver1.db">10.12041/geodata.58691800703558.ver1.db</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[134]</div><div class="csl-right-inline">王继民，罗鹏程，赵常煜，等．人文社会科学数据集检索方法研究的数据集[DS/OL]．北京大学开放研究数据平台，2025[2025-07-10]．<a href="http://opendata.pku.edu.cn/dataset.xhtml?persistentId=doi:10.18170/DVN/R96MSN">http://opendata.pku.edu.cn/dataset.xhtml?persistentId=doi:10.18170/DVN/R96MSN</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[135]</div><div class="csl-right-inline">Sugarman L, Markham S. Students in a selective high school: some vocationally oriented data[DS/OL]. UK Data Service, 1980[2025-07-10]. <a href="https://beta.ukdataservice.ac.uk/datacatalogue/studies/study?id=996">https://beta.ukdataservice.ac.uk/datacatalogue/studies/study?id=996</a>. DOI:<a href="https://doi.org/10.5255/UKDA-SN-996-1">10.5255/UKDA-SN-996-1</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[136]</div><div class="csl-right-inline">Zhong X, Yan Q, Li G. Long time series nighttime light dataset of China (2000-2020)[DS/OL]. Global Change Research Data Publishing &#38; Repository, 2022[2024-11-25]. <a href="http://www.geodoi.ac.cn/edoi.aspx?DOI=10.3974/geodb.2022.06.01.V1">http://www.geodoi.ac.cn/edoi.aspx?DOI=10.3974/geodb.2022.06.01.V1</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[137]</div><div class="csl-right-inline">IHME. Global Burden of Disease Study 2019 (GBD2019) data resources[DS/OL]. Global Health Data Exchange, 2021[2024-11-25]. <a href="https://ghdx.healthdata.org/gbd-2019">https://ghdx.healthdata.org/gbd-2019</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[138]</div><div class="csl-right-inline">方向明，曹迎杰．元宇宙在图书馆的应用：理论研究与实践进展[A/OL]．ChinaXiv，2023[2024-09-30]．<a href="http://www.chinaxiv.org/abs/202303.00020">http://www.chinaxiv.org/abs/202303.00020</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[139]</div><div class="csl-right-inline">肖玲，张雪，王永．数据要素的统计测算方法探究[A/OL]．PSSXiv，2024[2024-09-30]．<a href="https://zsyyb.cn/abs/202408.01096">https://zsyyb.cn/abs/202408.01096</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[140]</div><div class="csl-right-inline">Bloss C S, Wineinger N E, Peters M, et al. A prospective randomized trial examining health care utilization in individuals using multiple smartphone-enabled biosensors[A/OL]. bioRxiv, 2015[2018-07-12]. <a href="https://doi.org/10.1101/029983">https://doi.org/10.1101/029983</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[141]</div><div class="csl-right-inline">Jenkins S D, Ruostekoski J. Controlled manipulation of light by cooperative response of atoms in an optical lattice[A/OL]. arXiv, 2012[2020-06-24]. <a href="https://doi.org/10.48550/arXiv.1112.6136">https://doi.org/10.48550/arXiv.1112.6136</a>.</div>
+  </div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《心理学报》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-4 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">张三．中国心理学的过去与未来[J]．心理学报，2008，40：210-215．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">张三，李四．中国心理学的过去与未来[J]．心理学报，2008，40：210-215．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">Mou W, McNamara T P. Intrinsic frames of reference in spatial memory[J/OL]. Journal of Experimental Psychology: Learning, Memory, and Cognition, 2002, 28: 162-170. DOI:<a href="https://doi.org/10.1037/0278-7393.28.1.162">10.1037/0278-7393.28.1.162</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">赵一，钱二，孙三，等．中国心理学的过去与未来[J]．心理学报，2008，40：210-215．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">Mou W, Zhang K, McNamara T P. Frames of reference in spatial memories acquired from language[J/OL]. Journal of Experimental Psychology: Learning, Memory, and Cognition, 2004, 30: 171-180. DOI:<a href="https://doi.org/10.1037/0278-7393.30.1.171">10.1037/0278-7393.30.1.171</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">赵一一，钱二，孙三，等．中国心理学的过去与未来[J]．心理学报，2008，40：210-215．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[7]</div><div class="csl-right-inline">Wolchik S A, West S G, Sandler I N, et al. An experimental evaluation of theory-based mother and mother-child programs for children of divorce[J]. Journal of Consulting and Clinical Psychology, 2000, 68(5): 843-856.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[8]</div><div class="csl-right-inline">张三，李四．中国心理学的过去与未来[J]．心理学报．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[9]</div><div class="csl-right-inline">Huestegge S M, Raettig T, Huestegge L. Are face-incongruent voices harder to process? Effects of face–voice gender incongruency on basic cognitive information processing[J/OL]. Experimental Psychology, 2019. DOI:<a href="https://doi.org/10.1027/1618-3169/a000440">10.1027/1618-3169/a000440</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[10]</div><div class="csl-right-inline">Burin D, Kilteni K, Rabuffetti M, et al. Body ownership increases the interference between observed and executed movements[J/OL]. PLOS ONE, 2019, 14(1): e0209899. DOI:<a href="https://doi.org/10.1371/journal.pone.0209899">10.1371/journal.pone.0209899</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[11]</div><div class="csl-right-inline">张三．中国心理学的过去与未来[J]．心理学报，2008，40(增刊)：210-215．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[12]</div><div class="csl-right-inline">张三．心理学史[M]．北京：未名出版社，2008．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[13]</div><div class="csl-right-inline">张三．心理学史[M]．北京：未名出版社，2008．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[14]</div><div class="csl-right-inline">Gibbs J T, Huang L N. Children of color: Psychological interventions with minority youth[M]. Hoboken, NJ, US: Jossey-Bass, 1989.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[15]</div><div class="csl-right-inline">Laplace P S. A philosophical essay on probabilities[M]. Truscott F W, Emory F L, trans. Dover, 1951.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[16]</div><div class="csl-right-inline">拉普拉斯, Pierre-Simon．概率哲学[M]．张三，李四，译．北京：未名出版社，1951．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[17]</div><div class="csl-right-inline">Klatzky R. Allocentric and egocentric spatial representations: Definitions, distinctions, and interconnections[M]//Freksa C, Habel C, Wender K F. Lecture notes in artificial intelligence: Vol. 1404: Spatial cognition: An interdisciplinary approach to representing and processing spatial knowledge. Springer-Verlag, 1998: 1-17.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[18]</div><div class="csl-right-inline">Wang D F, Cui H. Theoretical analysis of the seven factor model of Chinese personality[M]//Wang D F, Hou Y B. Selected papers on personality and social psychology: Vol. 1. Beijing: Peking University Press, 2004: 46-84.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[19]</div><div class="csl-right-inline">王登峰，崔红．中国人“大七”人格结构的理论分析[M]//王登峰，侯玉波．人格与社会心理学论丛：卷 1．北京：北京大学出版社，2004：46-84．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[20]</div><div class="csl-right-inline">Auerbach J S. The origins of narcissism and narcissistic personality disorder: A theoretical and empirical reformulation[M/OL]//Bornstein M F. Handbook of child psychology: Vol. 4. Socialization, personality, and social development. 4th ed. Washington, DC, US: Wiley, 1993: 43-110. DOI:<a href="https://doi.org/10.1037/10138-002">10.1037/10138-002</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[21]</div><div class="csl-right-inline">Lichstein K L, Johnson R S. Relaxation therapy for polypharmacy use in elderly insomniacs and noninsomniacs[C]//Reducing medication in geriatric populations. Uppsala, Sweden, 1990.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[22]</div><div class="csl-right-inline">Lanktree C B, Briere J N. Early data on the Trauma Symptom Checklist for Children (TSC-C)[C]//Paper presented at the meeting of the American Professional Society on the Abuse of Children. San Diego, CA, 1991.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[23]</div><div class="csl-right-inline">Ruby J, Fulton C. Beyond redlining: Editing software that works[C]//Poster session presented at the annual meeting of the Society for Scholarly Publishing. Washington, DC, 1993.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[24]</div><div class="csl-right-inline">Australian Bureau of Statistics. Estimated resident population by age and sex in statistical local areas, New South Wales, June 1990: 3209.1[R]. Canberra, Australian Capital Territory: Author, 1991.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[25]</div><div class="csl-right-inline">Mitchell T R, Larson J R. People in organizations: An introduction to organizational behavior[M]. 3rd ed. New York: McGraw-Hill, 1987.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[26]</div><div class="csl-right-inline">Bergmann P G. Relativity[M]//The new encyclopedia Britannica: Vol. 26. New York: Encyclopedia Britannica, 1993: 501-508.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[27]</div><div class="csl-right-inline">Sadie S. The new Grove dictionary of music and musicians[M]. 6th ed. London : New York: Macmillan, 1980.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[28]</div><div class="csl-right-inline">李行健．现代汉语规范辞典[M/OL]．北京：外语教学与研究出版社，2004：255[2023-01-24]．<a href="http://book.ucdrs.superlib.net/views/specific/2929/bookDetail.jsp?dxNumber=000007502301&#38;d=6CE8370C1575089E8C1CA0C567C13999&#38;fenlei=08021204">http://book.ucdrs.superlib.net/views/specific/2929/bookDetail.jsp?dxNumber=000007502301&#38;d=6CE8370C1575089E8C1CA0C567C13999&#38;fenlei=08021204</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[29]</div><div class="csl-right-inline">现代汉语频率词典[M/OL]．北京：北京语言学院出版社，1986[2023-01-24]．<a href="http://book.ucdrs.superlib.net/views/specific/2929/bookDetail.jsp?dxNumber=000001022685&#38;d=71C299B1BB1D244BF2DDA9151F541912&#38;fenlei=0802080332">http://book.ucdrs.superlib.net/views/specific/2929/bookDetail.jsp?dxNumber=000001022685&#38;d=71C299B1BB1D244BF2DDA9151F541912&#38;fenlei=0802080332</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[30]</div><div class="csl-right-inline">Yu L. Phonological representation and processing in Chinese spoken language production[D/OL]. Beijing Normal University, 2000[2023-01-24]. <a href="https://gongjushu.cnki.net/rbook/Search/SimpleSearch?key=%E8%BE%9E%E5%85%B8&#38;t=0&#38;c=0&#38;tn=%E8%AF%8D%E7%9B%AE">https://gongjushu.cnki.net/rbook/Search/SimpleSearch?key=%E8%BE%9E%E5%85%B8&#38;t=0&#38;c=0&#38;tn=%E8%AF%8D%E7%9B%AE</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[31]</div><div class="csl-right-inline">余林．汉语语言产生中的语音表征与加工[D]．北京师范大学，2000．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[32]</div><div class="csl-right-inline">邱颖文．遗传与语言学习[D]．上海：华东师范大学，2009．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[33]</div><div class="csl-right-inline">张三，李四．中国心理学与奥林匹克[N]．新华日报，2008-08-08(2, 5-7)．</div>
+  </div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《中国社会科学》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-4 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">赵景深．文坛忆旧[M]．上海：北新书局，1948．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">荣庆日记[M]．西安：西北大学出版社，1986．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">蒋大兴．公司法的展开与评判——方法·判例·制度[M]．北京：法律出版社，2001．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">任继愈．中国哲学发展史（先秦卷）[M]．北京：人民出版社，1983．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">实藤惠秀．中国人留学日本史[M]．谭汝谦，林启彦，译．香港：香港中文大学出版社，1982．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">金冲及．周恩来传[M]．北京：人民出版社、中央文献出版社，1989．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[7]</div><div class="csl-right-inline">佚名．晚清洋务运动事类汇钞五十七种：上册[M]．北京：全国图书馆文献缩微复制中心，1998．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[8]</div><div class="csl-right-inline">狄葆贤．平等阁笔记[M]．上海：有正书局．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[9]</div><div class="csl-right-inline">马克思恩格斯全集：卷 31[M]．北京：人民出版社，1998．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[10]</div><div class="csl-right-inline">杜威·佛克马．走向新世界主义[M]//王宁，薛晓源．全球化与后殖民批评．北京：中央编译出版社，1999：247-266．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[11]</div><div class="csl-right-inline">鲁迅．中国小说的历史的变迁[M]//鲁迅全集：第9册．北京：人民文学出版社，1981．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[12]</div><div class="csl-right-inline">唐振常．师承与变法[M]//识史集．上海：上海古籍出版社，1997．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[13]</div><div class="csl-right-inline">李鹏程．当代文化哲学沉思[M]．北京：人民出版社，1994．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[14]</div><div class="csl-right-inline">楼适夷．读家书，想傅雷（代序）[M]//傅敏．傅雷家书．增补本．北京：三联书店，1998．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[15]</div><div class="csl-right-inline">黄仁宇．为什么称为“中国大历史”？——中文版自序[M]//中国大历史．北京：三联书店，1997．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[16]</div><div class="csl-right-inline">姚际恒．古今伪书考：卷 3[M]．光绪三年苏州文学山房活字本．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[17]</div><div class="csl-right-inline">毛祥麟．墨余录[M]．上海：上海古籍出版社，1985．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[18]</div><div class="csl-right-inline">杨钟羲．雪桥诗话续集：卷 5[M]．影印本．沈阳：辽沈书社，1991．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[19]</div><div class="csl-right-inline">太平御览：卷 690 服章部七[M]．影印本．北京：中华书局，1985．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[20]</div><div class="csl-right-inline">管志道．答屠仪部赤水丈书[M]//续问辨牍：卷 2．影印本．济南：齐鲁书社，1997．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[21]</div><div class="csl-right-inline">嘉定县志：卷 12 风俗[M]．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[22]</div><div class="csl-right-inline">上海县续志：卷 1 疆域[M]．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[23]</div><div class="csl-right-inline">广东通志[M]//稀见中国地方志汇刊：卷 15．影印本．北京：中国书店，1992．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[24]</div><div class="csl-right-inline">旧唐书：卷 9 玄宗纪下[M]．标点本．北京：中华书局，1975．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[25]</div><div class="csl-right-inline">方苞集：卷 6 答程夔州书[M]．标点本．上海：上海古籍出版社，1983．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[26]</div><div class="csl-right-inline">清德宗实录：卷 435[M]．影印本．北京：中华书局，1987．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[27]</div><div class="csl-right-inline">何龄修．读顾诚〈南明史〉[J]．中国史研究，1998(3)：167-173．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[28]</div><div class="csl-right-inline">汪疑今．江苏的小农及其副业[J]．中国经济，1936，4(6)．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[29]</div><div class="csl-right-inline">魏丽英．论近代西北人口波动的若干主要原因[J/OL]．社会科学，1990(6)：68-73, 86．DOI:<a href="https://doi.org/10.15891/j.cnki.cn62-1093/c.1990.06.017">10.15891/j.cnki.cn62-1093/c.1990.06.017</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[30]</div><div class="csl-right-inline">费成康．葡萄牙人如何进入澳门问题辨正[J/OL]．社会科学，1999(9)：63-67[2024-06-12]．<a href="https://kns.cnki.net/kcms2/article/abstract?v=wYgW8A8u9vp6Ema3Mwkv_hcFaP9q0L4fxESweZeAxPzw-huXM6FBnwEe2FoehE7Sd2LliAejUiZxsTfPnTIWzV4aatJcFq9w5tigPkT1ccDGdgVxQVqPXxPflnX1ldPM7zYuFexEd8g=&#38;uniplatform=NZKPT&#38;language=CHS">https://kns.cnki.net/kcms2/article/abstract?v=wYgW8A8u9vp6Ema3Mwkv_hcFaP9q0L4fxESweZeAxPzw-huXM6FBnwEe2FoehE7Sd2LliAejUiZxsTfPnTIWzV4aatJcFq9w5tigPkT1ccDGdgVxQVqPXxPflnX1ldPM7zYuFexEd8g=&#38;uniplatform=NZKPT&#38;language=CHS</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[31]</div><div class="csl-right-inline">黄义豪．评黄龟年四劾秦桧[J]．福建论坛，1997(3)：26-27．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[32]</div><div class="csl-right-inline">倪素香．德育学科的比较研究与理论探索[J]．武汉大学学报，2002(4)：512-513．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[33]</div><div class="csl-right-inline">李眉．李劼人轶事[N]．四川工人日报，1986-08-22(2)．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[34]</div><div class="csl-right-inline">伤心人（麦孟华）．说奴隶[N]．清议报(第1页)．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[35]</div><div class="csl-right-inline">四川会议厅暂行章程[N]．广益丛报，1910-09-03(第1—2页)．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[36]</div><div class="csl-right-inline">上海各路商界总联合会致外交部电[N]．民国日报，1925-08-14(4)．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[37]</div><div class="csl-right-inline">西南中委反对在宁召开五全会[N]．民国日报，1933-08-11(第1张第4版)．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[38]</div><div class="csl-right-inline">方明东．罗隆基政治思想研究（1913—1949）[D]．北京师范大学历史系，2000．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[39]</div><div class="csl-right-inline">任东来．对国际体制和国际制度的理解和翻译[C]//全球化与亚太区域化国际研讨会．天津，2000．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[40]</div><div class="csl-right-inline">傅良佐致国务院电：北洋档案 1011—5961[A]．1917．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[41]</div><div class="csl-right-inline">党外人士座谈会记录：李劼人档案[A]．1950．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[42]</div><div class="csl-right-inline">王明亮．关于中国学术期刊标准化数据库系统工程的进展[EB/OL]．(1998-08-16)[1998-10-04]．<a href="http://www.cajcd.cn/pub/wml.txt/980810-2.html">http://www.cajcd.cn/pub/wml.txt/980810-2.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[43]</div><div class="csl-right-inline">扬之水．两宋茶诗与茶事[EB/OL]．[2007-09-13]．<a href="http://www.literature.org.cn/Article.asp?ID=199">http://www.literature.org.cn/Article.asp?ID=199</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[44]</div><div class="csl-right-inline">Brooks P. Troubling confessions: Speaking guilt in law and literature[M]. Chicago: University of Chicago Press, 2000.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[45]</div><div class="csl-right-inline">Polo M. The travels of Marco Polo[M]. Marsden W, trans. Hertfordshire: Cumberland House, 1997.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[46]</div><div class="csl-right-inline">Chamberlain H B. On the search for civil society in China[J/OL]. Modern China, 1993, 19(2): 199-215. DOI:<a href="https://doi.org/10.1177/009770049301900206">10.1177/009770049301900206</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[47]</div><div class="csl-right-inline">Schfield R S. The impact of scarcity and plenty on population change in England[M]//Rotberg R I, Rabb T K. Hunger and history: The impact of changing food production and consumption pattern on society. Cambridge, Mass.: Cambridge University Press, 1983: 55-88.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[48]</div><div class="csl-right-inline">Nixon to Kissinger: Box 1032, NSC Files, Nixon Presidential Material Project (NPMP)[A]. National Archives II, College Park, MD, 1969.</div>
+  </div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《法学引注手册》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-4 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">王名扬．美国行政法[M]．北京大学出版社，2007．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">张新宝．侵权责任法[M]．4 版．中国人民大学出版社，2016．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">高鸿钧，程汉大．英美法原论[M]．北京大学出版社，2013．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">[美]富勒．法律的道德性[M]．郑戈，译．商务印书馆，2005．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">季卫东．法律程序的意义：对中国法制建设的另一种思考[J]．中国社会科学，1993(1)：83-103．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">王保树．股份有限公司机关构造中的董事和董事会[M]//梁慧星．民商法论丛：卷 1．法律出版社，1994：110．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[7]</div><div class="csl-right-inline">[德]莱纳·沃尔夫．风险法的风险[M/OL]．陈霄，译//刘刚．风险规制：德国的理论与实践．法律出版社，2012[2022-08-04]．<a href="https://book.douban.com/subject/20327000/">https://book.douban.com/subject/20327000/</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[8]</div><div class="csl-right-inline">何海波．判决书上网[N]．法制日报，2000-05-21(2)．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[9]</div><div class="csl-right-inline">汪波．哈尔滨市政法机关正对“宝马案”认真调查复查[EB/OL]．(2004-01-10)[2022-05-03]．<a href="http://www.people.com.cn/GB/shehui/1062/2289764.html">http://www.people.com.cn/GB/shehui/1062/2289764.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[10]</div><div class="csl-right-inline">被告人李宁、张磊贪污案一审开庭[EB/OL]．<a href="http://www.xinhuanet.com/legal/2019-12/31/c_1125406056.htm">http://www.xinhuanet.com/legal/2019-12/31/c_1125406056.htm</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[11]</div><div class="csl-right-inline">赵耀彤．一名基层法官眼里好律师的样子[EB/OL]．(2018-12-01)[2022-05-03]．<a href="http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm">http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[12]</div><div class="csl-right-inline">法国行政法院网站[EB/OL]．[2016-12-18]．<a href="http://english.conseil-etat.fr/Judging">http://english.conseil-etat.fr/Judging</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[13]</div><div class="csl-right-inline">李松锋．游走在上帝与凯撒之间：美国宪法第一修正案中的政教关系研究[D]．中国政法大学，2015．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[14]</div><div class="csl-right-inline">民法总则[A]．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[15]</div><div class="csl-right-inline">国务院．国务院关于在全国建立农村最低生活保障制度的通知：国发〔2007〕19号[A/OL]．(2007-07-11)[2022-10-17]．<a href="https://www.pkulaw.com/chl/dc46bb66e13150b8bdfb.html">https://www.pkulaw.com/chl/dc46bb66e13150b8bdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[16]</div><div class="csl-right-inline">包郑照诉苍南县人民政府强制拆除房屋案：（1988）浙法民上字 7 号[A]．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[17]</div><div class="csl-right-inline">陆红霞诉南通市发改委政府信息公开案[A/OL]//最高人民法院公报．(2015-07-06)[2022-10-17]．<a href="https://www.pkulaw.com/pfnl/a25051f3312b07f383ab74a250eadc412f753fb855fabeadbdfb.html">https://www.pkulaw.com/pfnl/a25051f3312b07f383ab74a250eadc412f753fb855fabeadbdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[18]</div><div class="csl-right-inline">Reich C A. The new property[J/OL]. Yale Law Journal, 1964, 73(5): 733-787. DOI:<a href="https://doi.org/10.2307/794645">10.2307/794645</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[19]</div><div class="csl-right-inline">Brandeis L D. What publicity can do[J]. Harper’s Weekly, 1913: 10.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[20]</div><div class="csl-right-inline">Alford W. To steal a book is an elegant offense: Intellectual property law in Chinese civilization[M]. Stanford University Press, 1995.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[21]</div><div class="csl-right-inline">应松年，马怀德．当代中国行政法的源流：王名扬教授九十华诞贺寿文集[M]．中国法制出版社，2006．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[22]</div><div class="csl-right-inline">R. v. Panel on Take-overs and Mergers[A]//QB: Vol. 815. 1987.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[23]</div><div class="csl-right-inline">罗豪才，袁曙宏，李文栋．现代行政法的理论基础——论行政机关与相对一方的权利义务平衡[J/OL]．中国法学，1993(1)：52-59[2022-07-25]．<a href="https://www.cnki.net/kcms/detail/detail.aspx?dbcode=CJFD&#38;dbname=CJFD1993&#38;filename=ZGFX199301009&#38;v=MDE4Njk5TE1ybzlGYllRS0RIODR2UjRUNmo1NE8zenFxQnRHRnJDVVI3aWZZK1pxRkNqbFZiN01QeXJOZHJLeEY=">https://www.cnki.net/kcms/detail/detail.aspx?dbcode=CJFD&#38;dbname=CJFD1993&#38;filename=ZGFX199301009&#38;v=MDE4Njk5TE1ybzlGYllRS0RIODR2UjRUNmo1NE8zenFxQnRHRnJDVVI3aWZZK1pxRkNqbFZiN01QeXJOZHJLeEY=</a>．DOI:<a href="https://doi.org/10.14111/j.cnki.zgfx.1993.01.010">10.14111/j.cnki.zgfx.1993.01.010</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[24]</div><div class="csl-right-inline">夏新华，胡旭晟，刘鄂，等．近代中国宪政历程[M/OL]．中国政法大学出版社，2004[2022-09-03]．<a href="https://book.douban.com/subject/1663375/">https://book.douban.com/subject/1663375/</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[25]</div><div class="csl-right-inline">邓小平．精简机构是一场革命[M]//邓小平文选：卷 2．2 版．人民出版社，1994．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[26]</div><div class="csl-right-inline">[英]劳特派特．奥本海国际法：上卷第一分册[M]．王铁崖，陈体强，译．8 版．商务印书馆，1971．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[27]</div><div class="csl-right-inline">瞿同祖．中国法律与中国社会[M/OL]．商务印书馆，2010[2024-11-06]．<a href="https://book.douban.com/subject/6004646/">https://book.douban.com/subject/6004646/</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[28]</div><div class="csl-right-inline">崔国斌．知识产权法官造法批判[J/OL]．中国法学，2006(1)：144-164[2024-11-06]．<a href="https://link.cnki.net/doi/10.14111/j.cnki.zgfx.2006.01.013">https://link.cnki.net/doi/10.14111/j.cnki.zgfx.2006.01.013</a>．DOI:<a href="https://doi.org/10.14111/j.cnki.zgfx.2006.01.013">10.14111/j.cnki.zgfx.2006.01.013</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[29]</div><div class="csl-right-inline">全国人大常委会．中华人民共和国刑法修正案（十）：中华人民共和国主席令第80号[A/OL]．(2017-11-04)[2022-10-14]．<a href="https://www.pkulaw.com/chl/3ae7651e2659029abdfb.html">https://www.pkulaw.com/chl/3ae7651e2659029abdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[30]</div><div class="csl-right-inline">全国人大常委会．中华人民共和国公司法[A/OL]．2005年修订．(2005-10-27)[2022-10-14]．<a href="https://www.pkulaw.com/chl/e54c465cca59c137bdfb.html">https://www.pkulaw.com/chl/e54c465cca59c137bdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[31]</div><div class="csl-right-inline">全国人大常委会．中华人民共和国公司法[A/OL]．2013年修正．(2013-12-28)[2022-10-27]．<a href="https://www.pkulaw.com/chl/1b2641cb68c3ed21bdfb.html">https://www.pkulaw.com/chl/1b2641cb68c3ed21bdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[32]</div><div class="csl-right-inline">最高人民法院，最高人民检察院．最高人民法院、最高人民检察院关于依法严惩破坏计划生育犯罪活动的通知：法发〔1993〕36号[A/OL]．(1993-11-12)[2022-10-14]．<a href="https://www.pkulaw.com/chl/98ef6bfbd5f5ecdebdfb.html">https://www.pkulaw.com/chl/98ef6bfbd5f5ecdebdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[33]</div><div class="csl-right-inline">全国人大常委会．全国人民代表大会常务委员会关于严禁卖淫嫖娼的决定[A/OL]．(1991-09-04)[2022-10-27]．<a href="https://www.pkulaw.com/chl/7d823d434f747555bdfb.html">https://www.pkulaw.com/chl/7d823d434f747555bdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[34]</div><div class="csl-right-inline">国务院．国务院关于在全国建立农村最低生活保障制度的通知：国发〔2007〕19号[A/OL]．(2007-07-11)[2022-10-27]．<a href="https://www.pkulaw.com/chl/dc46bb66e13150b8bdfb.html">https://www.pkulaw.com/chl/dc46bb66e13150b8bdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[35]</div><div class="csl-right-inline">最高人民法院．最高人民法院关于适用〈中华人民共和国行政诉讼法〉的解释：法释〔2018〕1号[A/OL]．(2018-02-06)[2022-10-27]．<a href="https://www.pkulaw.com/chl/0a15442a31eb74f6bdfb.html">https://www.pkulaw.com/chl/0a15442a31eb74f6bdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[36]</div><div class="csl-right-inline">国务院．国务院关于印发打赢蓝天保卫战三年行动计划的通知：国发〔2018〕22号[A/OL]．(2018-06-27)[2023-06-19]．<a href="https://www.pkulaw.com/chl/4a14adc2c14e5e68bdfb.html">https://www.pkulaw.com/chl/4a14adc2c14e5e68bdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[37]</div><div class="csl-right-inline">国家质量监督检验检疫总局，中国国家标准化管理委员会．信息与文献 参考文献著录规则：GB/T 7714—2015[S]．2015．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[38]</div><div class="csl-right-inline">信春鹰．关于《中华人民共和国行政诉讼法修正案（草案）》的说明[R/OL]．(2013-12-23)[2023-06-19]．<a href="https://www.pkulaw.com/protocol/e0c81a0878b582cddca4c85351d16972bdfb.html">https://www.pkulaw.com/protocol/e0c81a0878b582cddca4c85351d16972bdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[39]</div><div class="csl-right-inline">中国共产党中央委员会．中共中央关于全面推进依法治国若干重大问题的决定[A/OL]．(2014-10-23)[2023-06-19]．<a href="https://www.pkulaw.com/chl/8e624467ca77636dbdfb.html">https://www.pkulaw.com/chl/8e624467ca77636dbdfb.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[40]</div><div class="csl-right-inline">荣宝英诉王阳、永诚财产保险股份有限公司江阴支公司机动车交通事故责任纠纷案：（2013）锡民终字第497号[A]//最高人民法院公报．2013．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[41]</div><div class="csl-right-inline">榆林市凯奇莱能源投资有限公司诉陕西省地质矿产勘查开发局西安地质矿产勘查开发院合作勘查合同纠纷上诉案：（2011）民一终字第 81 号[A]．2017．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[42]</div><div class="csl-right-inline">Barbara Ward. Progress for a small planet[J/OL]. Harvard Business Review, 1979(Sep.-Oct.): 89[2022-07-26]. <a href="https://www.osti.gov/biblio/6023582">https://www.osti.gov/biblio/6023582</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[43]</div><div class="csl-right-inline">Rosenthal A. White House tutors Kremlin in how a presidency works[N/OL]. New York Times, 1990-06-15(A1)[2022-07-26]. <a href="https://www.nytimes.com/1990/06/15/world/white-house-tutors-kremlin-in-how-a-presidency-works.html">https://www.nytimes.com/1990/06/15/world/white-house-tutors-kremlin-in-how-a-presidency-works.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[44]</div><div class="csl-right-inline">Habermas J. Between facts and norms: contributions to a discourse theory of law and democracy[M]. Rehg W, trans. MIT Press, 1996.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[45]</div><div class="csl-right-inline">Horsley J. Rule of law in China: incremental progress[M]//Bergsten C F, Gill B, Lardy N R, et al. China: The balance sheet. Public Affairs Press, 2006.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[46]</div><div class="csl-right-inline">Department of Transportation Act: 89-670[A]//Stat.: Vol. 80. 1966: 931, 944-947.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[47]</div><div class="csl-right-inline">Administrative Procedure Act § 6[A]//U.S.C.: Vol. 5. 2006.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[48]</div><div class="csl-right-inline">Natural Resources Defense Council <i>v.</i> Gorsuch[A]//F.2d: Vol. 685. 1982: 718.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[49]</div><div class="csl-right-inline">Chevron U.S.A., Inc. <i>v.</i> Natural Resources Defense Council[A]//U.S.: Vol. 467. 1984: 837.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[50]</div><div class="csl-right-inline">Roe <i>v.</i> Wade[A]//U.S.: Vol. 410. 1973: 113.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[51]</div><div class="csl-right-inline">United States <i>v.</i> Dino Nastasi et al.: 3:15-cr-00213-FDW-DCK[A].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[52]</div><div class="csl-right-inline">McDonell S. When China began streaming trials online[EB/OL]. (2016-09-30)[2022-07-26]. <a href="https://www.bbc.com/news/blogs-china-blog-37515399">https://www.bbc.com/news/blogs-china-blog-37515399</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[53]</div><div class="csl-right-inline">Chevallier M．L’État de droit[M/OL]．4 版．Paris：Montchrestien，2003．<a href="https://www.decitre.fr/livres/l-etat-de-droit-9782707613714.html">https://www.decitre.fr/livres/l-etat-de-droit-9782707613714.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[54]</div><div class="csl-right-inline">Poisson M．Le droit de la mer[J]．RGDIP，2015：15-47．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[55]</div><div class="csl-right-inline">Badiou-Monferran C．La promotion esthétique du pathétique dans la seconde moitié du XVIIe siècle[J]．La Licorne，1997(43)：75-94．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[56]</div><div class="csl-right-inline">Poisson M．Le droit de la mer[M]//Lapieuvre R．Le droit des Océans．Éditions de la mer．2015：12-48．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[57]</div><div class="csl-right-inline">Poisson M．Le droit de la mer en Méditerranée[R]．Congrès de Marseille，2016：228-229．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[58]</div><div class="csl-right-inline">Poisson M．Le droit de la mer en Méditerranée：1202[R]．2016．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[59]</div><div class="csl-right-inline">Poisson M．Le droit de la mer appliqué à la Méditerranée[D]．l’Université de Marseille，2016．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[60]</div><div class="csl-right-inline">Joyeux-Prunel B．L’histoire de l’art et le quantitatif[EB/OL]．[2010-03-17]．<a href="http://histoiremesure.revues.org/index3543.html">http://histoiremesure.revues.org/index3543.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[61]</div><div class="csl-right-inline">Vogel B．Rechtsgüterschutz und Normgeltung[J/OL]．Zeitschrift für die gesamte Strafrechtswissenschaft，2017，129(3)：629-649[2022-07-26]．<a href="https://www.degruyter.com/document/doi/10.1515/zstw-2017-0033/html?lang=de">https://www.degruyter.com/document/doi/10.1515/zstw-2017-0033/html?lang=de</a>．DOI:<a href="https://doi.org/10.1515/zstw-2017-0033">10.1515/zstw-2017-0033</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[62]</div><div class="csl-right-inline">Würdinger M．Über Radarwarngeräte und die Zukunft des Europäischen Privatrechts[J/OL]．Juristische Schulung，2012(3)：234-240[2022-07-26]．<a href="https://dialnet.unirioja.es/servlet/articulo?codigo=3906259">https://dialnet.unirioja.es/servlet/articulo?codigo=3906259</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[63]</div><div class="csl-right-inline">Fischer T．Absurdes Spektakel um den Tod[N]．Die Zeit，2015-09-29．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[64]</div><div class="csl-right-inline">Roxin C．Strafrecht Allgemeiner Teil：卷 1[M]．4 版．C. H. Beck，2006．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[65]</div><div class="csl-right-inline">Dreier R，Paulson S．Rechtsphilosophie Studienausgabe[M]．2 版．Heidelberg：UTB Uni-Taschenbücher Verlag，2003．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[66]</div><div class="csl-right-inline">Schwab M．[M/OL]//Münchener Kommentar BGB：卷 5．6 版．2013．<a href="https://beck-online.beck.de/?vpath=bibdata%2Fkomm%2FMuekoBGB_Band5%2FBGB%2Fcont%2FMuekoBGB.BGB.P817.T0.htm">https://beck-online.beck.de/?vpath=bibdata%2Fkomm%2FMuekoBGB_Band5%2FBGB%2Fcont%2FMuekoBGB.BGB.P817.T0.htm</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[67]</div><div class="csl-right-inline">Kaufmann A．Bemerkungen zur Reform des § 218 StGB aus rechtsphilosophischer Sicht[M]//Baumann J．Das Abtreibungsverbot des § 218 StGB．2 版．1972．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[68]</div><div class="csl-right-inline">Canaris C W．Gesamtunwirksamkeit und Teilgültigkeit rechtsgeschäftlicher Regelungen[M]．1990．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[69]</div><div class="csl-right-inline">StGB[A]．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[70]</div><div class="csl-right-inline">StPO[A]．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[71]</div><div class="csl-right-inline">GG[A]．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[72]</div><div class="csl-right-inline">Strauß-Karikatur, Kunstfreiheit[A]//BVerfGE：卷 75．369．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[73]</div><div class="csl-right-inline">[A]//NStZ-RR．1999：185．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[74]</div><div class="csl-right-inline">[A]//NJW．2000：1560．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[75]</div><div class="csl-right-inline">Meidenbauer M．Wissenschaftliches Publizieren[EB/OL]．[2017-10-10]．<a href="https://www.clio-online.de/sites/files/clio/portal-archiv/site/lang_de/40208143/Default-2.html">https://www.clio-online.de/sites/files/clio/portal-archiv/site/lang_de/40208143/Default-2.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[76]</div><div class="csl-right-inline">我妻栄．新訂担保物権法[M]．有斐閣，1971．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[77]</div><div class="csl-right-inline">我妻栄，有泉亨．民法総則物権法[M]．日本評論社，1950．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[78]</div><div class="csl-right-inline">於保不二雄．付加物及び従物と抵当権[J/OL]．民商法雑誌，1954，29(5)：1．<a href="https://dl.ndl.go.jp/info:ndljp/pid/3564970?tocOpened=1">https://dl.ndl.go.jp/info:ndljp/pid/3564970?tocOpened=1</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[79]</div><div class="csl-right-inline">佐藤英明．一時所得の要件に関する覚書[M]//金子宏，中里実，J.マーク・ラムザイヤー．租税法と市場．有斐閣，2014：220．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[80]</div><div class="csl-right-inline">信玄公旗掛松事件[A/OL]//大審院民事判決録：卷 25．1919：356．<a href="https://ja.wikipedia.org/wiki/信玄公旗掛松事件">https://ja.wikipedia.org/wiki/信玄公旗掛松事件</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[81]</div><div class="csl-right-inline">約束手形金[A/OL]//最高裁判所民事判例集：36卷6号．1982：1113．<a href="https://www.courts.go.jp/app/hanrei_jp/detail2?id=55158">https://www.courts.go.jp/app/hanrei_jp/detail2?id=55158</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[82]</div><div class="csl-right-inline">動産及び債権の譲渡の対抗要件に関する民法の特例に関する法律[A/OL]．<a href="https://elaws.e-gov.go.jp/document?lawid=410AC0000000104_20220401_503AC0000000037">https://elaws.e-gov.go.jp/document?lawid=410AC0000000104_20220401_503AC0000000037</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[83]</div><div class="csl-right-inline">平成26年版犯罪白書[Z/OL]．<a href="https://hakusyo1.moj.go.jp/jp/61/nfm/mokuji.html">https://hakusyo1.moj.go.jp/jp/61/nfm/mokuji.html</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[84]</div><div class="csl-right-inline">ジュリスト[EB/OL]．[2022-09-01]．<a href="http://www.yuhikaku.co.jp/jurist">http://www.yuhikaku.co.jp/jurist</a>．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[85]</div><div class="csl-right-inline">欧中坦．千方百计上京城：清朝的京控[M]．谢鹏程，译//高道蕴，高鸿钧，贺卫方．美国学者论中国法律传统．中国政法大学出版社，1994．</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[86]</div><div class="csl-right-inline">温家宝主持国务院会议 研究房地产业健康发展措施[EB/OL]．<a href="http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm">http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm</a>．</div>
+  </div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### APA 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-5 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">McCauley S M, Christiansen M H. Language learning as language use: A cross-linguistic model of child language development[J/OL]. Psychological Review, 2019, 126(1): 1-51. DOI:<a href="https://doi.org/10.1037/rev0000126">10.1037/rev0000126</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">Ahmann E, Tuttle L J, Saviet M, et al. A descriptive review of ADHD coaching research: Implications for college students[J/OL]. Journal of Postsecondary Education and Disability, 2018, 31(1): 17-39. <a href="https://www.ahead.org/professional-resources/publications/jped/archived-jped/jped-volume-31">https://www.ahead.org/professional-resources/publications/jped/archived-jped/jped-volume-31</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">Anderson M. Getting consistent with consequences[J]. Educational Leadership, 2018, 76(1): 26-33.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">Goldman C. The complicated calibration of love, especially in adoption[N]. Chicago Tribune, 2018-11-28.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">Kalnay E, Kanamitsu M, Kistler R, et al. The NCEP/NCAR 40-year reanalysis project[J/OL]. Bulletin of the American Meteorological Society, 1996, 77(3): 437-471. DOI:<a href="https://doi.org/fg6rf9">fg6rf9</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">De Vries R, Nieuwenhuijze M, Buitendijk S E, et al. What does it take to have a strong and independent profession of midwifery? Lessons from the Netherlands[J/OL]. Midwifery, 2013, 29(10): 1122-1128. DOI:<a href="https://doi.org/10.1016/j.midw.2013.07.007">10.1016/j.midw.2013.07.007</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[7]</div><div class="csl-right-inline">Burin D, Kilteni K, Rabuffetti M, et al. Body ownership increases the interference between observed and executed movements[J/OL]. PLOS ONE, 2019, 14(1): e0209899. DOI:<a href="https://doi.org/10.1371/journal.pone.0209899">10.1371/journal.pone.0209899</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[8]</div><div class="csl-right-inline">Huestegge S M, Raettig T, Huestegge L. Are face-incongruent voices harder to process? Effects of face–voice gender incongruency on basic cognitive information processing[J/OL]. Experimental Psychology, 2019. DOI:<a href="https://doi.org/10.1027/1618-3169/a000440">10.1027/1618-3169/a000440</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[9]</div><div class="csl-right-inline">Pachur T, Scheibehenne B. Unpacking buyer-seller differences in valuation from experience: A cognitive modeling approach[J]. Psychonomic Bulletin &#38; Review.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[10]</div><div class="csl-right-inline">Chaves-Morillo V, Gómez Calero C, Fernández-Muñoz J J, et al. Sensorineural anosmia: Relationship between subtype, recognition time, and age[J/OL]. Clínica y Salud, 2018, 28(3): 155-161. DOI:<a href="https://doi.org/10.1016/j.clysa.2017.04.002">10.1016/j.clysa.2017.04.002</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[11]</div><div class="csl-right-inline">Piaget J. Intellectual evolution from adolescence to adulthood[J/OL]. Human Development, 1972, 15(1): 1-12. DOI:<a href="https://doi.org/10.1159/00027/1225">10.1159/00027/1225</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[12]</div><div class="csl-right-inline">Shore M F. Marking time in the land of plenty: Reflections on mental health in the United States[J/OL]. American Journal of Orthopsychiatry, 2014, 84(6): 611-618. DOI:<a href="https://doi.org/10.1037/h0100165">10.1037/h0100165</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[13]</div><div class="csl-right-inline">Marking time in the land of plenty: Reflections on mental health in the United States[J/OL]. American Journal of Orthopsychiatry, 1981, 51(3): 391-402. DOI:<a href="https://doi.org/10.1111/j.1939-0025.1981.tb01388.x">10.1111/j.1939-0025.1981.tb01388.x</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[14]</div><div class="csl-right-inline">Lilienfeld S O. Archives of scientific psychology: Heterodox issues in psychology[J]. 2018, 6(1). 2018: 51-104.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[15]</div><div class="csl-right-inline">McDaniel S H, Salas E, Kazak A E. American psychologist: The science of teamwork[J]. 2018, 73(4). 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[16]</div><div class="csl-right-inline">Mehrholz J, Pohl M, Platz T, et al. Electromechanical and robot-assisted arm training for improving activities of daily living, arm function, and arm muscle strength after stroke[J/OL]. Cochrane Database of Systematic Reviews, 2018. DOI:<a href="https://doi.org/10.1002/14651858.CD006876.pub5">10.1002/14651858.CD006876.pub5</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[17]</div><div class="csl-right-inline">Morey M C. Physical activity and exercise in older adults[J/OL]. UpToDate, 2019[2019-07-22]. <a href="https://www.uptodate.com/contents/physical-activity-and-exercise-in-older-adults">https://www.uptodate.com/contents/physical-activity-and-exercise-in-older-adults</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[18]</div><div class="csl-right-inline">Bergeson S. Really cool neutral plasmas[J/OL]. Science, 2019, 363(6422): 33-34. DOI:<a href="https://doi.org/10.1126/science.aau7988">10.1126/science.aau7988</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[19]</div><div class="csl-right-inline">Bustillos M. On video games and storytelling: An interview with Tom Bissell[J/OL]. The New Yorker, 2013. <a href="https://www.newyorker.com/books/page-turner/on-video-games-and-storytelling-an-interview-with-tom-bissell">https://www.newyorker.com/books/page-turner/on-video-games-and-storytelling-an-interview-with-tom-bissell</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[20]</div><div class="csl-right-inline">Weir K. Forgiveness can improve mental and physical health[J]. Monitor on Psychology, 2017, 48(1): 30.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[21]</div><div class="csl-right-inline">Guarino B. How will humanity react to alien life? Psychologists have some predictions[N/OL]. The Washington Post, 2017-12-04. <a href="https://www.washingtonpost.com/news/speaking-of-science/wp/2017/12/04/how-will-humanity-react-to-alien-life-psychologists-have-some-predictions">https://www.washingtonpost.com/news/speaking-of-science/wp/2017/12/04/how-will-humanity-react-to-alien-life-psychologists-have-some-predictions</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[22]</div><div class="csl-right-inline">Hess A. Cats who take direction[N]. The New York Times, 2019-01-03(C1).</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[23]</div><div class="csl-right-inline">Klymkowsky M. Can we talk scientifically about free will?[EB/OL]. (2018-09-15). <a href="https://blogs.plos.org/scied/2018/09/15/can-we-talk-scientifically-about-free-will/">https://blogs.plos.org/scied/2018/09/15/can-we-talk-scientifically-about-free-will/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[24]</div><div class="csl-right-inline">KS in NJ. From this article, it sounds like men are figuring something out that women have known forever. I know of many[N/OL]. The Washington Post, 2019-01-15. <a href="https://wapo.st/2HDToGJ">https://wapo.st/2HDToGJ</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[25]</div><div class="csl-right-inline">Author A. How workout buddies can help stave off loneliness[N]. The Washington Post, 2019-01-15.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[26]</div><div class="csl-right-inline">Cuellar N G. Study abroad programs[J/OL]. Journal of Transcultural Nursing, 2016, 27(3): 209. DOI:<a href="https://doi.org/10.1177/1043659616638722">10.1177/1043659616638722</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[27]</div><div class="csl-right-inline">Brown L S. Feminist therapy[M/OL]. 2nd ed. American Psychological Association, 2018. DOI:<a href="https://doi.org/10.1037/0000092-000">10.1037/0000092-000</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[28]</div><div class="csl-right-inline">Burgess R. Rethinking global health: Frameworks of power[M]. Routledge, 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[29]</div><div class="csl-right-inline">Cain S. Quiet: The power of introverts in a world that can’t stop talking[M/OL]. Random House Audio, 2012. <a href="http://bit.ly/2GOBpbl">http://bit.ly/2GOBpbl</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[30]</div><div class="csl-right-inline">Christian B, Griffiths T. Algorithms to live by: The computer science of human decisions[M/OL]. Henry Holt and Co., 2016. <a href="http://a.co/7qGBZAk">http://a.co/7qGBZAk</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[31]</div><div class="csl-right-inline">Meadows D H. Thinking in systems: A primer[M]. Chelsea Green Publishing, 2008.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[32]</div><div class="csl-right-inline">Schmid H J. Entrenchment and the psychology of language learning: How we reorganize and adapt linguistic knowledge[M/OL]. American Psychological Association; De Gruyter Mouton, 2017. DOI:<a href="https://doi.org/10.1037/15969-000">10.1037/15969-000</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[33]</div><div class="csl-right-inline">Hacker Hughes J. Military veteran psychological health and social care: Contemporary approaches[M]. Routledge, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[34]</div><div class="csl-right-inline">Pridham K F, Limbo R, Schroeder M. Guided participation in pediatric nursing practice: Relationship-based teaching and learning with parents, children and adolescents[M/OL]. Springer Publishing Company, 2018. <a href="http://a.co/0IAiVgt">http://a.co/0IAiVgt</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[35]</div><div class="csl-right-inline">Amano N, Kondo H. Lexical characteristics of Japanese language: Vol. 7[M]. Sansei-do, 2000.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[36]</div><div class="csl-right-inline">Piaget J, Inhelder B. The psychology of the child[M]. Quadrige, 1966.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[37]</div><div class="csl-right-inline">Piaget J, Inhelder B. The psychology of the child[M]. Weaver H, trans. 2nd ed. Basic Books, 1969.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[38]</div><div class="csl-right-inline">Freud S. The interpretation of dreams: The complete and definitive text[M]. Strachey J, trans. Basic Books, 2010.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[39]</div><div class="csl-right-inline">Rowling J K. Harry Potter and the sorceror’s stone[M/OL]. Pottermore Publishing, 2015. <a href="http://bit.ly/2TcHchx">http://bit.ly/2TcHchx</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[40]</div><div class="csl-right-inline">Fiske S T, Gilbert D T, Lindzey G. Handbook of social psychology: Vol. 1[M/OL]. 5th ed. John Wiley &#38; Sons, 2010. DOI:<a href="https://doi.org/10.1002/9780470561119">10.1002/9780470561119</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[41]</div><div class="csl-right-inline">Travis C B, White J W. APA handbook of the psychology of women: Vol. 1 History, theory, and battlegrounds[M/OL]. American Psychological Association, 2018. DOI:<a href="https://doi.org/10.1037/0000059-000">10.1037/0000059-000</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[42]</div><div class="csl-right-inline">Madigan S. Narrative therapy[M/OL]. 2nd ed. American Psychological Association, 2019. DOI:<a href="https://doi.org/10.1037/00000131-000">10.1037/00000131-000</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[43]</div><div class="csl-right-inline">American Psychiatric Association. Diagnostic and statistical manual of mental disorders[R/OL]. 5th ed. American Psychiatric Association, 2013. DOI:<a href="https://doi.org/10.1176/appi.books.9780890425596">10.1176/appi.books.9780890425596</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[44]</div><div class="csl-right-inline">World Health Organization. International statistical classification of diseases and related health problems[R/OL]. 11th ed. World Health Organization, 2019. <a href="https://icd.who.int/">https://icd.who.int/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[45]</div><div class="csl-right-inline">American Psychological Association. APA dictionary of psychology[M/OL]. [2019-06-14]. <a href="https://dictionary.apa.org/">https://dictionary.apa.org/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[46]</div><div class="csl-right-inline">Merriam-Webster. Merriam-Webster.com dictionary[M/OL]. [2019-05-05]. <a href="https://www.merriam-webster.com/">https://www.merriam-webster.com/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[47]</div><div class="csl-right-inline">Zalta E N. The Stanford encyclopedia of philosophy[M/OL]. Summer 2019 ed. Stanford University, 2019. <a href="https://plato.stanford.edu/archives/sum2019/">https://plato.stanford.edu/archives/sum2019/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[48]</div><div class="csl-right-inline">Gold M. The complete social scientist: A Kurt Lewin reader[M/OL]. American Psychological Association, 1999. DOI:<a href="https://doi.org/10.1037/10319-000">10.1037/10319-000</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[49]</div><div class="csl-right-inline">King James Bible[M/OL]. King James Bible Online, 2017. <a href="https://www.kingjamesbibleonline.org/">https://www.kingjamesbibleonline.org/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[50]</div><div class="csl-right-inline">The Qur’an[M]. Abdel Haleem M A S, trans. Oxford University Press, 2004.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[51]</div><div class="csl-right-inline">The Torah: The five books of Moses[M]. 3rd ed. The Jewish Publication Society, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[52]</div><div class="csl-right-inline">Aristotle. Poetics[M/OL]. Butcher S H, trans. The Internet Classics Archive, 1994. <a href="http://classics.mit.edu/Aristotle/poetics.html">http://classics.mit.edu/Aristotle/poetics.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[53]</div><div class="csl-right-inline">Shakespeare W. Much ado about nothing[M]. Washington Square Press, 1995.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[54]</div><div class="csl-right-inline">Balsam K F, Martell C R, Jones K P, et al. Affirmative cognitive behavior therapy with sexual and gender minority people[M/OL]//Iwamasa G Y, Hays P A. Culturally responsive cognitive behavior therapy: Practice and supervision. 2nd ed. American Psychological Association, 2019: 287-314. DOI:<a href="https://doi.org/10.1037/0000119-012">10.1037/0000119-012</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[55]</div><div class="csl-right-inline">Weinstock R, Leong G B, Silva J A. Defining forensic psychiatry: Roles and responsibilities[M]//Rosner R. Principles and practise of forensic psychiatry. 2nd ed. CRC Press, 2003: 7-13.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[56]</div><div class="csl-right-inline">Tafoya N, Del Vecchio A. Back to the future: An examination of the Native American Holocaust experience[M/OL]//McGoldrick M, Giordano J, Garcia-Preto N. Ethnicity and family therapy. 3rd ed. Guilford Press, 2005: 55-63. <a href="http://a.co/36xRhBT">http://a.co/36xRhBT</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[57]</div><div class="csl-right-inline">Carcavilla González N. Auditory sensory therapy: Brain activation through music[M/OL]//Garcia Meilán J J. Guía práctica de terapias estimulativas en el Alzhéimer. Editorial Síntesis, 2015: 67-86. <a href="http://www.sintesis.com/guias-profesionales-203/guia-practica-de-terapias-estimulativas-en-el-alzheimer-libro-1943.html">http://www.sintesis.com/guias-profesionales-203/guia-practica-de-terapias-estimulativas-en-el-alzheimer-libro-1943.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[58]</div><div class="csl-right-inline">Heidegger M. On the essence of truth[M]. Sallis J, trans.//Krell D F. Basic writings. Harper Perennial Modern Thought, 2008: 111-138.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[59]</div><div class="csl-right-inline">Sacchett C, Humphreys G W. Calling a squirrel and squirrel but a canoe a wigwam: A category-specific deficit for artefactual objects and body parts[M]//Balota D A, Marsh E J. Cognitive psychology: Key readings in cognition. Psychology Press, 2004: 100-108.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[60]</div><div class="csl-right-inline">Sacchett C, Humphreys G W. Calling a squirrel and squirrel but a canoe a wigwam: A category-specific deficit for artefactual objects and body parts[J/OL]. Cognitive Neuropsychology, 1992, 9(1): 73-86. DOI:<a href="https://doi.org/d4vb59">d4vb59</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[61]</div><div class="csl-right-inline">Bronfenbrenner U. The social ecology of human development: A retrospective conclusion[M]//Bronfenbrenner U. Making human beings human: Bioecological perspectives on human development. SAGE Publications, 2005: 27-40.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[62]</div><div class="csl-right-inline">Richardson F. Brain and intelligence: The ecology of child development[M]. National Educational Press, 1973: 113-123.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[63]</div><div class="csl-right-inline">Goldin-Meadow S. Gesture and cognitive development[M/OL]//Liben L S, Mueller U. Handbook of child psychology and developmental science: Vol. 2. 7th ed. John Wiley &#38; Sons, 2015: 339-380. DOI:<a href="https://doi.org/10.1002/9781118963418.childpsy209">10.1002/9781118963418.childpsy209</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[64]</div><div class="csl-right-inline">Lewin K. Group decision and social change[M/OL]//Gold M. The complete social scientist: A Kurt Lewin reader. American Psychological Association, 1999: 265-284. DOI:<a href="https://doi.org/10.1037/10319-000">10.1037/10319-000</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[65]</div><div class="csl-right-inline">American Psychological Association. Positive transference[M/OL]//APA dictionary of psychology. [2019-08-31]. <a href="https://dictionary.apa.org/positive-transference">https://dictionary.apa.org/positive-transference</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[66]</div><div class="csl-right-inline">Merriam-Webster. Self-report[M/OL]//Merriam-Webster.com dictionary. [2019-07-12]. <a href="https://www.merriam-webster.com/dictionary/self-report">https://www.merriam-webster.com/dictionary/self-report</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[67]</div><div class="csl-right-inline">Graham G. Behaviorism[M/OL]//Zalta E N. The Stanford encyclopedia of philosophy. Summer 2019 ed. Stanford University, 2019. <a href="https://plato.stanford.edu/archives/sum2019/entries/behaviorism">https://plato.stanford.edu/archives/sum2019/entries/behaviorism</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[68]</div><div class="csl-right-inline">List of oldest companies[M/OL]//Wikipedia. (2019-01-13). <a href="https://en.wikipedia.org/w/index.php?title=List_of_oldest_companies&#38;oldid=878158136">https://en.wikipedia.org/w/index.php?title=List_of_oldest_companies&#38;oldid=878158136</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[69]</div><div class="csl-right-inline">Australian Government Productivity Commission, New Zealand Productivity Commission. Strengthening trans-Tasman economic relations[R/OL]. 2012. <a href="https://www.pc.gov.au/inquiries/completed/australia-new-zealand/report/trans-tasman.pdf">https://www.pc.gov.au/inquiries/completed/australia-new-zealand/report/trans-tasman.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[70]</div><div class="csl-right-inline">Canada Council for the Arts. What we heard: Summary of key findings: 2013 Canada Council’s Inter-Arts Office Consultation[R/OL]. 2013. <a href="http://publications.gc.ca/collections/collection_2017/canadacouncil/K23-65-2013-eng.pdf">http://publications.gc.ca/collections/collection_2017/canadacouncil/K23-65-2013-eng.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[71]</div><div class="csl-right-inline">National Cancer Institute. Facing forward: Life after cancer treatment: 18-2424[R/OL]. U.S. Department of Health and Human Services, National Institutes of Health, 2018. <a href="https://www.cancer.gov/publications/patient-education/life-after-cancer-treatment.pdf">https://www.cancer.gov/publications/patient-education/life-after-cancer-treatment.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[72]</div><div class="csl-right-inline">Fried D, Polyakova A. Democratic defense against disinformation[R/OL]. Atlantic Council, 2018. <a href="https://www.atlantic.org/images/publications/Democratic_Defense_Against_Disinformation_FINAL.pdf">https://www.atlantic.org/images/publications/Democratic_Defense_Against_Disinformation_FINAL.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[73]</div><div class="csl-right-inline">Segaert A, Bauer A. The extent and nature of veteran homelessness in Canada[R/OL]. Employment and Social Development Canada, 2015. <a href="https://www.canada.ca/en/employment-social-development/programs/communities/homelessness/publications-bulletins/veterans-report.html">https://www.canada.ca/en/employment-social-development/programs/communities/homelessness/publications-bulletins/veterans-report.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[74]</div><div class="csl-right-inline">Blackwell D L, Lucas J W, Clarke T C. Summary health statistics for U.S. adults: National Health Interview Survey, 2012[R/OL]. Centers for Disease Control and Prevention, 2014. <a href="https://www.atlantic.org/images/publications/Democratic_Defense_Against_Disinformation_FINAL.pdf">https://www.atlantic.org/images/publications/Democratic_Defense_Against_Disinformation_FINAL.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[75]</div><div class="csl-right-inline">British Cardiovascular Society Working Group. British Cardiovascular Society Working Group report: Out-of-hours cardiovascular care: Management of cardiac emergencies and hospital in-patients[R/OL]. British Cardiovascular Society, 2016. <a href="http://www.bcs.com/documents/BCSOOHWP_Final_Report_05092016.pdf">http://www.bcs.com/documents/BCSOOHWP_Final_Report_05092016.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[76]</div><div class="csl-right-inline">U.S. Securities and Exchange Commission. Agency financial report: Fiscal Year 2017[R/OL]. 2017. <a href="https://www.sec.gov/files/sec-2017-agency-financial-report.pdf">https://www.sec.gov/files/sec-2017-agency-financial-report.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[77]</div><div class="csl-right-inline">American Counseling Association. 2014 ACA code of ethics[R/OL]. 2014. <a href="https://www.counseling.org/knowledge-center">https://www.counseling.org/knowledge-center</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[78]</div><div class="csl-right-inline">American Nurses Association. Code of ethics for nurses with interpretive statements[R/OL]. 2015. <a href="https://www.nursingworld.org/coe-view-only">https://www.nursingworld.org/coe-view-only</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[79]</div><div class="csl-right-inline">American Psychological Association. Ethical principles of psychologists and code of conduct[R/OL]. 2017. <a href="https://www.apa.org/ethics/code/index.aspx">https://www.apa.org/ethics/code/index.aspx</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[80]</div><div class="csl-right-inline">Blair C B. Stress, self-regulation and psychopathology in middle childhood: 5R01HD081252-04[R/OL]. Eunice Kennedy Shriver National Institute of Child Health &#38; Human Development, 2015-2020. <a href="https://projectreporter.nih.gov/project_info_details.cfm?aid=9473071&#38;icde=40092311">https://projectreporter.nih.gov/project_info_details.cfm?aid=9473071&#38;icde=40092311</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[81]</div><div class="csl-right-inline">Lichtenstein J. Profile of veteran business owners: More young veterans appear to be starting businesses: 1[R/OL]. U.S. Small Business Administration, Office of Advocacy, 2013. <a href="https://www.sba.org/sites/default/files/Issue%20Brief%201,%20Veteran%20Business%20Owners.pdf">https://www.sba.org/sites/default/files/Issue%20Brief%201,%20Veteran%20Business%20Owners.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[82]</div><div class="csl-right-inline">Harwell M. Don’t expect too much: The limited usefulness of common SES measures and a prescription for change[R/OL]. National Education Policy Center, 2018. <a href="https://nepc.colorado.edu/publication/SES">https://nepc.colorado.edu/publication/SES</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[83]</div><div class="csl-right-inline">U.S. Food and Drug Administration. FDA authorizes first interoperable insulin pup intended to allow patients to customize treatment through their individual diabetes management devices[R/OL]. U.S. Food and Drug Administration, 2019. <a href="https://www.fds.gov/NewsEvents/Newsroom/PressAnnouncements/ucm631412.htm">https://www.fds.gov/NewsEvents/Newsroom/PressAnnouncements/ucm631412.htm</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[84]</div><div class="csl-right-inline">Fistek A, Jester E, Sonnenberg K. Everybody’s got a little music in them: Using music therapy to connect, engage, and motivate[Z/OL]. Milwaukee, WI, United States, 2017. <a href="https://asa.confex.com/asa/2017/webprogramarchives/Session9517.html">https://asa.confex.com/asa/2017/webprogramarchives/Session9517.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[85]</div><div class="csl-right-inline">Maddox S, Hurling J, Stewart E, et al. If mama ain’t happy, nobody’s happy: The effect of parental depression on mood dysregulation in children[Z]. New Orleans, LA, United States, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[86]</div><div class="csl-right-inline">Pearson J. Fat talk and its effects on state-based body image in women[Z/OL]. Sydney, NSW, Australia, 2018. <a href="http://bit.ly/2XGSThP">http://bit.ly/2XGSThP</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[87]</div><div class="csl-right-inline">De Boer D, LaFavor T. The art and significance of successfully identifying resilient individuals A person-focused approach[Z]//Perspectives on resilience: Conceptualization, measurement, and enhancement. Portland, OR, United States, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[88]</div><div class="csl-right-inline">Harris L. Instructional leadership perceptions and practices of elementary school leaders[D]. University of Virginia, 2014.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[89]</div><div class="csl-right-inline">Hollander M M. Resistance to authority: Methodological innovations and new lessons from the Milgram experiment: 10289373[D]. University of Wisconsin–Madison, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[90]</div><div class="csl-right-inline">Hutcheson V H. Dealing with dual differences: Social coping strategies of gifted and lesbian, gay, bisexual, transgender, and queer adolescents[D/OL]. The College of William &#38; Mary, 2012. <a href="https://digitalarchive.wm.edu/bitstream/handle/10288/16594/HutchesonVirginia2012.pdf">https://digitalarchive.wm.edu/bitstream/handle/10288/16594/HutchesonVirginia2012.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[91]</div><div class="csl-right-inline">Mirabito L A, Heck N C. Bringing LGBTQ youth theater into the spotlight[J/OL]. Psychology of Sexual Orientation and Gender Diversity, 2016, 3(4): 499-500. DOI:<a href="https://doi.org/10.1037/sgd0000205">10.1037/sgd0000205</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[92]</div><div class="csl-right-inline">Brodsky E. The year we thought about love[Z]. 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[93]</div><div class="csl-right-inline">Santos F. Reframing refugee children’s stories[N/OL]. The New York Times, 2019-01-11. <a href="https://nyt.ms/2Hlgjk3">https://nyt.ms/2Hlgjk3</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[94]</div><div class="csl-right-inline">Yousafzai M. We are displaced: My journey and stories from refugee girls around the world[M]. 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[95]</div><div class="csl-right-inline">Perkins D. <i>The good place</i> ends its remarkable second season with irrational hope, unexpected gifts, and a smile[EB/OL]. (2018-02-01). <a href="https://www.avclub.com/the-good-place-ends-its-remarkable-second-season-with-i-1822649316">https://www.avclub.com/the-good-place-ends-its-remarkable-second-season-with-i-1822649316</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[96]</div><div class="csl-right-inline">Schur M. Somewhere else[Z]. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[97]</div><div class="csl-right-inline">Yoo J, Miyamoto Y, Rigotti A, et al. Linking positive affect to blood lipids: A cultural perspective[Z]. Department of Psychology, University of Wisconsin-Madison, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[98]</div><div class="csl-right-inline">O’Shea M. Understanding proactive behavior in the workplace as a function of gender[Z]. Department of Management, University of Kansas, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[99]</div><div class="csl-right-inline">Lippincott T, Poindexter E K. Emotion recognition as a function of facial cues: Implications for practice[Z]. Department of Psychology, University of Washington, 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[100]</div><div class="csl-right-inline">Leuker C, Samartzidis L, Hertwig R, et al. When money talks: Judging risk and coercion in high-paying clinical trials[A/OL]. PsyArXiv, 2018. DOI:<a href="https://doi.org/10.17605/OSF.IO/9P7CB">10.17605/OSF.IO/9P7CB</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[101]</div><div class="csl-right-inline">Stults-Kolehmainen M A, Sinha R. The effects of stress on physical activity and exercise[A/OL]. PubMed Central, 2015. <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3894304">https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3894304</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[102]</div><div class="csl-right-inline">Ho H K. Teacher preparation for early childhood special education in Taiwan[A/OL]. ERIC, 2014. <a href="https://files.eric.ed.gov/fulltext/ED545393.pdf">https://files.eric.ed.gov/fulltext/ED545393.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[103]</div><div class="csl-right-inline">D’Souza A, Wiseheart M. Cognitive effects of music and dance training in children: ICPSR 37080[DS/OL]. ICPSR, 2018. DOI:<a href="https://doi.org/10.3886/ICPSR37080.1">10.3886/ICPSR37080.1</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[104]</div><div class="csl-right-inline">National Center for Education Statistics. Fast response survey system (FRSS): Teacher’s use of educational technology in U.S. public schools, 2009: ICPSR 35531[DS/OL]. National Archive of Data on Arts and Culture, 2016. DOI:<a href="https://doi.org/10.3886/ICPSR335531.v3">10.3886/ICPSR335531.v3</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[105]</div><div class="csl-right-inline">Pew Research Center. American trends panel Wave 26[DS/OL]. 2018. <a href="https://www.pewsocialtrends.org/dataset/american-trends-panel-wave-26/">https://www.pewsocialtrends.org/dataset/american-trends-panel-wave-26/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[106]</div><div class="csl-right-inline">Baer R A. Unpublished raw data on the correlations between the Five Facet Mindfulness Questionnaire and the Kentucky Inventory of Mindfulness Skills[DS]. University of Kentucky, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[107]</div><div class="csl-right-inline">Oregan Youth Authority. Recidivism outcomes[DS]. 2011.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[108]</div><div class="csl-right-inline">Borenstein M, Hedges L, Higgins J, et al. Comprehensive meta-analysis[CP/OL]. Biostat, 2014. <a href="https://www.meta-analysis.com/">https://www.meta-analysis.com/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[109]</div><div class="csl-right-inline">SR Research. Eyelink 1000 plus[CP/OL]. 2016. <a href="https://www.sr-research.com/eyelink1000plus.html">https://www.sr-research.com/eyelink1000plus.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[110]</div><div class="csl-right-inline">Tactile Labs. Latero tactile display[CP/OL]. 2015. <a href="https://www.tactilelabs.com/products/haptics/latero-tactile-display/">https://www.tactilelabs.com/products/haptics/latero-tactile-display/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[111]</div><div class="csl-right-inline">Epocrates. Epocrates medical references[CP/OL]. App Store, 2019. <a href="https://itunes.apple.com/us/app/epocrates/id281935788?mt=8">https://itunes.apple.com/us/app/epocrates/id281935788?mt=8</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[112]</div><div class="csl-right-inline">Epocrates. Interaction Check: Aspirin + Sertraline[Z/OL]//Epocrates medical references. Google Play Store, 2019. <a href="https://play.google.com/store/apps/details?id=com.epocrates&#38;hl=en_US">https://play.google.com/store/apps/details?id=com.epocrates&#38;hl=en_US</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[113]</div><div class="csl-right-inline">Tellegen A, Ben-Porath Y S. Minnesota Multiphasic Personality Inventory-2 Restructured Form (MMPI-2-RF): Technical Manual[R]. Pearson, 2011.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[114]</div><div class="csl-right-inline">Project Implicit. Gender-Science IAT[Z/OL]. <a href="https://implicit.harvard.edi/implicit/takeatest.html">https://implicit.harvard.edi/implicit/takeatest.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[115]</div><div class="csl-right-inline">Alonso-Tapia J, Nieto C, Merino-Tejedor E, et al. Situated Goals Questionnaire for University Students (SGQ-U, CMS-U)[DS/OL]. PsycTESTS, 2018. DOI:<a href="https://doi.org/10.1037/t66267-000">10.1037/t66267-000</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[116]</div><div class="csl-right-inline">Cardoza D, Morris J K, Myers H F, et al. Acculturative Stress Inventory (ASI): TC022704[DS]. ETS TestLink, 2000.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[117]</div><div class="csl-right-inline">Forman M. One flew over the cuckoo’s nest[Z]. United Artists, 1975.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[118]</div><div class="csl-right-inline">Accelerated experiental dynamic psychotherapy (AEDP) supervision[Z/educational DVD]. American Pychological Association, 2017. <a href="http://www.apa.org/pubs/videos/4310958.aspx">http://www.apa.org/pubs/videos/4310958.aspx</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[119]</div><div class="csl-right-inline">Jackson P. The lord of the rings: The fellowship of the ring[Z/four-disc special extended ed. on DVD]. WingNut Films; The Saul Zaentz Company, 2001.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[120]</div><div class="csl-right-inline">Malle L. Goodbye children[Z]. Nouvelles Éditions de Films, 1987.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[121]</div><div class="csl-right-inline">The wire[Z]. Blown Deadline Productions; HBO, 2002-2008.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[122]</div><div class="csl-right-inline">Barris K. Lemons: Season 3, Episode 12[Z]//Black-ish. Wilmore Films; Artists First; Cinema Gypsy Productions; ABC Studios, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[123]</div><div class="csl-right-inline">Lynch J. Who shot Mr. Burns? (Part One): Season 6, Episode 25[Z]//The Simpsons. Gracie Films; Twentieth Century Fox Film Corporation, 1995.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[124]</div><div class="csl-right-inline">Giertz S. Why you should make useless things[Z/OL]. TED Conferences, 2018. <a href="https://www.ted.com/talks/simone_giertz_why_you_should_make_useless_things">https://www.ted.com/talks/simone_giertz_why_you_should_make_useless_things</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[125]</div><div class="csl-right-inline">TED. Brené Brown: Listening to shame[Z/OL]. YouTube, 2012. <a href="https://www.youtube.com/watch?v=psN1DORYYV0">https://www.youtube.com/watch?v=psN1DORYYV0</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[126]</div><div class="csl-right-inline">Goldberg J F. Evaluating adverse drug effects[Z/OL]. American Psychiatric Association, 2018. <a href="https://education.psychiatry.org/Users/ProductDetails.aspx?ActivityID=6172">https://education.psychiatry.org/Users/ProductDetails.aspx?ActivityID=6172</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[127]</div><div class="csl-right-inline">Cutts S. Happiness[Z/OL]. Vimeo, 2017. <a href="https://vimeo.com/244405542">https://vimeo.com/244405542</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[128]</div><div class="csl-right-inline">Fogarty M. How to diagram a sentence (absolute basics)[Z/OL]. YouTube, 2016. <a href="https://youtube.be/deiEY5Yq1ql">https://youtube.be/deiEY5Yq1ql</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[129]</div><div class="csl-right-inline">University of Oxford. How do geckos walk on water?[Z/OL]. YouTube, 2016. <a href="https://www.youtube.com/watch?v=qm1xGfOZJc8">https://www.youtube.com/watch?v=qm1xGfOZJc8</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[130]</div><div class="csl-right-inline">Bach J S. The Brandenburg concertos: Concertos BVW 1043 &#38; 1060[Z]. Decca, 2010.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[131]</div><div class="csl-right-inline">Bowie D. Blackstar[Z]. Columbia, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[132]</div><div class="csl-right-inline">van Beethoven L. Symphony No. 3 in E-flat major[Z]//Beethoven: Complete Symphonies. Brilliant Classics, 2012.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[133]</div><div class="csl-right-inline">Beyoncé. Formation[Z]//Lemonade. Parkwood; Columbia, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[134]</div><div class="csl-right-inline">Childish Gambino. This is America[Z]. mcDJ; RCA, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[135]</div><div class="csl-right-inline">Lamar K. Humble[Z]//Damn. Aftermath Entertainment; Interscope Records; Top Dawg Entertainment, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[136]</div><div class="csl-right-inline">Vedantam S. Hidden brain[Z/OL]. NPR, 2015. <a href="https://www.npr.org/series/423302056/hidden-brain">https://www.npr.org/series/423302056/hidden-brain</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[137]</div><div class="csl-right-inline">Glass I. Amusement park: 443[Z/OL]//This American Life. WBEZ Chicago, 2011. <a href="https://www.thisamericanlife.org/radio-archives/episode/443/amusement-park">https://www.thisamericanlife.org/radio-archives/episode/443/amusement-park</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[138]</div><div class="csl-right-inline">de Beauvoir S. Simone de Beauvoir discusses the art of writing[Z/OL]. Studs Terkel Radio Archive; The Chicago History Museum, 1960. <a href="https://studsterkel.wfmt.com/programs/simone-de-beauvoir-discusses-art-writing">https://studsterkel.wfmt.com/programs/simone-de-beauvoir-discusses-art-writing</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[139]</div><div class="csl-right-inline">King M L Jr. I have a dream[Z/OL]. American Rhetoric, 1963. <a href="https://www.americanrhetoric.com/speeches/mlkihaveadream.htm">https://www.americanrhetoric.com/speeches/mlkihaveadream.htm</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[140]</div><div class="csl-right-inline">Delacroix E. Faust attempts to seduce Marguerite[Z]. Paris, France: The Louvre, 1826-1827.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[141]</div><div class="csl-right-inline">Wood G. American gothic[Z/OL]. Chicago, IL, United States: Art Institute of Chicago, 1930. <a href="https://www.artic.edu/aic/collections/artwork/6565">https://www.artic.edu/aic/collections/artwork/6565</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[142]</div><div class="csl-right-inline">GDJ. Neural network deep learning prismatic[Z/OL]. Openclipart, 2018. <a href="https://openclipart.org/detail/309343/neural-network-deep-learning-prismatic">https://openclipart.org/detail/309343/neural-network-deep-learning-prismatic</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[143]</div><div class="csl-right-inline">Rossman J, Palmer R. Sorting through our space junk[Z/OL]. World Science Festival, 2015. <a href="https://www.worldsciencefestival.com/2015/11/space-junk-infographic/">https://www.worldsciencefestival.com/2015/11/space-junk-infographic/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[144]</div><div class="csl-right-inline">Cable D. The racial dot map[CM/OL]. University of Virginia: Weldon Cooper Center for Public Service, 2013. <a href="https://demographics.coopercenter.org/Racial-Dot-Map">https://demographics.coopercenter.org/Racial-Dot-Map</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[145]</div><div class="csl-right-inline">Google. Google Maps directions for driving from La Paz, Bolivia, to Lima, Peru[CM/OL]. [2020-02-16]. <a href="https://goo.gl/YYE3GR">https://goo.gl/YYE3GR</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[146]</div><div class="csl-right-inline">McCurry S. Afghan girl[Z/OL]. National Geographic, 1985. <a href="https://www.nationalgeographic.com/magazine/national-geographic-magazine-50-years-of-covers/#/ngm-1985-jun-714.jpg">https://www.nationalgeographic.com/magazine/national-geographic-magazine-50-years-of-covers/#/ngm-1985-jun-714.jpg</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[147]</div><div class="csl-right-inline">Rinaldi J. Photograph series of a boy who finds his footing after abuse by those he trusted[Z/OL]. The Pulitzer Prizes, 2016. <a href="https://www.pulitzer.org/winners/jessica-rinaldi">https://www.pulitzer.org/winners/jessica-rinaldi</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[148]</div><div class="csl-right-inline">Canan E, Vasilev J. Lecture notes on resource allocation[Z/OL]. Department of Management Control and Information Systems, University of Chile, 2019. <a href="https://uchilefau.academia.edu/ElseZCanan">https://uchilefau.academia.edu/ElseZCanan</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[149]</div><div class="csl-right-inline">Housand B. Game on! Integrating games and simulations in the classroom[Z/OL]. SlideShare, 2016. <a href="https://www.slideshare.net/brianhousand/game-on-iagc-2016/">https://www.slideshare.net/brianhousand/game-on-iagc-2016/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[150]</div><div class="csl-right-inline">Mack R, Spake G. Citing open source images and formatting references for presentations[Z/OL]. Canvas@FNU, 2018. <a href="https://fnu.onelogin.com/login">https://fnu.onelogin.com/login</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[151]</div><div class="csl-right-inline">APA Education [@APAEducation]. College students are forming mental-health Clubs—and they’re making a difference @washingtonpost [Thumbnail with link attached][EB/OL]. (2018-06-29). <a href="https://twitter.com/apaeducation/status/1012810490530140161">https://twitter.com/apaeducation/status/1012810490530140161</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[152]</div><div class="csl-right-inline">Badlands National Park [@BadlandsNPS]. Biologists have identified more than 400 different plant species growing in @BadlandsNPS #DYK #biodoversity[EB/OL]. (2018-02-26). <a href="https://twitter.com/BadlandsNPS/status/968196500412133379">https://twitter.com/BadlandsNPS/status/968196500412133379</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[153]</div><div class="csl-right-inline">White B. I treasure every minute we spent together #koko [image attached][EB/OL]. (2018-06-21). <a href="https://twitter.com/BettyMWhite/status/1009951892846227456">https://twitter.com/BettyMWhite/status/1009951892846227456</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[154]</div><div class="csl-right-inline">APA Style [@APA_Style]. Tweets[EB/OL]. [2019-11-01]. <a href="https://twitter.com/APA_Style">https://twitter.com/APA_Style</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[155]</div><div class="csl-right-inline">Gaiman N. 100,000+ Rohingya refugees could be at serious risk during Bangladesh’s monsoon season. My fellow UNHCR Goodwill Ambassador Cate Blanchett is [Image attached][EB/OL]. (2018-03-22). <a href="http://bit.ly/2JQxPAD">http://bit.ly/2JQxPAD</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[156]</div><div class="csl-right-inline">National Institute of Mental Health. Suicide affects all ages, genders, races, and ethnicities. Check out these 5 Action Steps for Helping Someone in Emotional Pain[EB/OL]. (2018-11-28). <a href="http://bit.ly/321Qstq">http://bit.ly/321Qstq</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[157]</div><div class="csl-right-inline">News From Science. These frogs walk instead of hop. https://scimag.2KlriwH[EB/OL]. (2018-06-26). <a href="https://www.facebook.com/ScienceNOW/videos/10155508587605108">https://www.facebook.com/ScienceNOW/videos/10155508587605108</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[158]</div><div class="csl-right-inline">Smithsonian’s National Zoo and Conservation Biology Institute. Home[EB/OL]. [2019-07-22]. <a href="https://www.facebookcom/nationalzoo">https://www.facebookcom/nationalzoo</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[159]</div><div class="csl-right-inline">Zeitz MOCAA [@zeitzmocaa]. Grade 6 learners from Parkfields Primary School in Hanover Park visited the museum for a tour and workshop hosted by[EB/OL]. (2018-11-26). <a href="https://www.instagram.com/p/BqpHpjFBs3b">https://www.instagram.com/p/BqpHpjFBs3b</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[160]</div><div class="csl-right-inline">The New York Public Library [@nypl]. The raven[EB/OL]. [2019-04-16]. <a href="https://bitly.com/2FV8bu3">https://bitly.com/2FV8bu3</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[161]</div><div class="csl-right-inline">National Aeronautics and Space Administration [@nasa]. I’m NASA Astronaut Scott Tingle. Ask me anything about adjusting to being back on Earth after my first spaceflight![EB/OL]. (2018-09-12). <a href="https://www.reddit.com/r/IAmA/comments/9fagqy/im_nasa_astronaut_scott_tingle_ask_me_anything/">https://www.reddit.com/r/IAmA/comments/9fagqy/im_nasa_astronaut_scott_tingle_ask_me_anything/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[162]</div><div class="csl-right-inline">Avramova N. The secret to a long, happy, health life? Think age-positive[EB/OL]. (2019-01-03). <a href="https://www.cnn.com/2019/01/03/health/respect-towards-elderly-leads-to-long-life-intl/index.html">https://www.cnn.com/2019/01/03/health/respect-towards-elderly-leads-to-long-life-intl/index.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[163]</div><div class="csl-right-inline">Bologna C. What happens to your mind and body when you feel homesick?[EB/OL]. (2018-06-27). <a href="https://www.huffingtonpost.com/entry/what-happens-mind-body-homesick_us_5b201ebde4b09d7a3d77eee1">https://www.huffingtonpost.com/entry/what-happens-mind-body-homesick_us_5b201ebde4b09d7a3d77eee1</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[164]</div><div class="csl-right-inline">Centers for Disease Control and Prevention. People at high risk of developing flu-related complications[EB/OL]. (2018-01-23). <a href="https://www.cdc.gov/flu/about/disease/high_risk.htm">https://www.cdc.gov/flu/about/disease/high_risk.htm</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[165]</div><div class="csl-right-inline">World Health Organization. Questions and answers on immunization and vaccine safety[EB/OL]. 2018. <a href="https://www.who.int/features/qa/84/en/">https://www.who.int/features/qa/84/en/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[166]</div><div class="csl-right-inline">Martin Lillie C M. Be kind to yourself: How self-compassion can improve your resiliency[EB/OL]. (2016-12-29). <a href="https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/self-compassion-can-improve-your-resiliency/art-20267193">https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/self-compassion-can-improve-your-resiliency/art-20267193</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[167]</div><div class="csl-right-inline">Boddy J, Neumann T, Jennings S, et al. Ethics principles[EB/OL]. <a href="http://www.ethicsguidebook.ac.uk/EthicsPrinciples">http://www.ethicsguidebook.ac.uk/EthicsPrinciples</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[168]</div><div class="csl-right-inline">National Nurses United. What employers should do to protect nurses from Zika[EB/OL]. <a href="https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika">https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[169]</div><div class="csl-right-inline">U.S. Census Bureau. U.S. and world population clock[EB/OL]. [2019-07-03]. <a href="https://www.census.gov/popclock/">https://www.census.gov/popclock/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[170]</div><div class="csl-right-inline">Brown v. Board of Education[A/OL]//U.S.: Vol. 347. 1954: 483. <a href="http://www.oyez.org/cases/1940-1955/347us483">http://www.oyez.org/cases/1940-1955/347us483</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[171]</div><div class="csl-right-inline">Obergefell v. Hodges[A/OL]//U.S.: Vol. 576. 2015. <a href="https://www.supremecourt.gov/opinions/14pdf/14-556_3204.pdf">https://www.supremecourt.gov/opinions/14pdf/14-556_3204.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[172]</div><div class="csl-right-inline">Daubert v. Merrell Dow Pharmaceuticals, Inc.[A/OL]//F.2d: Vol. 951. 1991: 1128. <a href="https://openjurist.org/951/f2d/1128/william-dabert-v-merrell-dow-pharmaceuticals">https://openjurist.org/951/f2d/1128/william-dabert-v-merrell-dow-pharmaceuticals</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[173]</div><div class="csl-right-inline">Burriola v. Greater Toledo YMCA[A/OL]//F.Supp.2d: Vol. 133. 2001: 1034. <a href="https://law.justia.com/cases/federal/district-courts/FSupp2/133/1034/2293141/">https://law.justia.com/cases/federal/district-courts/FSupp2/133/1034/2293141/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[174]</div><div class="csl-right-inline">Durflinger v. Artiles[A/OL]//F.Supp.: Vol. 563. 1984: 332. <a href="https://openjurist.org/727/f2d/888/durflinger-v-artiles">https://openjurist.org/727/f2d/888/durflinger-v-artiles</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[175]</div><div class="csl-right-inline">Tarasoff v. Regents of the University of California[A/OL]//Cal.3d: Vol. 17. 1976: 425. <a href="https://www.casebriefs.com/blog/law/torts/tors-keyed-to-dobbs/the-duty-to-protect-from-third-persons/tarasoff-v-regents-of-university-of-california">https://www.casebriefs.com/blog/law/torts/tors-keyed-to-dobbs/the-duty-to-protect-from-third-persons/tarasoff-v-regents-of-university-of-california</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[176]</div><div class="csl-right-inline">Texas v. Morales[A/OL]//S.W.2d: Vol. 826. 1992: 201. <a href="https://www.leagle.com/decision/19921027826sw2d20111010">https://www.leagle.com/decision/19921027826sw2d20111010</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[177]</div><div class="csl-right-inline">American With Disabilities Act of 1990[A/OL]//U.S.C: Vol. 42. 1990. <a href="https://www.ada.gov/pubs/adastatute08.htm">https://www.ada.gov/pubs/adastatute08.htm</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[178]</div><div class="csl-right-inline">Civil Rights Act of 1964: 88-352[A/OL]//Stat.: Vol. 78. 1964: 241. <a href="https://www.govinfo.gov/content/pkg/STATUE-78/pdf/STATUTE-78-Pg241.pdf">https://www.govinfo.gov/content/pkg/STATUE-78/pdf/STATUTE-78-Pg241.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[179]</div><div class="csl-right-inline">Every Student Succeeds Act[A/OL]//U.S.C: Vol. 20. 2015. <a href="https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf">https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[180]</div><div class="csl-right-inline">Lilly Leadbetter Fair Play Act of 2009: 111-2[A/OL]//Stat.: Vol. 123. 2009: 5. <a href="https://www.govinfo.gov/content/pkg/PLAW-111publ2/pdf/PLAW-111publ2.pdf">https://www.govinfo.gov/content/pkg/PLAW-111publ2/pdf/PLAW-111publ2.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[181]</div><div class="csl-right-inline">Patsy Mink Equal Opportunity in Education Act[A/OL]//U.S.C: Vol. 20. 1972. <a href="https://www.justice.org/crt/title-ix-education-amendments-1972">https://www.justice.org/crt/title-ix-education-amendments-1972</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[182]</div><div class="csl-right-inline">Florida Mental Health Act[A/OL]//Fla. Stat. 2009. <a href="http://www.leg.state.fl.us/statues/index.cfm?App_mode=Display_Statute&#38;URL=0300-0399/0394/0394.html">http://www.leg.state.fl.us/statues/index.cfm?App_mode=Display_Statute&#38;URL=0300-0399/0394/0394.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[183]</div><div class="csl-right-inline">Federal real property reform: How cutting red tape and better management count achieve billions in savings, U.S. Senate Committee on Homeland Security and Governmental Affairs[Z/OL]. 2016. <a href="http://www.gsa.gov/portal/content/233107">http://www.gsa.gov/portal/content/233107</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[184]</div><div class="csl-right-inline">Strengthening the federal student loan program for borrowers: Hearing before the U.S. Senate Committee on Health, Education, Labor &#38; Pensions[A/OL]. 2014. <a href="https://www.help.senate.gov/hearings/strengthening-the-federal-student-load-program-for-borrowers">https://www.help.senate.gov/hearings/strengthening-the-federal-student-load-program-for-borrowers</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[185]</div><div class="csl-right-inline">Mental Health on Campus Improvement Act: H.R. 1100[A/OL]. 2013. <a href="https://www.congress.gov/bill/113th-congress/house-bill/1100">https://www.congress.gov/bill/113th-congress/house-bill/1100</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[186]</div><div class="csl-right-inline">S. Res. 438[A/OL]//Cong. Rec.: Vol. 162. 2016: 2394. <a href="https://www.congress.gov/congressional-record/2016/04/21/senate-section/article/S2394-2">https://www.congress.gov/congressional-record/2016/04/21/senate-section/article/S2394-2</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[187]</div><div class="csl-right-inline">H.R. Rep. No. 114-358[R/OL]. 2015. <a href="https://www.gpo.gov/fdsys/pkg/CRPT-114rpt358/pdf/CRPT-114hrpt358.pdf">https://www.gpo.gov/fdsys/pkg/CRPT-114rpt358/pdf/CRPT-114hrpt358.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[188]</div><div class="csl-right-inline">Protection of human subjects[A/OL]//C.F.R.: Vol. 45. 2009. <a href="https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf">https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[189]</div><div class="csl-right-inline">Defining and delimiting the exemptions for executive, administrative, professional, outside sales and computer employees[A/OL]//F.R.: Vol. 81. 2016: 32391. <a href="https://www.federalregister.gov/articles/2016/05/23/2016-11754/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and">https://www.federalregister.gov/articles/2016/05/23/2016-11754/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[190]</div><div class="csl-right-inline">Exec. Order No. 13,676[A/OL]//C.F.R.: Vol. 3. 2014: 294. <a href="https://www.govinfo.gov/content/pkg/CFR-2015-title3-vol1/pdf/CFR-2015-title3-vol1-eo13676.pdf">https://www.govinfo.gov/content/pkg/CFR-2015-title3-vol1/pdf/CFR-2015-title3-vol1-eo13676.pdf</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[191]</div><div class="csl-right-inline">Hiremath S C, Kumar S, Lu F, et al. Using metaphors to present concepts across different intellectual domains: 9,367,592[P/OL]. 2016. <a href="http://patft.uspto.gov/netacgi/nph-Parser?patentnumber=9367592">http://patft.uspto.gov/netacgi/nph-Parser?patentnumber=9367592</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[192]</div><div class="csl-right-inline">U.S. Const. art. I, § 3[A].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[193]</div><div class="csl-right-inline">S.C. Const. art. XI, § 3[A].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[194]</div><div class="csl-right-inline">U.S. Const. amend. XIX[A].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[195]</div><div class="csl-right-inline">U.S. Const. amend. XVIII (repealed 1933)[A].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[196]</div><div class="csl-right-inline">U.S. Const. amend. I-X[A].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[197]</div><div class="csl-right-inline">U.N. Charter art. 1, para. 3[A].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[198]</div><div class="csl-right-inline">United nations convention on the rights of the child[A/OL]. (1989-11-20). <a href="https://www.ohchr.org/en/professionalinterest/pages/crc.aspx">https://www.ohchr.org/en/professionalinterest/pages/crc.aspx</a>.</div>
+  </div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->

--- a/src/东北大学-生命科学与健康学院（本科）/metadata.json
+++ b/src/东北大学-生命科学与健康学院（本科）/metadata.json
@@ -1,0 +1,40 @@
+{
+  "dir": "东北大学-生命科学与健康学院（本科）",
+  "file": "东北大学-生命科学与健康学院（本科）.csl",
+  "style_class": "in-text",
+  "title": "东北大学 - 生命科学与健康学院（本科）",
+  "id": "https://zotero-chinese.com/styles/东北大学-生命科学与健康学院（本科）",
+  "link_self": "https://zotero-chinese.com/styles/东北大学-生命科学与健康学院（本科）",
+  "link_template": "https://zotero-chinese.com/styles/GB-T-7714—2015（顺序编码，双语，全角标点）",
+  "link_documentation": "https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A",
+  "author": [
+    {
+      "name": "牛耕田"
+    }
+  ],
+  "contributor": [
+    {
+      "name": "韩小土"
+    },
+    {
+      "name": "Zeping Lee"
+    },
+    {
+      "name": "吴俊豪"
+    }
+  ],
+  "citation_format": "numeric",
+  "field": "generic-base",
+  "summary": "适用于东北大学生命科学与健康学院本科毕业论文。基于 GB/T 7714—2015 顺序编码双语样式，中文文献使用全角标点（括号除外），姓名不全大写，页码连接符使用半角连字符\"-\"。",
+  "updated": "2026-03-09T00:00:00+08:00",
+  "citations": "<sup>[1-8]</sup>",
+  "bibliography": "<div class=\"csl-bib-body maxoffset-3 second-field-align-flush hangingindent-false\">\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[1]</div><div class=\"csl-right-inline\">扬奎斯特，萨金特．递归宏观经济理论[M]．杨斌，王忠玉，陈彦斌，等，译．2 版．北京：中国人民大学出版社，2010：798．</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[2]</div><div class=\"csl-right-inline\">Praetzellis A. Death by theory: a tale of mystery and archaeological theory[M/OL]. Rev. ed. Rowman &#38; Littlefield Publishing Group, Inc., 2011: 13[2012-07-26]. <a href=\"http://lib.myilibrary.com/Open.aspx?id=293666\">http://lib.myilibrary.com/Open.aspx?id=293666</a>.</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[3]</div><div class=\"csl-right-inline\">于潇，刘义，柴跃廷，等．互联网药品可信交易环境中主体资质审核备案模式[J]．清华大学学报（自然科学版），2012，52(11)：1518-1523．</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[4]</div><div class=\"csl-right-inline\">Veen P H van der, Muller M, Vincken K L, et al. Longitudinal changes in brain volumes and cerebrovascular lesions on MRI in patients with manifest arterial disease: the SMART-MR study[J/OL]. Journal of the Neurological Sciences, 2014, 337(1/2): 112-118[2025-12-02]. <a href=\"https://pubmed.ncbi.nlm.nih.gov/24314719/\">https://pubmed.ncbi.nlm.nih.gov/24314719/</a>. DOI:<a href=\"https://doi.org/10.1016/j.jns.2013.11.029\">10.1016/j.jns.2013.11.029</a>.</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[5]</div><div class=\"csl-right-inline\">汪学军．中国农业转基因生物研发进展与安全管理[C]//国家环境保护总局生物安全管理办公室．中国国家生物安全框架实施国际合作项目研讨会论文集．北京：中国环境科学出版社，2005：22-25．</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[6]</div><div class=\"csl-right-inline\">Wang S. Application of improved SOM neural network in intelligent auditing of hospital financial vouchers[C/OL]//2022 6th Asian Conference on Artificial Intelligence Technology (ACAIT). 2022: 2[2025-12-02]. <a href=\"https://ieeexplore.ieee.org/document/10137867\">https://ieeexplore.ieee.org/document/10137867</a>. DOI:<a href=\"https://doi.org/10.1109/ACAIT56212.2022.10137867\">10.1109/ACAIT56212.2022.10137867</a>.</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[7]</div><div class=\"csl-right-inline\">肖玲，张雪，王永．数据要素的统计测算方法探究[A/OL]．PSSXiv，2024[2024-09-30]．<a href=\"https://zsyyb.cn/abs/202408.01096\">https://zsyyb.cn/abs/202408.01096</a>．</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[8]</div><div class=\"csl-right-inline\">Jenkins S D, Ruostekoski J. Controlled manipulation of light by cooperative response of atoms in an optical lattice[A/OL]. arXiv, 2012[2020-06-24]. <a href=\"https://doi.org/10.48550/arXiv.1112.6136\">https://doi.org/10.48550/arXiv.1112.6136</a>.</div>\n  </div>\n</div>",
+  "tags": [
+    "姓名小写",
+    "有标题",
+    "期刊全称",
+    "有URL",
+    "有DOI",
+    "无英文翻译"
+  ]
+}

--- a/src/东北大学-生命科学与健康学院（本科）/东北大学-生命科学与健康学院（本科）.csl
+++ b/src/东北大学-生命科学与健康学院（本科）/东北大学-生命科学与健康学院（本科）.csl
@@ -1,0 +1,676 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
+  <info>
+    <title>东北大学 - 生命科学与健康学院（本科）</title>
+    <id>https://zotero-chinese.com/styles/东北大学-生命科学与健康学院（本科）</id>
+    <link href="https://zotero-chinese.com/styles/东北大学-生命科学与健康学院（本科）" rel="self"/>
+    <link href="https://zotero-chinese.com/styles/GB-T-7714—2015（顺序编码，双语，全角标点）" rel="template"/>
+    <link href="https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A" rel="documentation"/>
+    <author>
+      <name>牛耕田</name>
+      <email>buffalo_d@163.com</email>
+    </author>
+    <contributor>
+      <name>韩小土</name>
+      <email>redleafnew@163.com</email>
+    </contributor>
+    <contributor>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </contributor>
+    <contributor>
+      <name>吴俊豪</name>
+      <email>neuclhswjh@163.com</email>
+    </contributor>
+    <category citation-format="numeric"/>
+    <category field="generic-base"/>
+    <summary>适用于东北大学生命科学与健康学院本科毕业论文。基于 GB/T 7714—2015 顺序编码双语样式，中文文献使用全角标点（括号除外），姓名不全大写，页码连接符使用半角连字符"-"。</summary>
+    <updated>2026-03-09T00:00:00+08:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="zh">
+    <terms>
+      <term name="edition" form="short">版</term>
+      <term name="open-quote">"</term>
+      <term name="close-quote">"</term>
+      <term name="open-inner-quote">'</term>
+      <term name="close-inner-quote">'</term>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+    </date>
+    <terms>
+      <term name="citation-range-delimiter">-</term>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <!-- 主要责任者 -->
+  <macro name="author-en">
+    <names variable="author">
+      <name>
+        <name-part name="family"/>
+      </name>
+      <institution/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-zh">
+    <names variable="author">
+      <name delimiter="，">
+        <name-part name="family"/>
+      </name>
+      <institution/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 题名 -->
+  <macro name="title-en">
+    <group delimiter=": ">
+      <text variable="title"/>
+      <group delimiter="&#8195;">
+        <choose>
+          <if variable="container-title" type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
+            <text macro="volume"/>
+            <text variable="volume-title"/>
+          </if>
+        </choose>
+        <choose>
+          <if type="article article-journal" match="none">
+            <!-- 预印本和期刊文章的编号用于其他位置 -->
+            <text variable="number"/>
+          </if>
+        </choose>
+        <choose>
+          <if type="collection manuscript personal_communication" match="any">
+            <!-- 档案的卷宗号 -->
+            <text variable="archive_location"/>
+          </if>
+        </choose>
+      </group>
+    </group>
+    <group delimiter="/" prefix="[" suffix="]">
+      <text macro="type-id"/>
+      <text macro="medium-id"/>
+    </group>
+  </macro>
+  <macro name="title-zh">
+    <group delimiter="：">
+      <text variable="title"/>
+      <group delimiter="&#8195;">
+        <choose>
+          <if variable="container-title" type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
+            <text macro="volume"/>
+            <text variable="volume-title"/>
+          </if>
+        </choose>
+        <choose>
+          <if type="article article-journal" match="none">
+            <!-- 预印本和期刊文章的编号用于其他位置 -->
+            <text variable="number"/>
+          </if>
+        </choose>
+        <choose>
+          <if type="collection manuscript personal_communication" match="any">
+            <!-- 档案的卷宗号 -->
+            <text variable="archive_location"/>
+          </if>
+        </choose>
+      </group>
+    </group>
+    <group delimiter="/" prefix="[" suffix="]">
+      <text macro="type-id"/>
+      <text macro="medium-id"/>
+    </group>
+  </macro>
+  <!-- 书籍的卷号（"第 x 卷"或"第 x 册"） -->
+  <macro name="volume">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper periodical" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <group delimiter=" ">
+              <label variable="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- 文献类型标识 -->
+  <macro name="type-id">
+    <choose>
+      <if type="article bill collection hearing legal_case legislation personal_communication regulation treaty" match="any">
+        <!-- 档案，A：分类保存以备查考的文件和材料，如人事档案、科技档案、法律法规、政府文件等。
+          article 为预印本，符合"科技档案"
+        -->
+        <text value="A"/>
+      </if>
+      <else-if type="article-journal article-magazine periodical" match="any">
+        <text value="J"/>
+      </else-if>
+      <else-if type="article-newspaper">
+        <text value="N"/>
+      </else-if>
+      <else-if type="book chapter classic entry-dictionary entry-encyclopedia" match="any">
+        <text value="M"/>
+      </else-if>
+      <else-if type="dataset">
+        <text value="DS"/>
+      </else-if>
+      <else-if type="map">
+        <text value="CM"/>
+      </else-if>
+      <else-if type="paper-conference">
+        <text value="C"/>
+      </else-if>
+      <else-if type="patent">
+        <text value="P"/>
+      </else-if>
+      <else-if type="post post-weblog webpage" match="any">
+        <text value="EB"/>
+      </else-if>
+      <else-if type="report">
+        <text value="R"/>
+      </else-if>
+      <else-if type="software">
+        <text value="CP"/>
+      </else-if>
+      <else-if type="standard">
+        <text value="S"/>
+      </else-if>
+      <else-if type="thesis">
+        <text value="D"/>
+      </else-if>
+      <else>
+        <text value="Z"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 文献载体标识 -->
+  <macro name="medium-id">
+    <choose>
+      <if variable="medium">
+        <text variable="medium"/>
+      </if>
+      <else-if variable="URL DOI" match="any">
+        <text value="OL"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributors-en">
+    <names variable="translator">
+      <name>
+        <name-part name="family"/>
+      </name>
+      <institution/>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="secondary-contributors-zh">
+    <names variable="translator">
+      <name delimiter="，">
+        <name-part name="family"/>
+      </name>
+      <institution/>
+      <label form="short" prefix="，"/>
+    </names>
+  </macro>
+  <!-- 专著主要责任者 -->
+  <macro name="container-contributors-en">
+    <names variable="editor">
+      <name>
+        <name-part name="family"/>
+      </name>
+      <institution/>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="container-contributors-zh">
+    <names variable="editor">
+      <name delimiter="，">
+        <name-part name="family"/>
+      </name>
+      <institution/>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 专著题名 -->
+  <macro name="container-booklike-en">
+    <group delimiter=". ">
+      <text macro="container-contributors-en"/>
+      <choose>
+        <if variable="container-title">
+          <!-- 优先使用专著或会议论文集的题名 -->
+          <group delimiter=": ">
+            <text variable="container-title"/>
+            <text macro="volume"/>
+          </group>
+        </if>
+        <else-if type="paper-conference">
+          <!-- 有些会议没有论文集，使用会议名代替 -->
+          <text variable="event-title"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-booklike-zh">
+    <group delimiter="．">
+      <text macro="container-contributors-zh"/>
+      <choose>
+        <if variable="container-title">
+          <!-- 优先使用专著或会议论文集的题名 -->
+          <group delimiter="：">
+            <text variable="container-title"/>
+            <text macro="volume"/>
+          </group>
+        </if>
+        <else-if type="paper-conference">
+          <!-- 有些会议没有论文集，使用会议名代替 -->
+          <text variable="event-title"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 连续出版物中的出处项 -->
+  <macro name="container-periodical-en">
+    <choose>
+      <if type="article-newspaper">
+        <!-- 报纸的出处项："刊名, 出版日期(版次): 页码[引用日期]" -->
+        <group delimiter=", ">
+          <text variable="container-title"/>
+          <text macro="issued-date"/>
+        </group>
+        <text variable="page" prefix="(" suffix=")"/>
+      </if>
+      <else>
+        <!-- 期刊、杂志的出处项："刊名, 年, 卷(期): 页码[引用日期]" -->
+        <group delimiter=": ">
+          <group>
+            <group delimiter=", ">
+              <text variable="container-title"/>
+              <text macro="issued-year-en"/>
+              <text variable="volume"/>
+            </group>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <choose>
+            <if variable="page">
+              <text variable="page"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+    <text macro="accessed-date-en"/>
+  </macro>
+  <macro name="container-periodical-zh">
+    <choose>
+      <if type="article-newspaper">
+        <!-- 报纸的出处项："刊名，出版日期（版次）：页码[引用日期]" -->
+        <group delimiter="，">
+          <text variable="container-title"/>
+          <text macro="issued-date"/>
+        </group>
+        <text variable="page" prefix="(" suffix=")"/>
+      </if>
+      <else>
+        <!-- 期刊、杂志的出处项："刊名，年，卷(期)：页码[引用日期]" -->
+        <group delimiter="：">
+          <group>
+            <group delimiter="，">
+              <text variable="container-title"/>
+              <text macro="issued-year-zh"/>
+              <text variable="volume"/>
+            </group>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <choose>
+            <if variable="page">
+              <text variable="page"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+    <text macro="accessed-date-zh"/>
+  </macro>
+  <!-- 版本项 -->
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 连续出版物的年卷期 -->
+  <macro name="year-volume-issue-en">
+    <group delimiter=", ">
+      <text macro="issued-year-en"/>
+      <text variable="volume"/>
+    </group>
+    <text variable="issue" prefix="(" suffix=")"/>
+  </macro>
+  <macro name="year-volume-issue-zh">
+    <group delimiter="，">
+      <text macro="issued-year-zh"/>
+      <text variable="volume"/>
+    </group>
+    <text variable="issue" prefix="(" suffix=")"/>
+  </macro>
+  <!-- 出版项 -->
+  <macro name="publisher-en">
+    <choose>
+      <if type="patent">
+        <!-- 专利的出版项格式"公告日期[引用日期]" -->
+        <text macro="issued-date"/>
+        <text macro="accessed-date-en"/>
+      </if>
+      <else-if type="book chapter paper-conference periodical thesis" variable="archive archive-place publisher publisher-place page" match="any">
+        <!-- 非纯电子资源的格式"出版地: 出版者, 出版年: 页码[引用日期]" -->
+        <group delimiter=": ">
+          <group delimiter=", ">
+            <group delimiter=": ">
+              <choose>
+                <if variable="publisher publisher-place" match="any">
+                  <text variable="publisher-place"/>
+                  <text variable="publisher"/>
+                </if>
+                <else>
+                  <!-- 档案的馆藏地以及收藏机构或单位 -->
+                  <text variable="archive-place"/>
+                  <text variable="archive"/>
+                </else>
+              </choose>
+            </group>
+            <text macro="issued-year-en"/>
+          </group>
+          <text variable="page"/>
+        </group>
+        <text macro="accessed-date-en"/>
+      </else-if>
+      <else-if variable="URL DOI" match="any">
+        <!-- 纯电子资源联机网络文献的格式"(更新或修改日期)[引用日期]"。
+          原国标中，电子公告、无出版社的报告、法规等文献都可以作为"纯电子文献"。
+        -->
+        <choose>
+          <if has-day="issued">
+            <text macro="issued-date" prefix="(" suffix=")"/>
+          </if>
+          <else-if variable="issued">
+            <text macro="issued-year-en"/>
+          </else-if>
+        </choose>
+        <text macro="accessed-date-en"/>
+      </else-if>
+      <else>
+        <text macro="issued-year-en"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-zh">
+    <choose>
+      <if type="patent">
+        <!-- 专利的出版项格式"公告日期[引用日期]" -->
+        <text macro="issued-date"/>
+        <text macro="accessed-date-zh"/>
+      </if>
+      <else-if type="book chapter paper-conference periodical thesis" variable="archive archive-place publisher publisher-place page" match="any">
+        <!-- 非纯电子资源的格式"出版地：出版者，出版年：页码[引用日期]" -->
+        <group delimiter="：">
+          <group delimiter="，">
+            <group delimiter="：">
+              <text variable="publisher-place"/>
+              <text variable="publisher"/>
+            </group>
+            <text macro="issued-year-zh"/>
+          </group>
+          <text variable="page"/>
+        </group>
+        <text macro="accessed-date-zh"/>
+      </else-if>
+      <else-if variable="URL DOI" match="any">
+        <!-- 纯电子资源联机网络文献的格式"(更新或修改日期)[引用日期]"。
+          原国标中，电子公告、无出版社的报告、法规等文献都可以作为"纯电子文献"。
+        -->
+        <choose>
+          <if has-day="issued">
+            <text macro="issued-date" prefix="(" suffix=")"/>
+          </if>
+          <else-if variable="issued">
+            <text macro="issued-year-zh"/>
+          </else-if>
+        </choose>
+        <text macro="accessed-date-zh"/>
+      </else-if>
+      <else>
+        <text macro="issued-year-zh"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 出版年 -->
+  <macro name="issued-year-en">
+    <choose>
+      <if is-uncertain-date="issued">
+        <!-- 出版年无法确定时, 估计的出版年应置于方括号内。 -->
+        <date variable="issued" prefix="[" suffix="]">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year-zh">
+    <choose>
+      <if is-uncertain-date="issued">
+        <!-- 出版年无法确定时，估计的出版年应置于方括号内。 -->
+        <date variable="issued" prefix="[" suffix="]">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <!-- 出版日期，用于报纸文献、专利的"公告日期或公开日期"、电子资源的"更新或修改日期" -->
+  <macro name="issued-date">
+    <date variable="issued" form="numeric"/>
+  </macro>
+  <!-- 引用日期 -->
+  <macro name="accessed-date-en">
+    <choose>
+      <if variable="URL DOI" match="any">
+        <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="accessed-date-zh">
+    <choose>
+      <if variable="URL DOI" match="any">
+        <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- 获取和访问路径、数字对象唯一标识符 -->
+  <macro name="access-en">
+    <group delimiter=". ">
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <macro name="access-zh">
+    <group delimiter="．">
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 参考文献表格式 -->
+  <macro name="entry-layout-en">
+    <group delimiter=". ">
+      <text macro="author-en"/>
+      <choose>
+        <if type="periodical">
+          <!-- 4.3 连续出版物 -->
+          <text macro="title-en"/>
+          <text macro="year-volume-issue-en"/>
+          <text macro="publisher-en"/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper" match="any">
+          <!-- 4.4 连续出版物中的析出文献 -->
+          <text macro="title-en"/>
+          <text macro="container-periodical-en"/>
+        </else-if>
+        <else-if type="patent">
+          <!-- 4.5 专利文献 -->
+          <text macro="title-en"/>
+          <text macro="publisher-en"/>
+        </else-if>
+        <else-if type="dataset post post-weblog software webpage" match="any">
+          <!-- 4.6 电子资源 -->
+          <text macro="title-en"/>
+          <text macro="publisher-en"/>
+        </else-if>
+        <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" variable="container-title" match="any">
+          <!-- 4.2 专著中的析出文献 -->
+          <group delimiter="//">
+            <group delimiter=". ">
+              <text macro="title-en"/>
+              <text macro="secondary-contributors-en"/>
+            </group>
+            <text macro="container-booklike-en"/>
+          </group>
+          <text macro="edition"/>
+          <text macro="publisher-en"/>
+        </else-if>
+        <else>
+          <!-- 4.1 专著 -->
+          <text macro="title-en"/>
+          <text macro="secondary-contributors-en"/>
+          <text macro="edition"/>
+          <text macro="publisher-en"/>
+        </else>
+      </choose>
+      <text macro="access-en"/>
+    </group>
+  </macro>
+  <macro name="entry-layout-zh">
+    <group delimiter="．">
+      <text macro="author-zh"/>
+      <choose>
+        <if type="periodical">
+          <!-- 4.3 连续出版物 -->
+          <text macro="title-zh"/>
+          <text macro="year-volume-issue-zh"/>
+          <text macro="publisher-zh"/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper" match="any">
+          <!-- 4.4 连续出版物中的析出文献 -->
+          <text macro="title-zh"/>
+          <text macro="container-periodical-zh"/>
+        </else-if>
+        <else-if type="patent">
+          <!-- 4.5 专利文献 -->
+          <text macro="title-zh"/>
+          <text macro="publisher-zh"/>
+        </else-if>
+        <else-if type="dataset post post-weblog software webpage" match="any">
+          <!-- 4.6 电子资源 -->
+          <text macro="title-zh"/>
+          <text macro="publisher-zh"/>
+        </else-if>
+        <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" variable="container-title" match="any">
+          <!-- 4.2 专著中的析出文献 -->
+          <group delimiter="//">
+            <group delimiter="．">
+              <text macro="title-zh"/>
+              <text macro="secondary-contributors-zh"/>
+            </group>
+            <text macro="container-booklike-zh"/>
+          </group>
+          <text macro="edition"/>
+          <text macro="publisher-zh"/>
+        </else-if>
+        <else>
+          <!-- 4.1 专著 -->
+          <text macro="title-zh"/>
+          <text macro="secondary-contributors-zh"/>
+          <text macro="edition"/>
+          <text macro="publisher-zh"/>
+        </else>
+      </choose>
+      <text macro="access-zh"/>
+    </group>
+  </macro>
+  <citation collapse="citation-number" after-collapse-delimiter=",">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout vertical-align="sup" delimiter="," prefix="[" suffix="]">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush">
+    <layout locale="en">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout-en" suffix="."/>
+    </layout>
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout-zh" suffix="．"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
## 新增样式

新增 **东北大学 - 生命科学与健康学院（本科）** 引用样式，适用于东北大学生命科学与健康学院本科毕业论文。

[东北大学生命学院本科生毕业设计（论文）书写印制规范（学校2024.11基础上完善版）.docx](https://github.com/user-attachments/files/25933922/2024.11.docx)


## 样式说明

基于 GB/T 7714—2015（顺序编码，双语，全角标点）衍生，主要特性如下：

1. 中文文献使用全角标点（逗号、句号、冒号等），括号（包括方括号与圆括号）统一使用半角
2. 姓名不全大写
3. 页码连接符使用半角连字符 `-`

## 已知局限

东北大学生命科学与健康学院本科毕设规范要求中文文献的句点使用**半角句点+宋体**，但 CSL 标准不支持对特定标点符号指定字体，这应该交给排版工具完成，因此本样式仍以**全角句点作近似处理**。如需严格匹配，需在排版工具中手动替换。

## 测试

已通过 `pnpm preview` 本地验证，`metadata.json` 与 `index.md` 均由脚本自动生成。
