### PR TITLE
新增地球科学（英文版）CSL 样式

### DIFF
--- a/src/地球科学（英文版）/cites.json
+++ b/src/地球科学（英文版）/cites.json
@@ -1,0 +1,38 @@
+[
+  [
+    {
+      "id": "jes-citation-kusky"
+    },
+    {
+      "id": "jes-citation-green"
+    },
+    {
+      "id": "jes-citation-smith"
+    }
+  ],
+  [
+    {
+      "id": "jes-periodical"
+    }
+  ],
+  [
+    {
+      "id": "jes-book"
+    }
+  ],
+  [
+    {
+      "id": "jes-chapter"
+    }
+  ],
+  [
+    {
+      "id": "jes-periodical-chapter"
+    }
+  ],
+  [
+    {
+      "id": "jes-thesis"
+    }
+  ]
+]

--- a/src/地球科学（英文版）/index.md
+++ b/src/地球科学（英文版）/index.md
@@ -1,0 +1,642 @@
+<!-- 此文件由脚本自动生成，请勿手动修改！ -->
+<!-- markdownlint-disable -->
+<!-- prettier-ignore -->
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE FILE -->
+
+## 样式预览
+
+### 引注
+
+(Smith et al., 2012; Green and Jin, 2008; Kusky, 2000)<br>
+(Chough and Barg, 1987)<br>
+(Shrock, 1948)<br>
+(Sun, 1984)<br>
+(Fox et al., 1971)<br>
+(Zhang, 2006)<br>
+
+
+### 参考文献表
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-false">
+  <div class="csl-entry">Chough, S. K., Barg, E., 1987. Tectonic History of Ulleung Basin Margin, East Sea (Sea of Japan). <i>Geology</i>, 15(1): 45. <a href="https://doi.org/10.1130/0091-7613(1987)15&#60;45:thoubm&#62;2.0.co;2">https://doi.org/10.1130/0091-7613(1987)15&#60;45:thoubm&#62;2.0.co;2</a></div>
+  <div class="csl-entry">Fox, P. J., Ruddiman, W. F., Ryan, W. B. F., et al., 1971. The Geology of the Caribbean Crust, I. Beata Ridge. In: Heezen, B. C., Kosminskaya, I. P., eds., The Structure of the Crust and Mantle beneath Inland and Marginal Seas. <i>Tectonophysics</i>, 10: 495–513. <a href="https://doi.org/10.1016/0040-1951(70)90041-7">https://doi.org/10.1016/0040-1951(70)90041-7</a></div>
+  <div class="csl-entry">Green, A., Jin, B., 2008. Example Paper with Two Authors. <i>Journal of Earth Science</i>, 1: 11–20.</div>
+  <div class="csl-entry">Kusky, T., 2000. Example Paper with One Author. <i>Journal of Earth Science</i>, 1: 21–30.</div>
+  <div class="csl-entry">Shrock, R. R., 1948. Sequence in Layered Rocks. McGraw-Hill, New York. 507</div>
+  <div class="csl-entry">Smith, A., Brown, B., Clark, C., et al., 2012. Example Paper with Four Authors. <i>Journal of Earth Science</i>, 1: 1–10.</div>
+  <div class="csl-entry">Sun, S. S., 1984. Geochemical Characteristics of Archean Ultramafic and Mafic Volcanic Rocks: Implication and Evolution. In: Kroner, A., Lansor, G. N., Goodwin, A. M., eds., Archean Geochemistry. Springer-Verlag, Berlin. 25–46</div>
+  <div class="csl-entry">Zhang, W. L., 2006. The High Precise Cenozoic Magnetostratigraphy of the Qaidam Basin and Uplift of the Northern Tibetan Plateau: [Dissertation]. Lanzhou University, Lanzhou. 95–105 (in Chinese)</div>
+</div>
+
+## 默认测试
+
+### 引注
+
+(张三, 2008)<br>
+张三 (2008)<br>
+(Jason, 2008)<br>
+Jason (2008)<br>
+张三 and 李四 (2008)<br>
+Wang and Sun (2009)<br>
+(Wolchik and West, 2009; 赵一 and 陈二, 2008)<br>
+张三, 李四, and 王五 (2008)<br>
+Wang, Sun and Zheng (2009)<br>
+(Wolchik, West and Sandler, 2009; 赵一, 陈二, and 张三, 2008)<br>
+张三, 李四, and 赵一 (2019)<br>
+张三, 王五, and 钱二 (2019)<br>
+Qian et al. (2020a)<br>
+Qian et al. (2020b)<br>
+(Qian et al., 2020a; 张三, 李四, and 赵一, 2019)<br>
+张三, 李四, and 王五 (2020)<br>
+张三, 李四, and 赵六 (2020)<br>
+Qian et al. (2009a)<br>
+Qian et al. (2009b)<br>
+(张三, 李四, and 王五, 2020)<br>
+(Qian et al., 2009a)<br>
+(Wong, 2007)<br>
+(Wong, 2008)<br>
+(Edeline and Weinberger, n.d., 2002b, 2002a, 2005)<br>
+(Chen, 2006; Deng and Feng, 2005; Bai, 2002)<br>
+
+
+### GB/T 7714—2025 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-false">
+  <div class="csl-entry">American Association for the Advancement of Science, eds., 1883. Science. 1883，1（1）—. tex.entrytype: periodical</div>
+  <div class="csl-entry">American Institute of Aeronautics and Astronautics (AIAA), 2022. Guide to Lithium Battery Safety for Space Applications. </div>
+  <div class="csl-entry">António, M., Pepper, L., 2019. Histórias de Portugal: livros caídos. <a href="https://arquivo.pt/wayback/20190905210731/http://publico.pt/2019/07/13/sociedade/noticia/podcast-historias-portugal-cuidadores-1879731">https://arquivo.pt/wayback/20190905210731/http://publico.pt/2019/07/13/sociedade/noticia/podcast-historias-portugal-cuidadores-1879731</a></div>
+  <div class="csl-entry">Babu, B. V., Nagar, A., Deep, K., et al., eds., 2014. Proceedings of the Second International Conference on Soft Computing for Problem Solving (SocProS 2012), December 28-30, 2012. Springer, New Delhi. tex.entrytype: proceedings</div>
+  <div class="csl-entry">Bevington, D., Brown, J. R., 2025. William Shakespeare. <a href="https://www.britannica.com/biography/William-Shakespeare">https://www.britannica.com/biography/William-Shakespeare</a></div>
+  <div class="csl-entry">Bloss, C. S., Wineinger, N. E., Peters, M., et al., 2015. A Prospective Randomized Trial Examining Health Care Utilization in Individuals Using Multiple Smartphone-Enabled Biosensors. tex.doi: 10.1101/029983</div>
+  <div class="csl-entry">Boobier, T., 2020. AI and the Future of Banking. John Wiley &#38; Sons, Chichester. 35 10.1002/9781119596165</div>
+  <div class="csl-entry">Cairns, B. R., 1965. Infrared Spectroscopic Studies on Solid Oxygen: [Doctoral dissertation]. University of California, Berkeley, Berkeley. 15</div>
+  <div class="csl-entry">Calkin, D. E., Ager, A. A., Thompson, M. P., 2011. A Comparative Risk Assessment Framework for Wildland Fire Management: The 2010 Cohesive Strategy Science Report. : 8–9.</div>
+  <div class="csl-entry">Caplan, P., 1993. Cataloging Internet Resources. <i>The Public-Access Computer Systems Review</i>, 4(2): 61–66.</div>
+  <div class="csl-entry">Christou, A., 2024. Improving Knowledge Graph Understanding with Contextual Views: [Doctoral dissertation]. Wright State University, Ohio. 18</div>
+  <div class="csl-entry">Cribb, R., 2015. Historical Atlas of Indonesia. tex.entrytype: map</div>
+  <div class="csl-entry">Des Marais, D. J., Strauss, H., Summons, R. E., et al., 1992. Carbon Isotope Evidence for the Stepwise Oxidation of the Proterozoic Environment. <i>Nature</i>, 359: 605–609.</div>
+  <div class="csl-entry">Deverell, W., Igler, D., eds., 2013. A Companion to California History. John Wiley &#38; Sons, New York. 21–22 tex.DOI: 10.1002/9781444305036</div>
+  <div class="csl-entry">Fitzwilliam, H., 1570. [Letter to Bess of Hardwick]. </div>
+  <div class="csl-entry">Fourney, M. E., 1971. Advances in Holographic Photoelasticity. In: Gottenberg, W. G., eds., Symposium on Applications of Holography in Mechanics, August 23-25, 1971, University of Southern California, Los Angeles, California. ASME, New York. 17–38</div>
+  <div class="csl-entry">Frese, K. S., Katus, H. A., Meder, B., 2013. Next-Generation Sequencing: From Understanding Biology to Personalized Medicine. <i>Biology</i>, 2(1): 378–398. <a href="https://doi.org/10.3390/biology2010378">https://doi.org/10.3390/biology2010378</a></div>
+  <div class="csl-entry">IHME, 2021. Global Burden of Disease Study 2019 (GBD2019) Data Resources. </div>
+  <div class="csl-entry">Institute for Art and Architecture, Academy of Fine Arts Vienna, 2023. Wiener Hitze: Architecture and Storytelling in Times of Heat. Park Books, Zürich. 78</div>
+  <div class="csl-entry">International Electrotechnical Commission (IEC), 2021. Software Interface for Maintenance Information Collection and Analysis (SIMICA): Exchanging Test Results and Session Information via the eXtensible Markup Language (XML). </div>
+  <div class="csl-entry">International Organization for Standardization, n.d. ISO Homepage. <a href="https://www.iso.org/home.html">https://www.iso.org/home.html</a></div>
+  <div class="csl-entry">ISO, 2016a. Atmosphères explosives — Partie 20-2: Caractéristiques des produits — Méthodes d’essai des poussières combustibles. </div>
+  <div class="csl-entry">ISO, 2016b. Explosive Atmospheres — Part 20-2: Material Characteristics — Combustible Dusts Test Methods. </div>
+  <div class="csl-entry">ISO, 2019. Audit Data Collection. </div>
+  <div class="csl-entry">Jenkins, S. D., Ruostekoski, J., 2012. Controlled Manipulation of Light by Cooperative Response of Atoms in an Optical Lattice. tex.doi: 10.48550/arXiv.1112.6136</div>
+  <div class="csl-entry">Kinchy, A., 2012. Seeds, Sciences, and Struggle: The Global Politics of Transgenic Crops. MIT Press, Cambridge, Mass. 50</div>
+  <div class="csl-entry">Myburg, A. A., Grattapaglia, D., Tuskan, G. A., et al., 2014. The Genome of <i>Eucalyptus grandis</i>. <i>Nature</i>, 510: 356–362. <a href="https://doi.org/10.1038/nature13308">https://doi.org/10.1038/nature13308</a></div>
+  <div class="csl-entry">Park, J.-R., Tosaka, Y., 2010. Metadata Quality Control in Digital Repositories and Collections: Criteria, Semantics, and Mechanisms. <i>Cataloging &#38; Classification Quarterly</i>, 48(8): 696–715.</div>
+  <div class="csl-entry">Peebles, P. Z., Jr., 2001. Probability, Random Variable, and Random Signal Principles. McGraw-Hill, New York.</div>
+  <div class="csl-entry">Praetzellis, A., 2011. Death by Theory: A Tale of Mystery and Archaeological Theory. Rowman &#38; Littlefield Publishing Group, Inc. 13</div>
+  <div class="csl-entry">Roberson, J. A., Burneson, E. G., 2011. Drinking Water Standards, Regulations and Goals. In: American Water Works Association, eds., Water Quality &#38; Treatment: A Handbook on Drinking Water. McGraw-Hill, New York. 1.1-1.36</div>
+  <div class="csl-entry">Sadock, B. J., Sadock, V. A., Ruiz, P., et al., eds., 2009. Kaplan &#38; Sadock’s Comprehensive Textbook of Psychiatry. Wolters Kluwer Health/Lippincott Williams &#38; Wilkins, Philadelphia.</div>
+  <div class="csl-entry">Saito, M., Miyazaki, K., 2006. Jadeite-Bearing Metagabbro in Serpentinite Melange of the “Kurosegawa Belt” in Izumi Town, Yatsushiro City, Kumamoto Prefecture, Central Kyushu. <i>Bulletin of the Geological Survey of Japan</i>, 57(5/6): 169–176. 10.9795/bullgsj.57.169</div>
+  <div class="csl-entry">Santer, R. D., Akanyeti, O., 2025. Using Artificial Neural Networks to Explain the Attraction of Jewel Beetles (Coleoptera: Buprestidae) to Colored Traps. <i>Insect science</i>,  <a href="https://doi.org/10.1111/1744-7917.13496">https://doi.org/10.1111/1744-7917.13496</a></div>
+  <div class="csl-entry">Shinotsuka, H., Nagata, K., Siriwardana, M., et al., 2023. Sample Structure Prediction from Measured XPS Data Using Bayesian Estimation and SESSA Simulator. <i>Journal of electron spectroscopy and related phenomena</i>, 267. tex.number:  tex.eid: 147370
+tex.doi: 10.1016/j.elspec.2023.147370</div>
+  <div class="csl-entry">Sugarman, L., Markham, S., 1980. Students in a Selective High School: Some Vocationally Oriented Data. <a href="https://doi.org/10.5255/UKDA-SN-996-1">https://doi.org/10.5255/UKDA-SN-996-1</a> 10.5255/UKDA-SN-996-1</div>
+  <div class="csl-entry">Tachibana, R., Shimizu, S., Kobayashi, S., et al., 2001. Electronic watermarking method and system. tex.holder: IBM
+tex.number: US89404301A</div>
+  <div class="csl-entry">Torres, L., Salisbury, F., Yazbeck, B., et al., eds., 2021. Connecting the Library to the Curriculum. Springer Nature, Singapore. 97 tex.DOI: 10.1007/978-981-16-3868-8</div>
+  <div class="csl-entry">Tristram, M., Skarshewski, P., Tristram, I., et al., 2022. Storage and delivery system. tex.holder: Trisco ICAP Pty Ltd
+tex.number: AU2022228203A</div>
+  <div class="csl-entry">United Nations Department of Economic and Social Affairs, n.d. United Nations E-Government Survey 2024: Accelerating Digital Transformation for Sustainable Development. </div>
+  <div class="csl-entry">U.S. Department of Transportation Federal Highway Administration, 1990. Guidelines for Handling Excavated Acid-Producing Material. : 25.</div>
+  <div class="csl-entry">Veen, P. H. van der, Muller, M., Vincken, K. L., et al., 2014. Longitudinal Changes in Brain Volumes and Cerebrovascular Lesions on MRI in Patients with Manifest Arterial Disease: The SMART-MR Study. <i>Journal of the Neurological Sciences</i>, 337(1/2): 112–118. <a href="https://doi.org/10.1016/j.jns.2013.11.029">https://doi.org/10.1016/j.jns.2013.11.029</a></div>
+  <div class="csl-entry">Wang, S., 2022. Application of Improved SOM Neural Network in Intelligent Auditing of Hospital Financial Vouchers. 2 <a href="https://doi.org/10.1109/ACAIT56212.2022.10137867">https://doi.org/10.1109/ACAIT56212.2022.10137867</a></div>
+  <div class="csl-entry">Weinstein, L., Swartz, M. N., 1974. Pathogenic Properties of Invading Microorganisms. In: Sodeman, W. A., Jr., Sodeman, W. A., eds., Pathologic Physiology: Mechanisms of Disease. Saunders, Philadelphia. 457–472</div>
+  <div class="csl-entry">Yu, Y., Pan, E., Wang, X., et al., 2024. Unmixing before Fusion: A Generalized Paradigm for Multi-Source-Based Hyperspectral Image Synthesis. 4</div>
+  <div class="csl-entry">Yufin, S. A., eds., 2000. Geoecology and Computers: Proceedings of the Third International Conference on Advances of Computer Methods in Geotechnical and Geoenvironmental Engineering, Moscow, Russia, 1-4 February 2000. A. A. Balkema, Rotterdam. tex.entrytype: proceedings</div>
+  <div class="csl-entry">Zhong, X., Yan, Q., Li, G., 2022. Long Time Series Nighttime Light Dataset of China: 2000–2020. tex.doi: 10.3974/geodb.2022.06.01.V1</div>
+  <div class="csl-entry">Zotero, n.d. [Zotero Download]. <a href="https://www.zotero.org/download/">https://www.zotero.org/download/</a></div>
+  <div class="csl-entry">丁文详, 2000. 数字革命与竞争国际化. 中国青年报, : 15.</div>
+  <div class="csl-entry">中华医学会湖北分会, eds., 1984. 临床内科杂志. 1984，1（1）—. tex.entrytype: periodical</div>
+  <div class="csl-entry">中国互联网络信息中心, 2012. 第29次中国互联网络发展状况统计报告. </div>
+  <div class="csl-entry">中国信息通信研究院, 中国电信股份有限公司研究院, 中国移动通信研究院, et al., 2023. 电信业发展白皮书：2023：新时代高质量发展探索. </div>
+  <div class="csl-entry">中国图书馆学会, eds., 1957–1990. 图书馆学通讯. 1957（1）—1990（4）. tex.entrytype: periodical</div>
+  <div class="csl-entry">中国社会科学院台湾史研究中心, eds., 2012. 台湾光复六十五周年暨抗战史实学术研讨会论文集. 九州出版社, 北京. tex.entrytype: proceedings</div>
+  <div class="csl-entry">中国科学院文献情报中心, n.d. 中国科学院科技论文预发布平台. <a href="https://chinaxiv.org/home.htm">https://chinaxiv.org/home.htm</a></div>
+  <div class="csl-entry">中国造纸学会, 2003. 中国造纸年鉴：2003. 中国轻工业出版社, 北京.</div>
+  <div class="csl-entry">中工武大设计研究有限公司, 2019. 阳新县标准地名图. tex.entrytype: map</div>
+  <div class="csl-entry">久保智康, 2009. 花枝蝶鸟方镜的镜范：以平安后期的铜镜制作工艺为中心. 东方博物, (1): 85–92.</div>
+  <div class="csl-entry">于潇, 刘义, 柴跃廷, et al., 2012. 互联网药品可信交易环境中主体资质审核备案模式. 清华大学学报（自然科学版）, 52(11): 1518–1523.</div>
+  <div class="csl-entry">云南省企业联合会, 云南省企业家协会, 云南民族新闻文化发展研究院, 2009. 改革开放三十年：云南企业家奋斗史. 德宏民族出版社, 芒市.</div>
+  <div class="csl-entry">井丽南, 2022. 支持状态可编程的SDN交换机关键技术研究: [博士学位论文]. 中国科学院大学, 北京. 43 tex.cstr: 35001.37.01.33142.20220037</div>
+  <div class="csl-entry">仉尚航, 2024. 开放世界中的实体基础模型. <a href="https://www.ppthub.com.cn/view/19309">https://www.ppthub.com.cn/view/19309</a></div>
+  <div class="csl-entry">何筱梅, 2016. 新媒体时代原生广告的策略与发展研究: [博士学位论文]. 武汉大学, 武汉. 24–25</div>
+  <div class="csl-entry">全国信息与文献标准化技术委员会, 2021. 信息与文献 资源描述. </div>
+  <div class="csl-entry">全国信息技术标准化技术委员会, 2016. 信息技术 先进音视频编码 第16部分：广播电视视频. </div>
+  <div class="csl-entry">冀超, 2001. 一种荒漠化地区生态植被综合培育种植方法. tex.holder: 河北绿洲生态环境科技有限公司
+tex.number: CN01129210.5</div>
+  <div class="csl-entry">冯友兰, 2008. 冯友兰自选集. 首都师范大学出版社, 北京. 第1版自序</div>
+  <div class="csl-entry">刘时银, 郭万钦, 许君利, 2012. 中国第二次水川编目科学数据：2006-2011. <a href="https://doi.org/10.3972/glacier.001.2013.db">https://doi.org/10.3972/glacier.001.2013.db</a></div>
+  <div class="csl-entry">刘祥沈, 2016. 沈阳市政区图. tex.entrytype: map</div>
+  <div class="csl-entry">北京鲁迅博物馆, 2021. 北京鲁迅博物馆志愿服务章程. <a href="http://www.luxunmuseum.com.cn/html/202104/a11310.htm">http://www.luxunmuseum.com.cn/html/202104/a11310.htm</a></div>
+  <div class="csl-entry">博伯尔, 2023. 银行业的未来与人工智能. 清华大学出版社, 北京. 35</div>
+  <div class="csl-entry">史国华, 樊金宇, 何益, et al., 2022. 光コヒーレンス断層拡張現実に基づく手術顕微鏡撮像システム及び方法. tex.holder: 中国科学院苏州生物医学工程技术研究所
+tex.number: JP2021578120A</div>
+  <div class="csl-entry">吴自银, 温珍河, 2019. 中国南部海域海底地形图. tex.entrytype: map</div>
+  <div class="csl-entry">周壮, 李盛阳, 吴薇, et al., 2023. 天宫二号遥感图像自然景物分类数据集. tex.cstr: 16666.11.nbsdc.tfpbwtqf</div>
+  <div class="csl-entry">哈里森, 沃尔德伦, 2012. 经济数学与金融数学. 中国人民大学出版社, 北京. 235–236</div>
+  <div class="csl-entry">図書館用語辞典編集委員会, eds., 2004. 最新図書館用語大辞典. 柏書房株式会社, 東京. 154</div>
+  <div class="csl-entry">国家测绘地理信息局, n.d. 一带一路经济走廊及其途经城市分布地势图. tex.entrytype: map</div>
+  <div class="csl-entry">国家能源局, 2020. 水电工程水温实时监测系统技术规范. </div>
+  <div class="csl-entry">国家药典委员会, eds., 2020. 大黄. In: 中华人民共和国药典. 中国医药科技出版社, 北京. 24–25</div>
+  <div class="csl-entry">工业和信息化部, 2022. 信息技术  中文编码字符集. </div>
+  <div class="csl-entry">张伯伟, 2002. 全唐五代诗格汇考. 江苏古籍出版社, 南京. 288</div>
+  <div class="csl-entry">张凯军, 赵永杰, 陈朝岗, 2013. 轨道火车及高速轨道火车紧急安全制动辅助装置. tex.holder: 张凯军
+tex.number: CN201220158825.2</div>
+  <div class="csl-entry">张群, 程志宝, 石志飞, 2024a. 惯性增强动力吸振器-浮置板轨道低频减振性能研究. 铁道学报, </div>
+  <div class="csl-entry">张群, 程志宝, 石志飞, 2024b. 惯性增强动力吸振器-浮置板轨道低频减振性能研究. 铁道学报, 46(8): 102–111.</div>
+  <div class="csl-entry">彭守璋, 2024. 1901—2023年中国1km分辨率逐月降水量数据集. </div>
+  <div class="csl-entry">徐建委, 2025. 历史的起点：《史记》中的时间设置及其意义. 北京大学学报（哲学社会科学版）, 62(2): 117–127.</div>
+  <div class="csl-entry">战德臣, 张丽杰, 2019. 大学计算机：计算思维与信息素养. 高等教育出版社, 北京.</div>
+  <div class="csl-entry">扬奎斯特, 萨金特, 2010. 递归宏观经济理论. 中国人民大学出版社, 北京. 813</div>
+  <div class="csl-entry">方向明, 曹迎杰, 2023. 元宇宙在图书馆的应用：理论研究与实践进展. tex.cstr: 32003.36.ChinaXiv.202303.00020.V1</div>
+  <div class="csl-entry">曹凌, 2011. 中国佛教疑伪经综录. 上海古籍出版社, 上海. 19</div>
+  <div class="csl-entry">李华, 王昊, 康佐, 2023. 一种拼接式桥梁模型. tex.holder: 李华 and 王昊 and 康佐
+tex.number: CN202222658126.0</div>
+  <div class="csl-entry">李妍, 王莹, 2022. 医疗机构保洁人员“一前五后”手卫生干预效果研究. 2</div>
+  <div class="csl-entry">李幼平, 王莉, 2010. 循证医学研究方法：附视频. 中华移植杂志（电子版）, 4(3): 225–228.</div>
+  <div class="csl-entry">李约瑟, 1991. 题词. In: 苏颂与《本草图经》研究. 长春出版社, 长春. 扉页</div>
+  <div class="csl-entry">李鸿章, 1887. 奏请上海道库洋务外销要款无款可筹仍拨药厘接济事. tex.number: 04-01-35-0399-039
+tex.location: 北京
+tex.institution: 中国第一历史档案馆</div>
+  <div class="csl-entry">杨洪升, 2013. 四库馆私家抄校书考略. 文献, (1): 56–75.</div>
+  <div class="csl-entry">楼梦麟, 杨燕, 2011. 汶川地震基岩地震动特征分析. In: 同济大学土木工程防灾国家重点实验室, eds., 汶川地震震害研究. 同济大学出版社, 上海. 11–12</div>
+  <div class="csl-entry">汤万金, 杨跃翔, 刘文, et al., 2013. 人体安全重要技术标准研制最终报告. </div>
+  <div class="csl-entry">汪学军, 2005. 中国农业转基因生物研发进展与安全管理. In: 国家环境保护总局生物安全管理办公室, eds., 中国国家生物安全框架实施国际合作项目研讨会论文集. 中国环境科学出版社, 北京. 22–25</div>
+  <div class="csl-entry">湖北省建设厅, 1931. 湖北省建设厅关于检发实业部农工矿业团体登记规则的布告、训令及湖北省政府的训令. tex.entrytype: archive
+tex.number: LS031-001-0001-001
+tex.location: 武汉
+tex.institution: 湖北省档案馆</div>
+  <div class="csl-entry">牛志明, Swingland I. R., 雷光春, eds., 2012. 综合湿地管理：综合湿地管理国际研讨会论文集. 海洋出版社, 北京. tex.entrytype: proceedings</div>
+  <div class="csl-entry">牛永敢, 孔晓, 王阳, et al., eds., 2019. 鼻整形应用解剖学. 人民卫生出版社, 北京. 65–66</div>
+  <div class="csl-entry">王利平, 王福新, 刘洪, 2024. 过冷大水滴环境粒径分布模拟方法研究进展. 航空学报, 45(增刊1). tex.author_transliteration_en: Wang, Liping and Wang, Fuxin and Liu, Hong
+tex.title_translation_en: Research progress on simulation methods of drop diameter distribution in supercooled large drop icing conditions
+tex.journal_translation_en: Acta Aeronautica et Astronautica Sinica
+tex.number:  tex.eid: 730570</div>
+  <div class="csl-entry">王夫之, 1865. 宋论. 湘乡曾国荃, 金陵.</div>
+  <div class="csl-entry">王夫之, eds., 2011. 周易外传：卷5. In: 船山全书. 岳麓书社, 长沙. 983–1029</div>
+  <div class="csl-entry">王琦, 2022. 融合星载GNSS-R和SAR数据的高时空分辨率土壤湿度反演方法研究: [博士学位论文]. 武汉大学, 武汉. 87</div>
+  <div class="csl-entry">王继民, 罗鹏程, 赵常煜, et al., 2025. 人文社会科学数据集检索方法研究的数据集. tex.doi: 10.18170/DVN/R96MSN</div>
+  <div class="csl-entry">石顺祥, 许海平, 孙艳玲, et al., 2002. 光折变自适应光外差探测方法. tex.holder: 西安电子科技大学
+tex.number: CN01128777.2</div>
+  <div class="csl-entry">程根伟, 1999. 1998年长江洪水的成因与减灾对策. In: 许厚泽, 赵其国, eds., 长江流域洪涝灾害与科技对策. 科学出版社, 北京. 32–36</div>
+  <div class="csl-entry">童世亨, 1926. 京兆直隶图. tex.entrytype: map</div>
+  <div class="csl-entry">肖希明, 石庆功, 刘奕, 2024. 民国图书馆学教育的社会贡献. In: 纪念北京大学图书馆学教育100周年研讨会论文集. 北京大学信息管理系, 北京. 134–147</div>
+  <div class="csl-entry">肖玲, 张雪, 王永, 2024. 数据要素的统计测算方法探究. tex.cstr: 32012.36.PSSXiv.202408.01096</div>
+  <div class="csl-entry">胡健民, 2021. 东南极拉斯曼丘陵地区地质图. tex.entrytype: map</div>
+  <div class="csl-entry">许振超, 2025. “好好干，当一个好工人.” <a href="https://cpc.people.com.cn/n1/2025/0217/c443712-40419790.html">https://cpc.people.com.cn/n1/2025/0217/c443712-40419790.html</a></div>
+  <div class="csl-entry">訾冬梅, 高秀静, 2006. 内蒙古自治区地图册. tex.entrytype: map</div>
+  <div class="csl-entry">谭其骧, 1982. 中国历史地图集. 第2册: 6. tex.entrytype: map</div>
+  <div class="csl-entry">贾东琴, 柯平, 2011. 面向数字素养的高校图书馆数字服务体系研究. In: 中国图书馆学会, eds., 中国图书馆学会年会论文集. 国家图书馆出版社, 北京. 45–52</div>
+  <div class="csl-entry">赵学功, 2001. 当代美国外交. 社会科学文献出版社, 北京.</div>
+  <div class="csl-entry">邓一刚, 2008. 全智能节电器. (CN200510022322.7 20051216): 8–9. tex.holder: 邓一刚
+tex.number: CN200610171314.3</div>
+  <div class="csl-entry">郑涵, 于贵瑞, 朱先进, et al., 2018. 2000—2010年中国典型陆地生态系统实际蒸散量和水分利用效率数据. </div>
+  <div class="csl-entry">金燕萍, 2020. 社交媒体时代的虚假信息研究: [硕士学位论文]. 温州大学, 温州. 16</div>
+  <div class="csl-entry">钱学森, 2001. 创建系统学. 山西科学技术出版社, 太原. 序2-3</div>
+  <div class="csl-entry">阿扬, 2023. 谈谈记忆：与诺贝尔获奖得者埃里克·坎德尔的问答. In: 《环球科学》杂志社, eds., 认识记忆力：关于学习、思考与遗忘的脑科学. 机械工业出版社, 北京. 15–18</div>
+  <div class="csl-entry">陈建军, 2010. 从数字地球到智慧地球. 国土资源导刊, 7(10): 93. <a href="https://doi.org/10.3969/j.issn.1672-5603.2010.10.038">https://doi.org/10.3969/j.issn.1672-5603.2010.10.038</a></div>
+  <div class="csl-entry">陈志勇, eds., 2011. 中国财税文化价值研究：“中国财税文化国际学术研讨会”论文集. 经济科学出版社, 北京. tex.entrytype: proceedings</div>
+  <div class="csl-entry">陈晋镳, 张惠民, 朱士兴, et al., 1980. 蓟县震旦亚界的研究. In: 中国地质科学院天津地质矿产研究所, eds., 中国震旦亚界. 天津科学技术出版社, 天津. 56–114</div>
+  <div class="csl-entry">陈登原, 2000. 国史旧闻. 中华书局, 北京. 29</div>
+  <div class="csl-entry">陈缮真, 2022. 探索微观世界的无穷奥秘（科技大观）. 人民日报, : 17.</div>
+  <div class="csl-entry">顾炎武, 1980. 昌平山水记；京东考古录. 北京古籍出版社, 北京.</div>
+  <div class="csl-entry">马克思, 2013. 政治经济学批判. In: 马克思恩格斯全集. 人民出版社, 北京. 302</div>
+  <div class="csl-entry">高等教育文献保障系统, n.d. 馆际互借与文献传递服务. <a href="http://home.calis.edu.cn/pages/list.html?id=4101e184-7f64-4798-a5e1-8e37aa6994fc">http://home.calis.edu.cn/pages/list.html?id=4101e184-7f64-4798-a5e1-8e37aa6994fc</a></div>
+  <div class="csl-entry">黄土高原科学数据中心（西北农林科技大学水土保持研究所）, 2024. 青海省县域教育、卫生发展指标（2001—2022年）. <a href="https://doi.org/10.12041/geodata.58691800703558.ver1.db">https://doi.org/10.12041/geodata.58691800703558.ver1.db</a></div>
+  <div class="csl-entry">1949. 中国人民解放军武汉市军事管制委员会接管国立武汉大学的文告. tex.entrytype: archive
+tex.location: 武汉
+tex.institution: 武汉大学档案馆</div>
+  <div class="csl-entry">1962. 康熙字典. 中华书局, 北京. 50</div>
+  <div class="csl-entry">1979. Public Library Quarterly. 1979，1（1）—. tex.entrytype: periodical</div>
+  <div class="csl-entry">2020. IEEE Approved Draft Standard for Information Technology--Telecommunications and Information Exchange between Systems Local and Metropolitan Area Networks--Specific Requirements Part 11: Wireless LAN Medium Access Control (MAC) and Physical Layer (PHY) Specifications Amendment 3: Wake-up Radio Operation. </div>
+  <div class="csl-entry">2022. 《庄子》读不懂？看完这一篇“导读”就明白了. </div>
+  <div class="csl-entry">2023. [《昨日之歌》图书封面]. tex.entrytype: image</div>
+  <div class="csl-entry">2023. 西黄丸. <a href="https://ydz.chp.org.cn/#/item?bookId=1&#38;entryId=1154">https://ydz.chp.org.cn/#/item?bookId=1&#38;entryId=1154</a></div>
+  <div class="csl-entry">2024. Coastal Wetlands Map of China Continent. : 50. Book Title: Coastal erosion and mitigation in east and southeast Asia  tex.entrytype: map</div>
+  <div class="csl-entry">N.d. Library of Congress. <a href="https://www.loc.gov/">https://www.loc.gov/</a></div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《心理学报》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-false">
+  <div class="csl-entry">Auerbach, J. S., 1993. The Origins of Narcissism and Narcissistic Personality Disorder: A Theoretical and Empirical Reformulation. In: Bornstein, M. F., eds., Handbook of Child Psychology: Vol. 4. Socialization, Personality, and Social Development. Wiley, Washington, DC, US. 43–110 <a href="https://doi.org/10.1037/10138-002">https://doi.org/10.1037/10138-002</a></div>
+  <div class="csl-entry">Australian Bureau of Statistics, 1991. Estimated Resident Population by Age and Sex in Statistical Local Areas, New South Wales, June 1990. </div>
+  <div class="csl-entry">Bergmann, P. G., 1993. Relativity. In: The New Encyclopedia Britannica. <i>McGraw-Hill series in management</i>, 26: 501–508.</div>
+  <div class="csl-entry">Burin, D., Kilteni, K., Rabuffetti, M., et al., 2019. Body Ownership Increases the Interference between Observed and Executed Movements. <i>PLOS ONE</i>, 14(1). <a href="https://doi.org/10.1371/journal.pone.0209899">https://doi.org/10.1371/journal.pone.0209899</a></div>
+  <div class="csl-entry">Gibbs, J. T., Huang, L. N., eds., 1989. Children of Color: Psychological Interventions with Minority Youth. Jossey-Bass, Hoboken, NJ, US.</div>
+  <div class="csl-entry">Huestegge, S. M., Raettig, T., Huestegge, L., 2019. Are Face-Incongruent Voices Harder to Process? Effects of Face–Voice Gender Incongruency on Basic Cognitive Information Processing. <i>Experimental Psychology</i>,  <a href="https://doi.org/10.1027/1618-3169/a000440">https://doi.org/10.1027/1618-3169/a000440</a></div>
+  <div class="csl-entry">Klatzky, R., 1998. Allocentric and Egocentric Spatial Representations: Definitions, Distinctions, and Interconnections. In: Freksa, C., Habel, C., Wender, K. F., eds., Lecture Notes in Artificial Intelligence: Vol. 1404: Spatial Cognition: An Interdisciplinary Approach to Representing and Processing Spatial Knowledge. Springer-Verlag. 1–17</div>
+  <div class="csl-entry">Lanktree, C. B., Briere, J. N., 1991. Early Data on the Trauma Symptom Checklist for Children (TSC-C). San Diego, CA.</div>
+  <div class="csl-entry">Laplace, P.-S., 1951. A Philosophical Essay on Probabilities. Dover.</div>
+  <div class="csl-entry">Lichstein, K. L., Johnson, R. S., 1990. Relaxation Therapy for Polypharmacy Use in Elderly Insomniacs and Noninsomniacs. In: Reducing Medication in Geriatric Populations. Uppsala, Sweden.</div>
+  <div class="csl-entry">Mitchell, T. R., Larson, J. R., 1987. People in Organizations: An Introduction to Organizational Behavior. McGraw-Hill, New York. 602</div>
+  <div class="csl-entry">Mou, W., McNamara, T. P., 2002. Intrinsic Frames of Reference in Spatial Memory. <i>Journal of Experimental Psychology: Learning, Memory, and Cognition</i>, 28: 162–170. <a href="https://doi.org/10.1037/0278-7393.28.1.162">https://doi.org/10.1037/0278-7393.28.1.162</a></div>
+  <div class="csl-entry">Mou, W., Zhang, K., McNamara, T. P., 2004. Frames of Reference in Spatial Memories Acquired from Language. <i>Journal of Experimental Psychology: Learning, Memory, and Cognition</i>, 30: 171–180. <a href="https://doi.org/10.1037/0278-7393.30.1.171">https://doi.org/10.1037/0278-7393.30.1.171</a></div>
+  <div class="csl-entry">Ruby, J., Fulton, C., 1993. Beyond Redlining: Editing Software That Works. Washington, DC.</div>
+  <div class="csl-entry">Sadie, S., eds., 1980. The New Grove Dictionary of Music and Musicians. Macmillan, London : New York. 29</div>
+  <div class="csl-entry">Wang, D. F., Cui, H., 2004. Theoretical Analysis of the Seven Factor Model of Chinese Personality. In: Wang, D. F., Hou, Y. B., eds., Selected Papers on Personality and Social Psychology. Peking University Press, Beijing. 46–84</div>
+  <div class="csl-entry">Wolchik, S. A., West, S. G., Sandler, I. N., et al., 2000. An Experimental Evaluation of Theory-Based Mother and Mother-Child Programs for Children of Divorce. <i>Journal of Consulting and Clinical Psychology</i>, 68(5): 843–856.</div>
+  <div class="csl-entry">Yu, L., 2000. Phonological Representation and Processing in Chinese Spoken Language Production: [Unpublished doctorial dissertation]. Beijing Normal University.</div>
+  <div class="csl-entry">余林, 2000. 汉语语言产生中的语音表征与加工: [博士学位论文]. 北京师范大学.</div>
+  <div class="csl-entry">张三, 2008a. 中国心理学的过去与未来. 心理学报, 40: 210–215.</div>
+  <div class="csl-entry">张三, 2008b. 中国心理学的过去与未来. 心理学报, 40(增刊): 210–215.</div>
+  <div class="csl-entry">张三, 2008c. 心理学史. 未名出版社, 北京. 450</div>
+  <div class="csl-entry">张三, eds., 2008d. 心理学史. 未名出版社, 北京. 450</div>
+  <div class="csl-entry">张三, 李四, 2008a. 中国心理学与奥林匹克. 新华日报, : 2, 5–7.</div>
+  <div class="csl-entry">张三, 李四, 2008b. 中国心理学的过去与未来. 心理学报, 40: 210–215.</div>
+  <div class="csl-entry">张三, 李四, n.d. 中国心理学的过去与未来. 心理学报, </div>
+  <div class="csl-entry">拉普拉斯, Pierre-Simon, 1951. 概率哲学. 未名出版社, 北京.</div>
+  <div class="csl-entry">李行健, eds., 2004. 现代汉语规范辞典. 外语教学与研究出版社, 北京. 255</div>
+  <div class="csl-entry">王登峰, 崔红, 2004. 中国人“大七”人格结构的理论分析. In: 王登峰, 侯玉波, eds., 人格与社会心理学论丛. 北京大学出版社, 北京. 46–84</div>
+  <div class="csl-entry">赵一, 钱二, 孙三, et al., 2008. 中国心理学的过去与未来. 心理学报, 40: 210–215.</div>
+  <div class="csl-entry">赵一一, 钱二, 孙三, et al., 2008. 中国心理学的过去与未来. 心理学报, 40: 210–215.</div>
+  <div class="csl-entry">邱颖文, 2009. 遗传与语言学习: [博士学位论文]. 华东师范大学, 上海.</div>
+  <div class="csl-entry">1986. 现代汉语频率词典. 北京语言学院出版社, 北京.</div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《中国社会科学》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-false">
+  <div class="csl-entry">Brooks, P., 2000. Troubling Confessions: Speaking Guilt in Law and Literature. University of Chicago Press, Chicago.</div>
+  <div class="csl-entry">Chamberlain, H. B., 1993. On the Search for Civil Society in China. <i>Modern China</i>, 19(2): 199–215. <a href="https://doi.org/10.1177/009770049301900206">https://doi.org/10.1177/009770049301900206</a></div>
+  <div class="csl-entry">Polo, M., 1997. The Travels of Marco Polo. Cumberland House, Hertfordshire.</div>
+  <div class="csl-entry">Schfield, R. S., 1983. The Impact of Scarcity and Plenty on Population Change in England. In: Rotberg, R. I., Rabb, T. K., eds., Hunger and History: The Impact of Changing Food Production and Consumption Pattern on Society. Cambridge University Press, Cambridge, Mass. 55–88</div>
+  <div class="csl-entry">任东来, 2000. 对国际体制和国际制度的理解和翻译. 天津.</div>
+  <div class="csl-entry">任继愈, eds., 1983. 中国哲学发展史（先秦卷）. 人民出版社, 北京.</div>
+  <div class="csl-entry">伤心人（麦孟华）, n.d. 说奴隶. 清议报, 第69册: 第1页.</div>
+  <div class="csl-entry">何龄修, 1998. 读顾诚〈南明史〉. 中国史研究, (3): 167–173.</div>
+  <div class="csl-entry">佚名, 1998. 晚清洋务运动事类汇钞五十七种. 全国图书馆文献缩微复制中心, 北京.</div>
+  <div class="csl-entry">倪素香, 2002. 德育学科的比较研究与理论探索. 武汉大学学报, (4): 512–513.</div>
+  <div class="csl-entry">唐振常, 1997. 师承与变法. In: 识史集. 上海古籍出版社, 上海.</div>
+  <div class="csl-entry">姚际恒, n.d. 古今伪书考. 3.</div>
+  <div class="csl-entry">实藤惠秀, 1982. 中国人留学日本史. 香港中文大学出版社, 香港.</div>
+  <div class="csl-entry">扬之水, n.d. 两宋茶诗与茶事. <i>《文学遗产通讯》（网络版试刊）2006年第1期</i>. <a href="http://www.literature.org.cn/Article.asp?ID=199">http://www.literature.org.cn/Article.asp?ID=199</a></div>
+  <div class="csl-entry">方明东, 2000. 罗隆基政治思想研究（1913—1949）: [博士学位论文]. 北京师范大学历史系.</div>
+  <div class="csl-entry">李眉, 1986. 李劼人轶事. 四川工人日报, : 2.</div>
+  <div class="csl-entry">李鹏程, 1994. 当代文化哲学沉思. 人民出版社, 北京. ，“序言”，第1页。</div>
+  <div class="csl-entry">杜威·佛克马, 1999. 走向新世界主义. In: 王宁, 薛晓源, eds., 全球化与后殖民批评. 中央编译出版社, 北京. 247–266</div>
+  <div class="csl-entry">杨钟羲, 1991. 雪桥诗话续集. 5.</div>
+  <div class="csl-entry">楼适夷, 1998. 读家书，想傅雷（代序）. In: 傅敏, eds., 傅雷家书. 三联书店, 北京.</div>
+  <div class="csl-entry">毛祥麟, 1985. 墨余录. </div>
+  <div class="csl-entry">汪疑今, 1936. 江苏的小农及其副业. 中国经济, 4(6).</div>
+  <div class="csl-entry">狄葆贤, n.d. 平等阁笔记. 有正书局, 上海.</div>
+  <div class="csl-entry">王明亮, 1998. 关于中国学术期刊标准化数据库系统工程的进展. <a href="http://www.cajcd.cn/pub/wml.txt/980810-2.html">http://www.cajcd.cn/pub/wml.txt/980810-2.html</a></div>
+  <div class="csl-entry">管志道, 1997. 答屠仪部赤水丈书. 续问辨牍, 2.</div>
+  <div class="csl-entry">蒋大兴, 2001. 公司法的展开与评判——方法·判例·制度. 法律出版社, 北京.</div>
+  <div class="csl-entry">费成康, 1999. 葡萄牙人如何进入澳门问题辨正. 社会科学, (9): 63–67.</div>
+  <div class="csl-entry">赵景深, 1948. 文坛忆旧. 北新书局, 上海.</div>
+  <div class="csl-entry">金冲及, eds., 1989. 周恩来传. 人民出版社、中央文献出版社, 北京.</div>
+  <div class="csl-entry">魏丽英, 1990. 论近代西北人口波动的若干主要原因. 社会科学, (6): 68–73, 86. <a href="https://doi.org/10.15891/j.cnki.cn62-1093/c.1990.06.017">https://doi.org/10.15891/j.cnki.cn62-1093/c.1990.06.017</a></div>
+  <div class="csl-entry">鲁迅, 1981. 中国小说的历史的变迁. In: 鲁迅全集. 人民文学出版社, 北京.</div>
+  <div class="csl-entry">黄义豪, 1997. 评黄龟年四劾秦桧. 福建论坛, (3): 26–27.</div>
+  <div class="csl-entry">黄仁宇, 1997. 为什么称为“中国大历史”？——中文版自序. In: 中国大历史. 三联书店, 北京.</div>
+  <div class="csl-entry">1910. 四川会议厅暂行章程. 广益丛报, (第8年第19期): 第1—2页.</div>
+  <div class="csl-entry">1917. 傅良佐致国务院电. </div>
+  <div class="csl-entry">1925. 上海各路商界总联合会致外交部电. 民国日报, : 4.</div>
+  <div class="csl-entry">1933. 西南中委反对在宁召开五全会. 民国日报, : 第1张第4版.</div>
+  <div class="csl-entry">1950. 党外人士座谈会记录. </div>
+  <div class="csl-entry">1969. Nixon to Kissinger. </div>
+  <div class="csl-entry">1975. 旧唐书. 9.</div>
+  <div class="csl-entry">1983. 方苞集. 6.</div>
+  <div class="csl-entry">1985. 太平御览. 690.</div>
+  <div class="csl-entry">1986. 荣庆日记. 西北大学出版社, 西安.</div>
+  <div class="csl-entry">1987. 清德宗实录. 435.</div>
+  <div class="csl-entry">1992. 广东通志. 稀见中国地方志汇刊, 15.</div>
+  <div class="csl-entry">1998. 马克思恩格斯全集. 人民出版社, 北京.</div>
+  <div class="csl-entry">N.d. 上海县续志. 1.</div>
+  <div class="csl-entry">N.d. 嘉定县志. 12.</div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《法学引注手册》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-false">
+  <div class="csl-entry">Alford, W., 1995. To Steal a Book Is an Elegant Offense: Intellectual Property Law in Chinese Civilization. Stanford University Press.</div>
+  <div class="csl-entry">Badiou-Monferran, C., 1997. La promotion esthétique du pathétique dans la seconde moitié du XVIIe siècle. <i>La Licorne</i>, (43): 75–94.</div>
+  <div class="csl-entry">Barbara Ward, 1979. Progress for a Small Planet. <i>Harvard Business Review</i>, (Sep.-Oct.): 89.</div>
+  <div class="csl-entry">Brandeis, L. D., 1913. What Publicity Can Do. <i>Harper’s Weekly</i>, : 10.</div>
+  <div class="csl-entry">Canaris, C.-W., 1990. Gesamtunwirksamkeit und Teilgültigkeit rechtsgeschäftlicher Regelungen. <i>FS-Steindorff</i>,  为祝贺文集</div>
+  <div class="csl-entry">Chevallier, M., 2003. L’État de droit. Montchrestien, Paris.</div>
+  <div class="csl-entry">Dreier, R., Paulson, S., eds., 2003. Rechtsphilosophie Studienausgabe. UTB Uni-Taschenbücher Verlag, Heidelberg. 286</div>
+  <div class="csl-entry">Fischer, T., 2015. Absurdes Spektakel um den Tod. <i>Die Zeit</i>, </div>
+  <div class="csl-entry">Habermas, J., 1996. Between Facts and Norms: Contributions to a Discourse Theory of Law and Democracy. MIT Press. 676</div>
+  <div class="csl-entry">Horsley, J., 2006. Rule of Law in China: Incremental Progress. In: Bergsten, C. F., Gill, B., Lardy, N. R., et al., eds., China: The Balance Sheet. Public Affairs Press.</div>
+  <div class="csl-entry">Joyeux-Prunel, B., n.d. L’histoire de l’art et le quantitatif. <i>Histoire &#38; mesure, vol. XXIII, n° 2, 2008</i>. <a href="http://histoiremesure.revues.org/index3543.html">http://histoiremesure.revues.org/index3543.html</a></div>
+  <div class="csl-entry">Kaufmann, A., 1972. Bemerkungen zur Reform des § 218 StGB aus rechtsphilosophischer Sicht. In: Baumann, J., eds., Das Abtreibungsverbot des § 218 StGB. </div>
+  <div class="csl-entry">McDonell, S., 2016. When China Began Streaming Trials Online. <i>BBC News</i>. <a href="https://www.bbc.com/news/blogs-china-blog-37515399">https://www.bbc.com/news/blogs-china-blog-37515399</a></div>
+  <div class="csl-entry">Meidenbauer, M., n.d. Wissenschaftliches Publizieren. <a href="https://www.clio-online.de/sites/files/clio/portal-archiv/site/lang_de/40208143/Default-2.html">https://www.clio-online.de/sites/files/clio/portal-archiv/site/lang_de/40208143/Default-2.html</a></div>
+  <div class="csl-entry">Poisson, M., 2015a. Le droit de la mer. <i>RGDIP</i>, : 15–47.</div>
+  <div class="csl-entry">Poisson, M., 2015b. Le droit de la mer. In: Le droit des Océans. 12–48</div>
+  <div class="csl-entry">Poisson, M., 2016a. Le droit de la mer appliqué à la Méditerranée: [Thèse de doctorat]. l’Université de Marseille.</div>
+  <div class="csl-entry">Poisson, M., 2016b. Le droit de la mer en Méditerranée. : 228–229.</div>
+  <div class="csl-entry">Poisson, M., 2016c. Le droit de la mer en Méditerranée. </div>
+  <div class="csl-entry">Reich, C. A., 1964. The New Property. <i>Yale Law Journal</i>, 73(5): 733–787. <a href="https://doi.org/10.2307/794645">https://doi.org/10.2307/794645</a></div>
+  <div class="csl-entry">Rosenthal, A., 1990. White House Tutors Kremlin in How a Presidency Works. <i>New York Times</i>, : A1.</div>
+  <div class="csl-entry">Roxin, C., 2006. Strafrecht Allgemeiner Teil. C. H. Beck. 1136</div>
+  <div class="csl-entry">Schwab, M., 2013. In: Münchener Kommentar BGB. </div>
+  <div class="csl-entry">Vogel, B., 2017. Rechtsgüterschutz und Normgeltung. <i>Zeitschrift für die gesamte Strafrechtswissenschaft</i>, 129(3): 629–649. <a href="https://doi.org/10.1515/zstw-2017-0033">https://doi.org/10.1515/zstw-2017-0033</a></div>
+  <div class="csl-entry">Würdinger, M., 2012. Über Radarwarngeräte und die Zukunft des Europäischen Privatrechts. <i>Juristische Schulung</i>, (3): 234–240.</div>
+  <div class="csl-entry">中国共产党中央委员会, 2014. 中共中央关于全面推进依法治国若干重大问题的决定. 法宝引证码: CLI.16.237344</div>
+  <div class="csl-entry">佐藤英明, 2014. 一時所得の要件に関する覚書. In: 金子宏, 中里実, J.マーク・ラムザイヤー, eds., 租税法と市場. 有斐閣. 220</div>
+  <div class="csl-entry">何海波, 2000. 判决书上网. 法制日报, : 2.</div>
+  <div class="csl-entry">信春鹰, 2013. 关于《中华人民共和国行政诉讼法修正案（草案）》的说明. 法宝引证码: CLI.DL.6311</div>
+  <div class="csl-entry">全国人大常委会, 1991. 全国人民代表大会常务委员会关于严禁卖淫嫖娼的决定. 法宝引证码: CLI.1.5373</div>
+  <div class="csl-entry">全国人大常委会, 2005. 中华人民共和国公司法. 法宝引证码: CLI.1.60597</div>
+  <div class="csl-entry">全国人大常委会, 2013. 中华人民共和国公司法. 法宝引证码: CLI.1.218774</div>
+  <div class="csl-entry">全国人大常委会, 2017. 中华人民共和国刑法修正案（十）. 法宝引证码: CLI.1.304263</div>
+  <div class="csl-entry">最高人民法院, 2018. 最高人民法院关于适用〈中华人民共和国行政诉讼法〉的解释. 法宝引证码: CLI.3.309904</div>
+  <div class="csl-entry">最高人民法院, 最高人民检察院, 1993. 最高人民法院、最高人民检察院关于依法严惩破坏计划生育犯罪活动的通知. 法宝引证码: CLI.3.8815</div>
+  <div class="csl-entry">国务院, 2007a. 国务院关于在全国建立农村最低生活保障制度的通知. 法宝引证码: CLI.2.96270</div>
+  <div class="csl-entry">国务院, 2007b. 国务院关于在全国建立农村最低生活保障制度的通知. 法宝引证码: CLI.2.96270</div>
+  <div class="csl-entry">国务院, 2018. 国务院关于印发打赢蓝天保卫战三年行动计划的通知. 法宝引证码: CLI.2.316828</div>
+  <div class="csl-entry">国家质量监督检验检疫总局, 中国国家标准化管理委员会, 2015. 信息与文献 参考文献著录规则. </div>
+  <div class="csl-entry">夏新华, 胡旭晟, 刘鄂, et al., 2004. 近代中国宪政历程. 中国政法大学出版社. 1159</div>
+  <div class="csl-entry">季卫东, 1993. 法律程序的意义：对中国法制建设的另一种思考. 中国社会科学, (1): 83–103.</div>
+  <div class="csl-entry">崔国斌, 2006. 知识产权法官造法批判. 中国法学, (1): 144–164. <a href="https://doi.org/10.14111/j.cnki.zgfx.2006.01.013">https://doi.org/10.14111/j.cnki.zgfx.2006.01.013</a></div>
+  <div class="csl-entry">应松年, 马怀德, eds., 2006. 当代中国行政法的源流：王名扬教授九十华诞贺寿文集. 中国法制出版社.</div>
+  <div class="csl-entry">张新宝, 2016. 侵权责任法. 中国人民大学出版社.</div>
+  <div class="csl-entry">[德]莱纳·沃尔夫, 2012. 风险法的风险. In: 刘刚, eds., 风险规制：德国的理论与实践. 法律出版社.</div>
+  <div class="csl-entry">我妻栄, 1971. 新訂担保物権法. 有斐閣.</div>
+  <div class="csl-entry">我妻栄, 有泉亨, 1950. 民法総則物権法. 日本評論社.</div>
+  <div class="csl-entry">於保不二雄, 1954. 付加物及び従物と抵当権. 民商法雑誌, 29(5): 1.</div>
+  <div class="csl-entry">李松锋, 2015. 游走在上帝与凯撒之间：美国宪法第一修正案中的政教关系研究: [博士学位论文]. 中国政法大学.</div>
+  <div class="csl-entry">欧中坦, 1994. 千方百计上京城：清朝的京控. In: 高道蕴, 高鸿钧, 贺卫方, eds., 美国学者论中国法律传统. 中国政法大学出版社.</div>
+  <div class="csl-entry">汪波, 2004. 哈尔滨市政法机关正对“宝马案”认真调查复查. 人民网. <a href="http://www.people.com.cn/GB/shehui/1062/2289764.html">http://www.people.com.cn/GB/shehui/1062/2289764.html</a></div>
+  <div class="csl-entry">王保树, 1994. 股份有限公司机关构造中的董事和董事会. In: 梁慧星, eds., 民商法论丛. 法律出版社. 110</div>
+  <div class="csl-entry">王名扬, 2007. 美国行政法. 北京大学出版社.</div>
+  <div class="csl-entry">瞿同祖, 2010. 中国法律与中国社会. 商务印书馆. 428</div>
+  <div class="csl-entry">罗豪才, 袁曙宏, 李文栋, 1993. 现代行政法的理论基础——论行政机关与相对一方的权利义务平衡. 中国法学, (1): 52–59. <a href="https://doi.org/10.14111/j.cnki.zgfx.1993.01.010">https://doi.org/10.14111/j.cnki.zgfx.1993.01.010</a></div>
+  <div class="csl-entry">[美]富勒, 2005. 法律的道德性. 商务印书馆.</div>
+  <div class="csl-entry">[英]劳特派特, 1971. 奥本海国际法. 商务印书馆.</div>
+  <div class="csl-entry">赵耀彤, 2018. 一名基层法官眼里好律师的样子. 中国法律评论. <a href="http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm">http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm</a></div>
+  <div class="csl-entry">邓小平, 1994. 精简机构是一场革命. In: 邓小平文选. 人民出版社.</div>
+  <div class="csl-entry">高鸿钧, 程汉大, eds., 2013. 英美法原论. 北京大学出版社.</div>
+  <div class="csl-entry">1919. 信玄公旗掛松事件. 大審院民事判決録, 25: 356.</div>
+  <div class="csl-entry">1966. Department of Transportation Act. <i>Stat.</i>, 80: 931, 944–947.</div>
+  <div class="csl-entry">1973. Roe <i>v.</i> Wade. <i>U.S.</i>, 410: 113.</div>
+  <div class="csl-entry">1982. Natural Resources Defense Council <i>v.</i> Gorsuch. <i>F.2d</i>, 685: 718.</div>
+  <div class="csl-entry">1982. 約束手形金. 最高裁判所民事判例集, 36卷6号: 1113.</div>
+  <div class="csl-entry">1984. Chevron U.S.A., Inc. <i>v.</i> Natural Resources Defense Council. <i>U.S.</i>, 467: 837.</div>
+  <div class="csl-entry">1987. R. v. Panel on Take-Overs and Mergers. <i>QB</i>, 815.</div>
+  <div class="csl-entry">1999. <i>NStZ-RR</i>, : 185.</div>
+  <div class="csl-entry">2000. <i>NJW</i>, : 1560.</div>
+  <div class="csl-entry">2006. Administrative Procedure Act § 6. <i>U.S.C.</i>, 5.</div>
+  <div class="csl-entry">2013. 荣宝英诉王阳、永诚财产保险股份有限公司江阴支公司机动车交通事故责任纠纷案. 最高人民法院公报, (8). 法宝引证码: CLI.C.2125100</div>
+  <div class="csl-entry">2015. 陆红霞诉南通市发改委政府信息公开案. 最高人民法院公报, (11). 法宝引证码: CLI.C.7997435</div>
+  <div class="csl-entry">2017. 榆林市凯奇莱能源投资有限公司诉陕西省地质矿产勘查开发局西安地质矿产勘查开发院合作勘查合同纠纷上诉案. </div>
+  <div class="csl-entry">N.d. GG. </div>
+  <div class="csl-entry">N.d. StGB. </div>
+  <div class="csl-entry">N.d. StPO. </div>
+  <div class="csl-entry">N.d. Strauß-Karikatur, Kunstfreiheit. <i>BVerfGE</i>, 75: 369.</div>
+  <div class="csl-entry">N.d. United States <i>v.</i> Dino Nastasi et Al. </div>
+  <div class="csl-entry">N.d. ジュリスト. <a href="http://www.yuhikaku.co.jp/jurist">http://www.yuhikaku.co.jp/jurist</a></div>
+  <div class="csl-entry">N.d. 動産及び債権の譲渡の対抗要件に関する民法の特例に関する法律. </div>
+  <div class="csl-entry">N.d. 包郑照诉苍南县人民政府强制拆除房屋案. </div>
+  <div class="csl-entry">N.d. 平成26年版犯罪白書. </div>
+  <div class="csl-entry">N.d. 民法总则. </div>
+  <div class="csl-entry">N.d. 法国行政法院网站. <a href="http://english.conseil-etat.fr/Judging">http://english.conseil-etat.fr/Judging</a></div>
+  <div class="csl-entry">N.d. 温家宝主持国务院会议 研究房地产业健康发展措施. 新华网. <a href="http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm">http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm</a></div>
+  <div class="csl-entry">N.d. 被告人李宁、张磊贪污案一审开庭. 新华网. <a href="http://www.xinhuanet.com/legal/2019-12/31/c_1125406056.htm">http://www.xinhuanet.com/legal/2019-12/31/c_1125406056.htm</a></div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### APA 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-false">
+  <div class="csl-entry">Ahmann, E., Tuttle, L. J., Saviet, M., et al., 2018. A Descriptive Review of ADHD Coaching Research: Implications for College Students. <i>Journal of Postsecondary Education and Disability</i>, 31(1): 17–39.</div>
+  <div class="csl-entry">Alonso-Tapia, J., Nieto, C., Merino-Tejedor, E., et al., 2018. Situated Goals Questionnaire for University Students (SGQ-U, CMS-U). <a href="https://doi.org/10.1037/t66267-000">https://doi.org/10.1037/t66267-000</a></div>
+  <div class="csl-entry">Amano, N., Kondo, H., 2000. Lexical Characteristics of Japanese Language. Sansei-do.</div>
+  <div class="csl-entry">American Counseling Association, 2014. 2014 ACA Code of Ethics. </div>
+  <div class="csl-entry">American Nurses Association, 2015. Code of Ethics for Nurses with Interpretive Statements. </div>
+  <div class="csl-entry">American Psychiatric Association, 2013. Diagnostic and Statistical Manual of Mental Disorders. <a href="https://doi.org/10.1176/appi.books.9780890425596">https://doi.org/10.1176/appi.books.9780890425596</a> tex.shorthand: DSM-5</div>
+  <div class="csl-entry">American Psychological Association, 2017. Ethical Principles of Psychologists and Code of Conduct. </div>
+  <div class="csl-entry">American Psychological Association, n.d. APA Dictionary of Psychology. </div>
+  <div class="csl-entry">American Psychological Association, n.d. Positive Transference. In: APA Dictionary of Psychology. </div>
+  <div class="csl-entry">Anderson, M., 2018. Getting Consistent with Consequences. <i>Educational Leadership</i>, 76(1): 26–33.</div>
+  <div class="csl-entry">APA Education [@APAEducation], 2018. College Students Are Forming Mental-Health Clubs—and They’re Making a Difference @washingtonpost [Thumbnail with Link Attached]. <i>Twitter</i>, </div>
+  <div class="csl-entry">APA Style [@APA_Style], n.d. Tweets. <i>Twitter</i>. <a href="https://twitter.com/APA_Style">https://twitter.com/APA_Style</a></div>
+  <div class="csl-entry">Aristotle, 1994. Poetics. The Internet Classics Archive. Typs: classic</div>
+  <div class="csl-entry">Australian Government Productivity Commission, New Zealand Productivity Commission, 2012. Strengthening Trans-Tasman Economic Relations. </div>
+  <div class="csl-entry">Author, A., 2019. How Workout Buddies Can Help Stave off Loneliness. <i>The Washington Post</i>, </div>
+  <div class="csl-entry">Avramova, N., 2019. The Secret to a Long, Happy, Health Life? Think Age-Positive. <i>CNN</i>. <a href="https://www.cnn.com/2019/01/03/health/respect-towards-elderly-leads-to-long-life-intl/index.html">https://www.cnn.com/2019/01/03/health/respect-towards-elderly-leads-to-long-life-intl/index.html</a></div>
+  <div class="csl-entry">Badlands National Park [@BadlandsNPS], 2018. Biologists Have Identified More than 400 Different Plant Species Growing in @BadlandsNPS #DYK #biodoversity. <i>Twitter</i>, </div>
+  <div class="csl-entry">Baer, R. A., 2015. Unpublished Raw Data on the Correlations between the Five Facet Mindfulness Questionnaire and the Kentucky Inventory of Mindfulness Skills. </div>
+  <div class="csl-entry">Balsam, K. F., Martell, C. R., Jones, K. P., et al., 2019. Affirmative Cognitive Behavior Therapy with Sexual and Gender Minority People. In: Iwamasa, G. Y., Hays, P. A., eds., Culturally Responsive Cognitive Behavior Therapy: Practice and Supervision. American Psychological Association. 287–314 <a href="https://doi.org/10.1037/0000119-012">https://doi.org/10.1037/0000119-012</a></div>
+  <div class="csl-entry">de Beauvoir, S., 1960. Simone de Beauvoir Discusses the Art of Writing. </div>
+  <div class="csl-entry">Bergeson, S., 2019. Really Cool Neutral Plasmas. <i>Science</i>, 363(6422): 33–34. <a href="https://doi.org/10.1126/science.aau7988">https://doi.org/10.1126/science.aau7988</a></div>
+  <div class="csl-entry">Beyoncé, 2016. Formation. <i>Lemonade</i>, </div>
+  <div class="csl-entry">Blackwell, D. L., Lucas, J. W., Clarke, T. C., 2014. Summary Health Statistics for U.S. Adults: National Health Interview Survey, 2012. </div>
+  <div class="csl-entry">Blair, C. B., 2015–2020. Stress, Self-Regulation and Psychopathology in Middle Childhood. </div>
+  <div class="csl-entry">Boddy, J., Neumann, T., Jennings, S., et al., n.d. Ethics Principles. <i>The research ethics guidebook: A resource for social scientists</i>. <a href="http://www.ethicsguidebook.ac.uk/EthicsPrinciples">http://www.ethicsguidebook.ac.uk/EthicsPrinciples</a></div>
+  <div class="csl-entry">Bologna, C., 2018. What Happens to Your Mind and Body When You Feel Homesick? <i>HuffPost</i>. <a href="https://www.huffingtonpost.com/entry/what-happens-mind-body-homesick_us_5b201ebde4b09d7a3d77eee1">https://www.huffingtonpost.com/entry/what-happens-mind-body-homesick_us_5b201ebde4b09d7a3d77eee1</a></div>
+  <div class="csl-entry">Borenstein, M., Hedges, L., Higgins, J., et al., 2014. Comprehensive Meta-Analysis. </div>
+  <div class="csl-entry">Bowie, D., 2016. Blackstar. </div>
+  <div class="csl-entry">British Cardiovascular Society Working Group, 2016. British Cardiovascular Society Working Group Report: Out-of-Hours Cardiovascular Care: Management of Cardiac Emergencies and Hospital in-Patients. </div>
+  <div class="csl-entry">Bronfenbrenner, U., 2005. The Social Ecology of Human Development: A Retrospective Conclusion. In: Bronfenbrenner, U., eds., Making Human Beings Human: Bioecological Perspectives on Human Development. SAGE Publications. 27–40 tex.related: 10.3:44r
+tex.relatedtype: reprintfrom</div>
+  <div class="csl-entry">Brown, L. S., 2018. Feminist Therapy. American Psychological Association. <a href="https://doi.org/10.1037/0000092-000">https://doi.org/10.1037/0000092-000</a></div>
+  <div class="csl-entry">Burgess, R., 2019. Rethinking Global Health: Frameworks of Power. Routledge.</div>
+  <div class="csl-entry">Burin, D., Kilteni, K., Rabuffetti, M., et al., 2019. Body Ownership Increases the Interference between Observed and Executed Movements. <i>PLOS ONE</i>, 14(1). <a href="https://doi.org/10.1371/journal.pone.0209899">https://doi.org/10.1371/journal.pone.0209899</a></div>
+  <div class="csl-entry">Bustillos, M., 2013. On Video Games and Storytelling: An Interview with Tom Bissell. <i>The New Yorker</i>, </div>
+  <div class="csl-entry">Cable, D., 2013. The Racial Dot Map. </div>
+  <div class="csl-entry">Cain, S., 2012. Quiet: The Power of Introverts in a World That Can’t Stop Talking. Random House Audio.</div>
+  <div class="csl-entry">Canada Council for the Arts, 2013. What We Heard: Summary of Key Findings: 2013 Canada Council’s Inter-Arts Office Consultation. </div>
+  <div class="csl-entry">Canan, E., Vasilev, J., 2019. Lecture Notes on Resource Allocation. </div>
+  <div class="csl-entry">Carcavilla González, N., 2015. Auditory Sensory Therapy: Brain Activation through Music. In: Garcia Meilán, J. J., eds., Guía Práctica de Terapias Estimulativas En El Alzhéimer. Editorial Síntesis. 67–86</div>
+  <div class="csl-entry">Cardoza, D., Morris, J. K., Myers, H. F., et al., 2000. Acculturative Stress Inventory (ASI). </div>
+  <div class="csl-entry">Centers for Disease Control and Prevention, 2018. People at High Risk of Developing Flu-Related Complications. <a href="https://www.cdc.gov/flu/about/disease/high_risk.htm">https://www.cdc.gov/flu/about/disease/high_risk.htm</a></div>
+  <div class="csl-entry">Chaves-Morillo, V., Gómez Calero, C., Fernández-Muñoz, J. J., et al., 2018. Sensorineural Anosmia: Relationship between Subtype, Recognition Time, and Age. <i>Clínica y Salud</i>, 28(3): 155–161. <a href="https://doi.org/10.1016/j.clysa.2017.04.002">https://doi.org/10.1016/j.clysa.2017.04.002</a></div>
+  <div class="csl-entry">Childish Gambino, 2018. This Is America. </div>
+  <div class="csl-entry">Christian, B., Griffiths, T., 2016. Algorithms to Live by: The Computer Science of Human Decisions. Henry Holt and Co.</div>
+  <div class="csl-entry">Cuellar, N. G., 2016. Study Abroad Programs. <i>Journal of Transcultural Nursing</i>, 27(3): 209. <a href="https://doi.org/10.1177/1043659616638722">https://doi.org/10.1177/1043659616638722</a></div>
+  <div class="csl-entry">De Boer, D., LaFavor, T., 2018. The Art and Significance of Successfully Identifying Resilient Individuals A Person-Focused Approach. <i>Perspectives on resilience: Conceptualization, measurement, and enhancement</i>, </div>
+  <div class="csl-entry">De Vries, R., Nieuwenhuijze, M., Buitendijk, S. E., et al., 2013. What Does It Take to Have a Strong and Independent Profession of Midwifery? Lessons from the Netherlands. <i>Midwifery</i>, 29(10): 1122–1128. <a href="https://doi.org/10.1016/j.midw.2013.07.007">https://doi.org/10.1016/j.midw.2013.07.007</a></div>
+  <div class="csl-entry">Delacroix, E., 1826–1827. Faust Attempts to Seduce Marguerite. </div>
+  <div class="csl-entry">D’Souza, A., Wiseheart, M., 2018. Cognitive Effects of Music and Dance Training in Children. <a href="https://doi.org/10.3886/ICPSR37080.1">https://doi.org/10.3886/ICPSR37080.1</a></div>
+  <div class="csl-entry">Epocrates, 2019a. Epocrates Medical References. </div>
+  <div class="csl-entry">Epocrates, 2019b. Interaction Check: Aspirin + Sertraline. <i>Epocrates medical references</i>, </div>
+  <div class="csl-entry">Fiske, S. T., Gilbert, D. T., Lindzey, G., 2010. Handbook of Social Psychology. John Wiley &#38; Sons. <a href="https://doi.org/10.1002/9780470561119">https://doi.org/10.1002/9780470561119</a></div>
+  <div class="csl-entry">Fistek, A., Jester, E., Sonnenberg, K., 2017. Everybody’s Got a Little Music in Them: Using Music Therapy to Connect, Engage, and Motivate. </div>
+  <div class="csl-entry">Freud, S., 2010. The Interpretation of Dreams: The Complete and Definitive Text. Basic Books.</div>
+  <div class="csl-entry">Fried, D., Polyakova, A., 2018. Democratic Defense against Disinformation. </div>
+  <div class="csl-entry">Gaiman, N., 2018. 100,000+ Rohingya Refugees Could Be at Serious Risk during Bangladesh’s Monsoon Season. My Fellow UNHCR Goodwill Ambassador Cate Blanchett Is [Image Attached]. <i>Facebook</i>, </div>
+  <div class="csl-entry">GDJ, 2018. Neural Network Deep Learning Prismatic. </div>
+  <div class="csl-entry">Glass, I., 2011. Amusement Park. <i>This American Life</i>, </div>
+  <div class="csl-entry">Gold, M., eds., 1999. The Complete Social Scientist: A Kurt Lewin Reader. American Psychological Association. <a href="https://doi.org/10.1037/10319-000">https://doi.org/10.1037/10319-000</a></div>
+  <div class="csl-entry">Goldin-Meadow, S., 2015. Gesture and Cognitive Development. In: Liben, L. S., Mueller, U., eds., Handbook of Child Psychology and Developmental Science. John Wiley &#38; Sons. 339–380 <a href="https://doi.org/10.1002/9781118963418.childpsy209">https://doi.org/10.1002/9781118963418.childpsy209</a></div>
+  <div class="csl-entry">Goldman, C., 2018. The Complicated Calibration of Love, Especially in Adoption. <i>Chicago Tribune</i>, </div>
+  <div class="csl-entry">Google, n.d. Google Maps Directions for Driving from La Paz, Bolivia, to Lima, Peru. </div>
+  <div class="csl-entry">Graham, G., 2019. Behaviorism. In: Zalta, E. N., eds., The Stanford Encyclopedia of Philosophy. Stanford University.</div>
+  <div class="csl-entry">Guarino, B., 2017. How Will Humanity React to Alien Life? Psychologists Have Some Predictions. <i>The Washington Post</i>, </div>
+  <div class="csl-entry">Hacker Hughes, J., eds., 2017. Military Veteran Psychological Health and Social Care: Contemporary Approaches. Routledge.</div>
+  <div class="csl-entry">Harris, L., 2014. Instructional Leadership Perceptions and Practices of Elementary School Leaders: [Unpublished doctoral dissertation]. University of Virginia.</div>
+  <div class="csl-entry">Harwell, M., 2018. Don’t Expect Too Much: The Limited Usefulness of Common SES Measures and a Prescription for Change. </div>
+  <div class="csl-entry">Heidegger, M., 2008. On the Essence of Truth. In: Krell, D. F., eds., Basic Writings. Harper Perennial Modern Thought. 111–138</div>
+  <div class="csl-entry">Hess, A., 2019. Cats Who Take Direction. <i>The New York Times</i>, : C1.</div>
+  <div class="csl-entry">Hiremath, S. C., Kumar, S., Lu, F., et al., 2016. Using Metaphors to Present Concepts across Different Intellectual Domains. </div>
+  <div class="csl-entry">Ho, H.-K., 2014. Teacher Preparation for Early Childhood Special Education in Taiwan. </div>
+  <div class="csl-entry">Hollander, M. M., 2017. Resistance to Authority: Methodological Innovations and New Lessons from the Milgram Experiment: [Doctoral dissertation]. University of Wisconsin–Madison.</div>
+  <div class="csl-entry">Housand, B., 2016. Game on! Integrating Games and Simulations in the Classroom. </div>
+  <div class="csl-entry">Huestegge, S. M., Raettig, T., Huestegge, L., 2019. Are Face-Incongruent Voices Harder to Process? Effects of Face–Voice Gender Incongruency on Basic Cognitive Information Processing. <i>Experimental Psychology</i>,  <a href="https://doi.org/10.1027/1618-3169/a000440">https://doi.org/10.1027/1618-3169/a000440</a></div>
+  <div class="csl-entry">Hutcheson, V. H., 2012. Dealing with Dual Differences: Social Coping Strategies of Gifted and Lesbian, Gay, Bisexual, Transgender, and Queer Adolescents: [Master’s thesis]. The College of William &#38; Mary.</div>
+  <div class="csl-entry">Kalnay, E., Kanamitsu, M., Kistler, R., et al., 1996. The NCEP/NCAR 40-Year Reanalysis Project. <i>Bulletin of the American Meteorological Society</i>, 77(3): 437–471. <a href="https://doi.org/fg6rf9">https://doi.org/fg6rf9</a></div>
+  <div class="csl-entry">King, M. L., Jr., 1963. I Have a Dream. </div>
+  <div class="csl-entry">Klymkowsky, M., 2018. Can We Talk Scientifically about Free Will? <i>Sci-Ed</i>. <a href="https://blogs.plos.org/scied/2018/09/15/can-we-talk-scientifically-about-free-will/">https://blogs.plos.org/scied/2018/09/15/can-we-talk-scientifically-about-free-will/</a></div>
+  <div class="csl-entry">KS in NJ, 2019. From This Article, It Sounds like Men Are Figuring Something out That Women Have Known Forever. I Know of Many. <i>The Washington Post</i>,  tex.related: 10.1:18r
+tex.relatedstring: Comment on the article
+tex.relatedtype: commenton</div>
+  <div class="csl-entry">Lamar, K., 2017. Humble. <i>Damn</i>, </div>
+  <div class="csl-entry">Leuker, C., Samartzidis, L., Hertwig, R., et al., 2018. When Money Talks: Judging Risk and Coercion in High-Paying Clinical Trials. <a href="https://doi.org/10.17605/OSF.IO/9P7CB">https://doi.org/10.17605/OSF.IO/9P7CB</a></div>
+  <div class="csl-entry">Lewin, K., 1999. Group Decision and Social Change. In: Gold, M., eds., The Complete Social Scientist: A Kurt Lewin Reader. American Psychological Association. 265–284 <a href="https://doi.org/10.1037/10319-000">https://doi.org/10.1037/10319-000</a></div>
+  <div class="csl-entry">Lichtenstein, J., 2013. Profile of Veteran Business Owners: More Young Veterans Appear to Be Starting Businesses. </div>
+  <div class="csl-entry">Lilienfeld, S. O., eds., 2018. Archives of Scientific Psychology. 6(1): 51–104.</div>
+  <div class="csl-entry">Lippincott, T., Poindexter, E. K., 2019. Emotion Recognition as a Function of Facial Cues: Implications for Practice. </div>
+  <div class="csl-entry">Mack, R., Spake, G., 2018. Citing Open Source Images and Formatting References for Presentations. </div>
+  <div class="csl-entry">Maddox, S., Hurling, J., Stewart, E., et al., 2016. If Mama Ain’t Happy, Nobody’s Happy: The Effect of Parental Depression on Mood Dysregulation in Children. </div>
+  <div class="csl-entry">Madigan, S., 2019. Narrative Therapy. American Psychological Association. <a href="https://doi.org/10.1037/00000131-000">https://doi.org/10.1037/00000131-000</a></div>
+  <div class="csl-entry">Martin Lillie, C. M., 2016. Be Kind to Yourself: How Self-Compassion Can Improve Your Resiliency. <i>Mayo Clinic</i>. <a href="https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/self-compassion-can-improve-your-resiliency/art-20267193">https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/self-compassion-can-improve-your-resiliency/art-20267193</a></div>
+  <div class="csl-entry">McCauley, S. M., Christiansen, M. H., 2019. Language Learning as Language Use: A Cross-Linguistic Model of Child Language Development. <i>Psychological Review</i>, 126(1): 1–51. <a href="https://doi.org/10.1037/rev0000126">https://doi.org/10.1037/rev0000126</a></div>
+  <div class="csl-entry">McCurry, S., 1985. Afghan Girl. </div>
+  <div class="csl-entry">McDaniel, S. H., Salas, E., Kazak, A. E., eds., 2018. American Psychologist. 73(4).</div>
+  <div class="csl-entry">Meadows, D. H., 2008. Thinking in Systems: A Primer. Chelsea Green Publishing.</div>
+  <div class="csl-entry">Mehrholz, J., Pohl, M., Platz, T., et al., 2018. Electromechanical and Robot-Assisted Arm Training for Improving Activities of Daily Living, Arm Function, and Arm Muscle Strength after Stroke. <i>Cochrane Database of Systematic Reviews</i>,  <a href="https://doi.org/10.1002/14651858.CD006876.pub5">https://doi.org/10.1002/14651858.CD006876.pub5</a></div>
+  <div class="csl-entry">Merriam-Webster, n.d. Merriam-Webster.Com Dictionary. </div>
+  <div class="csl-entry">Merriam-Webster, n.d. Self-Report. In: Merriam-Webster.Com Dictionary. </div>
+  <div class="csl-entry">Mirabito, L. A., Heck, N. C., 2016. Bringing LGBTQ Youth Theater into the Spotlight. <i>Psychology of Sexual Orientation and Gender Diversity</i>, 3(4): 499–500. <a href="https://doi.org/10.1037/sgd0000205">https://doi.org/10.1037/sgd0000205</a> tex.related: 10.7:67r
+tex.relatedstring: Review of the film
+tex.relatedtype: reviewof</div>
+  <div class="csl-entry">Morey, M. C., 2019. Physical Activity and Exercise in Older Adults. <i>UpToDate</i>, </div>
+  <div class="csl-entry">National Aeronautics and Space Administration [@nasa], 2018. I’m NASA Astronaut Scott Tingle. Ask Me Anything about Adjusting to Being Back on Earth after My First Spaceflight! <i>Reddit</i>, </div>
+  <div class="csl-entry">National Cancer Institute, 2018. Facing Forward: Life after Cancer Treatment. </div>
+  <div class="csl-entry">National Center for Education Statistics, 2016. Fast Response Survey System (FRSS): Teacher’s Use of Educational Technology in U.S. Public Schools, 2009. <a href="https://doi.org/10.3886/ICPSR335531.v3">https://doi.org/10.3886/ICPSR335531.v3</a></div>
+  <div class="csl-entry">National Institute of Mental Health, 2018. Suicide Affects All Ages, Genders, Races, and Ethnicities. Check out These 5 Action Steps for Helping Someone in Emotional Pain. <i>Facebook</i>, </div>
+  <div class="csl-entry">National Nurses United, n.d. What Employers Should Do to Protect Nurses from Zika. <a href="https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika">https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika</a></div>
+  <div class="csl-entry">News From Science, 2018. These Frogs Walk Instead of Hop. Https://Scimag.2KlriwH. <i>Facebook</i>, </div>
+  <div class="csl-entry">Oregan Youth Authority, 2011. Recidivism Outcomes. </div>
+  <div class="csl-entry">O’Shea, M., 2018. Understanding Proactive Behavior in the Workplace as a Function of Gender. </div>
+  <div class="csl-entry">Pachur, T., Scheibehenne, B., n.d. Unpacking Buyer-Seller Differences in Valuation from Experience: A Cognitive Modeling Approach. <i>Psychonomic Bulletin &#38; Review</i>, </div>
+  <div class="csl-entry">Pearson, J., 2018. Fat Talk and Its Effects on State-Based Body Image in Women. </div>
+  <div class="csl-entry">Perkins, D., 2018. <i>The Good Place</i> Ends Its Remarkable Second Season with Irrational Hope, Unexpected Gifts, and a Smile. <a href="https://www.avclub.com/the-good-place-ends-its-remarkable-second-season-with-i-1822649316">https://www.avclub.com/the-good-place-ends-its-remarkable-second-season-with-i-1822649316</a> tex.related: 10.7:69r
+tex.relatedstring: Review of the TV series episode
+tex.relatedtype: reviewof</div>
+  <div class="csl-entry">Pew Research Center, 2018. American Trends Panel Wave 26. </div>
+  <div class="csl-entry">Piaget, J., 1972. Intellectual Evolution from Adolescence to Adulthood. <i>Human Development</i>, 15(1): 1–12. <a href="https://doi.org/10.1159/00027/1225">https://doi.org/10.1159/00027/1225</a></div>
+  <div class="csl-entry">Piaget, J., Inhelder, B., 1966. The Psychology of the Child. Quadrige.</div>
+  <div class="csl-entry">Piaget, J., Inhelder, B., 1969. The Psychology of the Child. Basic Books.</div>
+  <div class="csl-entry">Pridham, K. F., Limbo, R., Schroeder, M., eds., 2018. Guided Participation in Pediatric Nursing Practice: Relationship-Based Teaching and Learning with Parents, Children and Adolescents. Springer Publishing Company.</div>
+  <div class="csl-entry">Project Implicit, n.d. Gender-Science IAT. </div>
+  <div class="csl-entry">Richardson, F., eds., 1973. Brain and Intelligence: The Ecology of Child Development. National Educational Press. 113–123</div>
+  <div class="csl-entry">Rinaldi, J., 2016. Photograph Series of a Boy Who Finds His Footing after Abuse by Those He Trusted. </div>
+  <div class="csl-entry">Rossman, J., Palmer, R., 2015. Sorting through Our Space Junk. </div>
+  <div class="csl-entry">Rowling, J. K., 2015. Harry Potter and the Sorceror’s Stone. Pottermore Publishing.</div>
+  <div class="csl-entry">Sacchett, C., Humphreys, G. W., 1992. Calling a Squirrel and Squirrel but a Canoe a Wigwam: A Category-Specific Deficit for Artefactual Objects and Body Parts. <i>Cognitive Neuropsychology</i>, 9(1): 73–86. <a href="https://doi.org/d4vb59">https://doi.org/d4vb59</a></div>
+  <div class="csl-entry">Sacchett, C., Humphreys, G. W., 2004. Calling a Squirrel and Squirrel but a Canoe a Wigwam: A Category-Specific Deficit for Artefactual Objects and Body Parts. In: Balota, D. A., Marsh, E. J., eds., Cognitive Psychology: Key Readings in Cognition. Psychology Press. 100–108 tex.related: 10.3:43r
+tex.relatedtype: reprintfrom</div>
+  <div class="csl-entry">Santos, F., 2019. Reframing Refugee Children’s Stories. <i>The New York Times</i>,  tex.related: 10.7:68r
+tex.relatedstring: Review of the book
+tex.relatedtype: reviewof</div>
+  <div class="csl-entry">Schmid, H.-J., eds., 2017. Entrenchment and the Psychology of Language Learning: How We Reorganize and Adapt Linguistic Knowledge. American Psychological Association; De Gruyter Mouton. <a href="https://doi.org/10.1037/15969-000">https://doi.org/10.1037/15969-000</a></div>
+  <div class="csl-entry">Segaert, A., Bauer, A., 2015. The Extent and Nature of Veteran Homelessness in Canada. </div>
+  <div class="csl-entry">Shakespeare, W., 1995. Much Ado about Nothing. Washington Square Press.</div>
+  <div class="csl-entry">Shore, M. F., 2014. Marking Time in the Land of Plenty: Reflections on Mental Health in the United States. <i>American Journal of Orthopsychiatry</i>, 84(6): 611–618. <a href="https://doi.org/10.1037/h0100165">https://doi.org/10.1037/h0100165</a> tex.related: 10.1:11r
+tex.relatedtype: reprintfrom</div>
+  <div class="csl-entry">Smithsonian’s National Zoo and Conservation Biology Institute, n.d. Home. <i>Facebook</i>. <a href="https://www.facebookcom/nationalzoo">https://www.facebookcom/nationalzoo</a></div>
+  <div class="csl-entry">SR Research, 2016. Eyelink 1000 Plus. </div>
+  <div class="csl-entry">Stults-Kolehmainen, M. A., Sinha, R., 2015. The Effects of Stress on Physical Activity and Exercise. </div>
+  <div class="csl-entry">Tactile Labs, 2015. Latero Tactile Display. </div>
+  <div class="csl-entry">Tafoya, N., Del Vecchio, A., 2005. Back to the Future: An Examination of the Native American Holocaust Experience. In: McGoldrick, M., Giordano, J., Garcia-Preto, N., eds., Ethnicity and Family Therapy. Guilford Press. 55–63</div>
+  <div class="csl-entry">Tellegen, A., Ben-Porath, Y. S., 2011. Minnesota Multiphasic Personality Inventory-2 Restructured Form (MMPI-2-RF): Technical Manual. </div>
+  <div class="csl-entry">The New York Public Library [@nypl], n.d. The Raven. <i>Instagram</i>, </div>
+  <div class="csl-entry">Travis, C. B., White, J. W., eds., 2018. APA Handbook of the Psychology of Women. American Psychological Association. <a href="https://doi.org/10.1037/0000059-000">https://doi.org/10.1037/0000059-000</a></div>
+  <div class="csl-entry">U.S. Census Bureau, n.d. U.S. and World Population Clock. <i>U.S. Department of Commerce</i>. <a href="https://www.census.gov/popclock/">https://www.census.gov/popclock/</a></div>
+  <div class="csl-entry">U.S. Food and Drug Administration, 2019. FDA Authorizes First Interoperable Insulin Pup Intended to Allow Patients to Customize Treatment through Their Individual Diabetes Management Devices. </div>
+  <div class="csl-entry">U.S. Securities and Exchange Commission, 2017. Agency Financial Report: Fiscal Year 2017. </div>
+  <div class="csl-entry">Vedantam, S., 2015. Hidden Brain. </div>
+  <div class="csl-entry">Weinstock, R., Leong, G. B., Silva, J. A., 2003. Defining Forensic Psychiatry: Roles and Responsibilities. In: Rosner, R., eds., Principles and Practise of Forensic Psychiatry. CRC Press. 7–13</div>
+  <div class="csl-entry">Weir, K., 2017. Forgiveness Can Improve Mental and Physical Health. <i>Monitor on Psychology</i>, 48(1): 30.</div>
+  <div class="csl-entry">White, B., 2018. I Treasure Every Minute We Spent Together #koko [Image Attached]. <i>Twitter</i>, </div>
+  <div class="csl-entry">Wood, G., 1930. American Gothic. </div>
+  <div class="csl-entry">World Health Organization, 2018. Questions and Answers on Immunization and Vaccine Safety. <a href="https://www.who.int/features/qa/84/en/">https://www.who.int/features/qa/84/en/</a></div>
+  <div class="csl-entry">World Health Organization, 2019. International Statistical Classification of Diseases and Related Health Problems. tex.shorthand: ICD-11</div>
+  <div class="csl-entry">Yoo, J., Miyamoto, Y., Rigotti, A., et al., 2016. Linking Positive Affect to Blood Lipids: A Cultural Perspective. </div>
+  <div class="csl-entry">Yousafzai, M., 2016. We Are Displaced: My Journey and Stories from Refugee Girls around the World. </div>
+  <div class="csl-entry">Zalta, E. N., eds., 2019. The Stanford Encyclopedia of Philosophy. Stanford University.</div>
+  <div class="csl-entry">Zeitz MOCAA [@zeitzmocaa], 2018. Grade 6 Learners from Parkfields Primary School in Hanover Park Visited the Museum for a Tour and Workshop Hosted By. <i>Instagram</i>, </div>
+  <div class="csl-entry">1954. Brown v. Board of Education. <i>U.S.</i>, 347: 483.</div>
+  <div class="csl-entry">1964. Civil Rights Act of 1964. <i>Stat.</i>, 78: 241.</div>
+  <div class="csl-entry">1972. Patsy Mink Equal Opportunity in Education Act. <i>U.S.C</i>, 20.</div>
+  <div class="csl-entry">1975. One Flew over the Cuckoo’s Nest. </div>
+  <div class="csl-entry">1976. Tarasoff v. Regents of the University of California. <i>Cal.3d</i>, 17: 425.</div>
+  <div class="csl-entry">1981. Marking Time in the Land of Plenty: Reflections on Mental Health in the United States. <i>American Journal of Orthopsychiatry</i>, 51(3): 391–402. <a href="https://doi.org/10.1111/j.1939-0025.1981.tb01388.x">https://doi.org/10.1111/j.1939-0025.1981.tb01388.x</a></div>
+  <div class="csl-entry">1984. Durflinger v. Artiles. <i>F.Supp.</i>, 563: 332.</div>
+  <div class="csl-entry">1987. Goodbye Children. </div>
+  <div class="csl-entry">1989. United Nations Convention on the Rights of the Child. </div>
+  <div class="csl-entry">1990. American With Disabilities Act of 1990. <i>U.S.C</i>, 42.</div>
+  <div class="csl-entry">1991. Daubert v. Merrell Dow Pharmaceuticals, Inc. <i>F.2d</i>, 951: 1128.</div>
+  <div class="csl-entry">1992. Texas v. Morales. <i>S.W.2d</i>, 826: 201.</div>
+  <div class="csl-entry">1995. Who Shot Mr. Burns? (Part One). <i>The Simpsons</i>, </div>
+  <div class="csl-entry">2001. Burriola v. Greater Toledo YMCA. <i>F.Supp.2d</i>, 133: 1034.</div>
+  <div class="csl-entry">2001. The Lord of the Rings: The Fellowship of the Ring. </div>
+  <div class="csl-entry">2002–2008. The Wire. </div>
+  <div class="csl-entry">2004. The Qur’an. Oxford University Press.</div>
+  <div class="csl-entry">2009. Florida Mental Health Act. <i>Fla. Stat.</i>, </div>
+  <div class="csl-entry">2009. Lilly Leadbetter Fair Play Act of 2009. <i>Stat.</i>, 123: 5.</div>
+  <div class="csl-entry">2009. Protection of Human Subjects. <i>C.F.R.</i>, 45.</div>
+  <div class="csl-entry">2010. The Brandenburg Concertos: Concertos BVW 1043 &#38; 1060. </div>
+  <div class="csl-entry">2012. Brené Brown: Listening to Shame. </div>
+  <div class="csl-entry">2012. Symphony No. 3 in E-Flat Major. <i>Beethoven: Complete Symphonies</i>, </div>
+  <div class="csl-entry">2013. Mental Health on Campus Improvement Act. </div>
+  <div class="csl-entry">2014. Exec. Order No. 13,676. <i>C.F.R.</i>, 3: 294.</div>
+  <div class="csl-entry">2014. Strengthening the Federal Student Loan Program for Borrowers: Hearing before the U.S. Senate Committee on Health, Education, Labor &#38; Pensions. </div>
+  <div class="csl-entry">2015. Every Student Succeeds Act. <i>U.S.C</i>, 20.</div>
+  <div class="csl-entry">2015. H.R. Rep. No. 114-358. </div>
+  <div class="csl-entry">2015. Obergefell v. Hodges. <i>U.S.</i>, 576.</div>
+  <div class="csl-entry">2015. The Torah: The Five Books of Moses. The Jewish Publication Society.</div>
+  <div class="csl-entry">2016. Defining and Delimiting the Exemptions for Executive, Administrative, Professional, Outside Sales and Computer Employees. <i>F.R.</i>, 81: 32391.</div>
+  <div class="csl-entry">2016. Federal Real Property Reform: How Cutting Red Tape and Better Management Count Achieve Billions in Savings, U.S. Senate Committee on Homeland Security and Governmental Affairs. </div>
+  <div class="csl-entry">2016. How Do Geckos Walk on Water? </div>
+  <div class="csl-entry">2016. How to Diagram a Sentence (Absolute Basics). </div>
+  <div class="csl-entry">2016. S. Res. 438. <i>Cong. Rec.</i>, 162: 2394. Legislative Body: 114th Cong.</div>
+  <div class="csl-entry">2016. The Year We Thought about Love. </div>
+  <div class="csl-entry">2017. Accelerated Experiental Dynamic Psychotherapy (AEDP) Supervision. </div>
+  <div class="csl-entry">2017. Happiness. </div>
+  <div class="csl-entry">2017. King James Bible. King James Bible Online.</div>
+  <div class="csl-entry">2017. Lemons. <i>Black-ish</i>, </div>
+  <div class="csl-entry">2018. Evaluating Adverse Drug Effects. </div>
+  <div class="csl-entry">2018. Somewhere Else. </div>
+  <div class="csl-entry">2018. Why You Should Make Useless Things. </div>
+  <div class="csl-entry">2019. List of Oldest Companies. In: Wikipedia. </div>
+  <div class="csl-entry">N.d. S.C. Const. Art. XI, § 3. </div>
+  <div class="csl-entry">N.d. U.N. Charter Art. 1, Para. 3. </div>
+  <div class="csl-entry">N.d. U.S. Const. Amend. I-X. </div>
+  <div class="csl-entry">N.d. U.S. Const. Amend. XIX. </div>
+  <div class="csl-entry">N.d. U.S. Const. Amend. XVIII (Repealed 1933). </div>
+  <div class="csl-entry">N.d. U.S. Const. Art. I, § 3. </div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->

