### PR TITLE
中国农业科学：改正不合法的`<name-part>`用法

### DIFF
--- a/src/中国农业科学/中国农业科学.csl
+++ b/src/中国农业科学/中国农业科学.csl
@@ -61,8 +61,9 @@
     <choose>
       <if variable="original-author">
         <names variable="original-author">
-          <name initialize="true" initialize-with=" " sort-separator=",  "/>
-          <name-part name="family" text-case="uppercase"/>
+          <name initialize="true" initialize-with=" " sort-separator=",  ">
+            <name-part name="family" text-case="uppercase"/>
+          </name>
         </names>
       </if>
       <else>


### PR DESCRIPTION
6e91814107900e0f59d1ffb524758d4680fcba63 添加了这处`<name-part>`，但并未加到`<name>`中，不符合CSL标准。

将当前版本 CSL 上传到 [CSL Validator (forked by Typst Chinese Community)](https://typst-doc-cn.github.io/csl-validator/?url=https%3A%2F%2Fgithub.com%2Fzotero-chinese%2Fstyles%2Fraw%2F6e91814%2Fsrc%2F%E4%B8%AD%E5%9B%BD%E5%86%9C%E4%B8%9A%E7%A7%91%E5%AD%A6%2F%E4%B8%AD%E5%9B%BD%E5%86%9C%E4%B8%9A%E7%A7%91%E5%AD%A6.csl&version=zotero-chinese%3A4e791b3)，会报以下错误：

> Line 65: Element “name-part” from namespace “http://purl.org/net/xbiblio/csl” not allowed as child of element “names” from namespace “http://purl.org/net/xbiblio/csl” in this context. (Suppressing further errors from this subtree.)