--- a/src/地球科学（英文版）/items.json
+++ b/src/地球科学（英文版）/items.json
@@ -1,0 +1,209 @@
+[
+  {
+    "id": "jes-periodical",
+    "type": "article-journal",
+    "container-title": "Geology",
+    "DOI": "10.1130/0091-7613(1987)15<45:thoubm>2.0.co;2",
+    "issue": "1",
+    "language": "en-US",
+    "page": "45",
+    "title": "Tectonic History of Ulleung Basin Margin, East Sea (Sea of Japan)",
+    "volume": "15",
+    "author": [
+      {
+        "family": "Chough",
+        "given": "S. K."
+      },
+      {
+        "family": "Barg",
+        "given": "E."
+      }
+    ],
+    "issued": {
+      "date-parts": [["1987"]]
+    }
+  },
+  {
+    "id": "jes-book",
+    "type": "book",
+    "language": "en-US",
+    "number-of-pages": "507",
+    "publisher": "McGraw-Hill",
+    "publisher-place": "New York",
+    "title": "Sequence in Layered Rocks",
+    "author": [
+      {
+        "family": "Shrock",
+        "given": "R. R."
+      }
+    ],
+    "issued": {
+      "date-parts": [["1948"]]
+    }
+  },
+  {
+    "id": "jes-chapter",
+    "type": "chapter",
+    "container-title": "Archean Geochemistry",
+    "language": "en-US",
+    "page": "25-46",
+    "publisher": "Springer-Verlag",
+    "publisher-place": "Berlin",
+    "title": "Geochemical Characteristics of Archean Ultramafic and Mafic Volcanic Rocks: Implication and Evolution",
+    "author": [
+      {
+        "family": "Sun",
+        "given": "S. S."
+      }
+    ],
+    "editor": [
+      {
+        "family": "Kroner",
+        "given": "A."
+      },
+      {
+        "family": "Lansor",
+        "given": "G. N."
+      },
+      {
+        "family": "Goodwin",
+        "given": "A. M."
+      }
+    ],
+    "issued": {
+      "date-parts": [["1984"]]
+    }
+  },
+  {
+    "id": "jes-periodical-chapter",
+    "type": "chapter",
+    "collection-title": "Tectonophysics",
+    "container-title": "The Structure of the Crust and Mantle beneath Inland and Marginal Seas",
+    "DOI": "10.1016/0040-1951(70)90041-7",
+    "language": "en-US",
+    "page": "495-513",
+    "title": "The Geology of the Caribbean Crust, I. Beata Ridge",
+    "volume": "10",
+    "author": [
+      {
+        "family": "Fox",
+        "given": "P. J."
+      },
+      {
+        "family": "Ruddiman",
+        "given": "W. F."
+      },
+      {
+        "family": "Ryan",
+        "given": "W. B. F."
+      },
+      {
+        "family": "Heezen",
+        "given": "B. C."
+      }
+    ],
+    "editor": [
+      {
+        "family": "Heezen",
+        "given": "B. C."
+      },
+      {
+        "family": "Kosminskaya",
+        "given": "I. P."
+      }
+    ],
+    "issued": {
+      "date-parts": [["1971"]]
+    }
+  },
+  {
+    "id": "jes-thesis",
+    "type": "thesis",
+    "genre": "Dissertation",
+    "language": "en-US",
+    "note": "(in Chinese)",
+    "page": "95-105",
+    "publisher": "Lanzhou University",
+    "publisher-place": "Lanzhou",
+    "title": "The High Precise Cenozoic Magnetostratigraphy of the Qaidam Basin and Uplift of the Northern Tibetan Plateau",
+    "author": [
+      {
+        "family": "Zhang",
+        "given": "W. L."
+      }
+    ],
+    "issued": {
+      "date-parts": [["2006"]]
+    }
+  },
+  {
+    "id": "jes-citation-smith",
+    "type": "article-journal",
+    "container-title": "Journal of Earth Science",
+    "language": "en-US",
+    "page": "1-10",
+    "title": "Example Paper with Four Authors",
+    "volume": "1",
+    "author": [
+      {
+        "family": "Smith",
+        "given": "A."
+      },
+      {
+        "family": "Brown",
+        "given": "B."
+      },
+      {
+        "family": "Clark",
+        "given": "C."
+      },
+      {
+        "family": "Davis",
+        "given": "D."
+      }
+    ],
+    "issued": {
+      "date-parts": [["2012"]]
+    }
+  },
+  {
+    "id": "jes-citation-green",
+    "type": "article-journal",
+    "container-title": "Journal of Earth Science",
+    "language": "en-US",
+    "page": "11-20",
+    "title": "Example Paper with Two Authors",
+    "volume": "1",
+    "author": [
+      {
+        "family": "Green",
+        "given": "A."
+      },
+      {
+        "family": "Jin",
+        "given": "B."
+      }
+    ],
+    "issued": {
+      "date-parts": [["2008"]]
+    }
+  },
+  {
+    "id": "jes-citation-kusky",
+    "type": "article-journal",
+    "container-title": "Journal of Earth Science",
+    "language": "en-US",
+    "page": "21-30",
+    "title": "Example Paper with One Author",
+    "volume": "1",
+    "author": [
+      {
+        "family": "Kusky",
+        "given": "T."
+      }
+    ],
+    "issued": {
+      "date-parts": [["2000"]]
+    }
+  }
+]

--- a/src/地球科学（英文版）/metadata.json
+++ b/src/地球科学（英文版）/metadata.json
@@ -1,0 +1,29 @@
+{
+  "dir": "地球科学（英文版）",
+  "file": "地球科学（英文版）.csl",
+  "style_class": "in-text",
+  "title": "地球科学（英文版）",
+  "id": "https://zotero-chinese.com/styles/%E5%9C%B0%E7%90%83%E7%A7%91%E5%AD%A6%EF%BC%88%E8%8B%B1%E6%96%87%E7%89%88%EF%BC%89",
+  "link_self": "https://zotero-chinese.com/styles/%E5%9C%B0%E7%90%83%E7%A7%91%E5%AD%A6%EF%BC%88%E8%8B%B1%E6%96%87%E7%89%88%EF%BC%89",
+  "link_documentation": "https://media.springer.com/full/springer-instructions-for-authors-assets/pdf/643998_173839904_IFA_12583_Journal%20of%20Earth%20Science.pdf",
+  "author": [
+    {
+      "name": "RenXiaokai1999"
+    }
+  ],
+  "contributor": [],
+  "citation_format": "author-date",
+  "field": "geology",
+  "summary": "依据 Journal of Earth Science GUIDE FOR AUTHORS 制作，覆盖期刊论文、图书、专著析出文献、期刊专题/特刊析出文献和学位论文。",
+  "updated": "2026-06-29T10:13:12+08:00",
+  "citations": "(Smith et al., 2012; Green and Jin, 2008; Kusky, 2000)<br>\n(Chough and Barg, 1987)<br>\n(Shrock, 1948)<br>\n(Sun, 1984)<br>\n(Fox et al., 1971)<br>\n(Zhang, 2006)<br>\n",
+  "bibliography": "<div class=\"csl-bib-body maxoffset-0 second-field-align-false hangingindent-false\">\n  <div class=\"csl-entry\">Chough, S. K., Barg, E., 1987. Tectonic History of Ulleung Basin Margin, East Sea (Sea of Japan). <i>Geology</i>, 15(1): 45. <a href=\"https://doi.org/10.1130/0091-7613(1987)15&#60;45:thoubm&#62;2.0.co;2\">https://doi.org/10.1130/0091-7613(1987)15&#60;45:thoubm&#62;2.0.co;2</a></div>\n  <div class=\"csl-entry\">Fox, P. J., Ruddiman, W. F., Ryan, W. B. F., et al., 1971. The Geology of the Caribbean Crust, I. Beata Ridge. In: Heezen, B. C., Kosminskaya, I. P., eds., The Structure of the Crust and Mantle beneath Inland and Marginal Seas. <i>Tectonophysics</i>, 10: 495–513. <a href=\"https://doi.org/10.1016/0040-1951(70)90041-7\">https://doi.org/10.1016/0040-1951(70)90041-7</a></div>\n  <div class=\"csl-entry\">Green, A., Jin, B., 2008. Example Paper with Two Authors. <i>Journal of Earth Science</i>, 1: 11–20.</div>\n  <div class=\"csl-entry\">Kusky, T., 2000. Example Paper with One Author. <i>Journal of Earth Science</i>, 1: 21–30.</div>\n  <div class=\"csl-entry\">Shrock, R. R., 1948. Sequence in Layered Rocks. McGraw-Hill, New York. 507</div>\n  <div class=\"csl-entry\">Smith, A., Brown, B., Clark, C., et al., 2012. Example Paper with Four Authors. <i>Journal of Earth Science</i>, 1: 1–10.</div>\n  <div class=\"csl-entry\">Sun, S. S., 1984. Geochemical Characteristics of Archean Ultramafic and Mafic Volcanic Rocks: Implication and Evolution. In: Kroner, A., Lansor, G. N., Goodwin, A. M., eds., Archean Geochemistry. Springer-Verlag, Berlin. 25–46</div>\n  <div class=\"csl-entry\">Zhang, W. L., 2006. The High Precise Cenozoic Magnetostratigraphy of the Qaidam Basin and Uplift of the Northern Tibetan Plateau: [Dissertation]. Lanzhou University, Lanzhou. 95–105 (in Chinese)</div>\n</div>",
+  "tags": [
+    "姓名小写",
+    "有标题",
+    "期刊全称",
+    "有URL",
+    "有DOI",
+    "无英文翻译"
+  ]
+}

--- a/src/地球科学（英文版）/地球科学（英文版）.csl
+++ b/src/地球科学（英文版）/地球科学（英文版）.csl
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-US" page-range-format="expanded" demote-non-dropping-particle="sort-only">
+  <info>
+    <title>地球科学（英文版）</title>
+    <title-short>Journal of Earth Science / JES</title-short>
+    <id>https://zotero-chinese.com/styles/%E5%9C%B0%E7%90%83%E7%A7%91%E5%AD%A6%EF%BC%88%E8%8B%B1%E6%96%87%E7%89%88%EF%BC%89</id>
+    <link href="https://zotero-chinese.com/styles/%E5%9C%B0%E7%90%83%E7%A7%91%E5%AD%A6%EF%BC%88%E8%8B%B1%E6%96%87%E7%89%88%EF%BC%89" rel="self"/>
+    <link href="https://media.springer.com/full/springer-instructions-for-authors-assets/pdf/643998_173839904_IFA_12583_Journal%20of%20Earth%20Science.pdf" rel="documentation"/>
+    <link href="https://mc03.manuscriptcentral.com/jes" rel="documentation"/>
+    <author>
+      <name>RenXiaokai1999</name>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="geology"/>
+    <issn>1674-487X</issn>
+    <eissn>1867-111X</eissn>
+    <summary>依据 Journal of Earth Science GUIDE FOR AUTHORS 制作，覆盖期刊论文、图书、专著析出文献、期刊专题/特刊析出文献和学位论文。</summary>
+    <updated>2026-06-29T10:13:12+08:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+
+  <locale xml:lang="en">
+    <terms>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
+      <term name="et-al">et al.</term>
+      <term name="and">and</term>
+      <term name="page-range-delimiter">–</term>
+    </terms>
+  </locale>
+
+  <macro name="author-bib">
+    <names variable="author">
+      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", "/>
+      <et-al font-style="normal"/>
+      <substitute>
+        <group delimiter=", ">
+          <names variable="editor">
+            <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", "/>
+          </names>
+          <text term="editor" form="short" plural="true"/>
+        </group>
+        <text variable="title" text-case="title"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
+      <et-al font-style="normal"/>
+      <substitute>
+        <names variable="editor">
+          <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+        <text variable="title" text-case="title"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="title">
+    <text variable="title" text-case="title"/>
+  </macro>
+
+  <macro name="editor-in">
+    <group delimiter=", " suffix=", ">
+      <names variable="editor">
+        <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", "/>
+      </names>
+      <text term="editor" form="short" plural="true"/>
+    </group>
+  </macro>
+
+  <macro name="publisher-place">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+
+  <macro name="doi-or-url">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if type="webpage post-weblog" match="any">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="note">
+    <text variable="note"/>
+  </macro>
+
+  <macro name="journal-volume-pages">
+    <group>
+      <text variable="volume"/>
+      <text variable="issue" prefix="(" suffix=")"/>
+      <text variable="page" prefix=": "/>
+    </group>
+  </macro>
+
+  <macro name="article-journal">
+    <group>
+      <text macro="author-bib" suffix=", "/>
+      <text macro="issued-year" suffix=". "/>
+      <text macro="title" suffix=". "/>
+      <text variable="container-title" font-style="italic" suffix=", "/>
+      <text macro="journal-volume-pages" suffix="."/>
+      <text macro="doi-or-url" prefix=" "/>
+      <text macro="note" prefix=" "/>
+    </group>
+  </macro>
+
+  <macro name="book">
+    <group>
+      <text macro="author-bib" suffix=", "/>
+      <text macro="issued-year" suffix=". "/>
+      <text macro="title" suffix=". "/>
+      <text macro="publisher-place" suffix="."/>
+      <choose>
+        <if variable="number-of-pages">
+          <text variable="number-of-pages" prefix=" "/>
+        </if>
+        <else-if variable="page">
+          <text variable="page" prefix=" "/>
+        </else-if>
+      </choose>
+      <text macro="doi-or-url" prefix=" "/>
+      <text macro="note" prefix=" "/>
+    </group>
+  </macro>
+
+  <macro name="chapter-in">
+    <group delimiter="">
+      <text value="In: "/>
+      <text macro="editor-in"/>
+      <text variable="container-title" text-case="title"/>
+    </group>
+  </macro>
+
+  <macro name="chapter">
+    <group>
+      <text macro="author-bib" suffix=", "/>
+      <text macro="issued-year" suffix=". "/>
+      <text macro="title" suffix=". "/>
+      <text macro="chapter-in" suffix=". "/>
+      <text macro="publisher-place" suffix="."/>
+      <text variable="page" prefix=" "/>
+      <text macro="doi-or-url" prefix=" "/>
+      <text macro="note" prefix=" "/>
+    </group>
+  </macro>
+
+  <macro name="chapter-periodical">
+    <group>
+      <text macro="author-bib" suffix=", "/>
+      <text macro="issued-year" suffix=". "/>
+      <text macro="title" suffix=". "/>
+      <text macro="chapter-in" suffix=". "/>
+      <text variable="collection-title" font-style="italic" suffix=", "/>
+      <text macro="journal-volume-pages" suffix="."/>
+      <text macro="doi-or-url" prefix=" "/>
+      <text macro="note" prefix=" "/>
+    </group>
+  </macro>
+
+  <macro name="thesis">
+    <group>
+      <text macro="author-bib" suffix=", "/>
+      <text macro="issued-year" suffix=". "/>
+      <text macro="title"/>
+      <choose>
+        <if variable="genre">
+          <text variable="genre" prefix=": [" suffix="]. "/>
+        </if>
+        <else>
+          <text value=": [Dissertation]. "/>
+        </else>
+      </choose>
+      <text macro="publisher-place" suffix="."/>
+      <text variable="page" prefix=" "/>
+      <text macro="doi-or-url" prefix=" "/>
+      <text macro="note" prefix=" "/>
+    </group>
+  </macro>
+
+  <macro name="webpage">
+    <group>
+      <text macro="author-bib" suffix=", "/>
+      <text macro="issued-year" suffix=". "/>
+      <text macro="title" suffix=". "/>
+      <text variable="container-title" font-style="italic" suffix=". "/>
+      <text macro="doi-or-url"/>
+      <text macro="note" prefix=" "/>
+    </group>
+  </macro>
+
+  <macro name="generic">
+    <group>
+      <text macro="author-bib" suffix=", "/>
+      <text macro="issued-year" suffix=". "/>
+      <text macro="title" suffix=". "/>
+      <text variable="container-title" font-style="italic" suffix=", "/>
+      <text macro="journal-volume-pages" suffix="."/>
+      <text macro="doi-or-url" prefix=" "/>
+      <text macro="note" prefix=" "/>
+    </group>
+  </macro>
+
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
+    <sort>
+      <key macro="issued-year" sort="descending"/>
+      <key macro="author-short" sort="ascending"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued-year"/>
+      </group>
+    </layout>
+  </citation>
+
+  <bibliography et-al-min="4" et-al-use-first="3" entry-spacing="0" line-spacing="1" hanging-indent="false">
+    <sort>
+      <key macro="author-bib" sort="ascending"/>
+      <key macro="issued-year" sort="ascending"/>
+      <key variable="title" sort="ascending"/>
+    </sort>
+    <layout>
+      <choose>
+        <if type="article-journal article-magazine article-newspaper" match="any">
+          <text macro="article-journal"/>
+        </if>
+        <else-if type="book" match="any">
+          <text macro="book"/>
+        </else-if>
+        <else-if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
+          <choose>
+            <if variable="collection-title">
+              <text macro="chapter-periodical"/>
+            </if>
+            <else>
+              <text macro="chapter"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if type="thesis" match="any">
+          <text macro="thesis"/>
+        </else-if>
+        <else-if type="webpage post-weblog" match="any">
+          <text macro="webpage"/>
+        </else-if>
+        <else>
+          <text macro="generic"/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
## 内容

- 新增《地球科学（英文版）》/ Journal of Earth Science 的作者-出版年 CSL 样式。
- 添加 `items.json` 与 `cites.json`，覆盖投稿指南中的期刊论文、图书、专著析出文献、期刊专题/特刊析出文献和学位论文示例。

## 依据

- Journal of Earth Science GUIDE FOR AUTHORS。
- 正文引用示例：`(Smith et al., 2012; Green and Jin, 2008; Kusky, 2000)`。

<https://media.springer.com/full/springer-instructions-for-authors-assets/pdf/643998_173839904_IFA_12583_Journal%20of%20Earth%20Science.pdf>

[643998_173839904_IFA_12583_Journal of Earth Science.pdf](https://github.com/user-attachments/files/29599661/643998_173839904_IFA_12583_Journal.of.Earth.Science.pdf)


## 验证

- `csl-validator-wasm`: `CSL schema validation OK`
- `citeproc`: 正文引用渲染为 `(Smith et al., 2012; Green and Jin, 2008; Kusky, 2000)`