### PR TITLE
新增兰州大学-资源环境学院CSL样式

### DIFF
--- a/src/兰州大学-资源环境学院/index.md
+++ b/src/兰州大学-资源环境学院/index.md
@@ -1,0 +1,1626 @@
+<!-- 此文件由脚本自动生成，请勿手动修改！ -->
+<!-- markdownlint-disable -->
+<!-- prettier-ignore -->
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE FILE -->
+
+## 样式预览
+
+### 引注
+
+(Smith et al., 2013)<br>
+(Smith and Jones, 2012)<br>
+(张明等，2011）<br>
+(张明和王辉，2010）<br>
+
+
+### 参考文献表
+
+<div class="csl-bib-body maxoffset-3 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">Smith, J., Jones, D. English two-author test article[J]. Test Journal. 2012, 3(1): 21-30.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">Smith, J., Jones, D., Brown, M. English three-author test article[J]. Test Journal. 2013, 4(1): 31-40.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">张明, 王辉. 中文双作者测试文献[J]. 测试期刊. 2010, 1(1): 1-10.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">张明, 王辉, 李强. 中文三作者测试文献[J]. 测试期刊. 2011, 2(1): 11-20.</div>
+  </div>
+</div>
+
+## 默认测试
+
+### 引注
+
+(张三，2008）<br>
+张三 (2008）<br>
+(Jason, 2008)<br>
+Jason (2008)<br>
+张三和李四 (2008）<br>
+Wang and Sun (2009)<br>
+(Wolchik and West, 2009; 赵一和陈二，2008）<br>
+张三等 (2008）<br>
+Wang et al. (2009)<br>
+(Wolchik et al., 2009; 赵一等，2008）<br>
+张三等 (2019a）<br>
+张三等 (2019b）<br>
+Qian et al. (2020b)<br>
+Qian et al. (2020a)<br>
+(Qian et al., 2020b; 张三等，2019a）<br>
+张三等 (2020a）<br>
+张三等 (2020b）<br>
+Qian et al. (2009b)<br>
+Qian et al. (2009a)<br>
+(张三等，2020a）<br>
+(Qian et al., 2009b)<br>
+(Wong, 2007)<br>
+(Wong, 2008)<br>
+(Edeline and Weinberger, 2002a; Edeline and Weinberger, 2002b; Edeline and Weinberger, 2005; Edeline and Weinberger)<br>
+(Bai, 2002; Chen, 2006; Deng and Feng, 2005)<br>
+
+
+### GB/T 7714—2025 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-5 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">American Institute of Aeronautics and Astronautics (AIAA). AIAA G-136-2022, Guide to lithium battery safety for space applications[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">António, M., Pepper, L. Histórias de Portugal: livros caídos[EB/OL]. (2019-07-13)[2025-01-02] . <a href="https://arquivo.pt/wayback/20190905210731/http://publico.pt/2019/07/13/sociedade/noticia/podcast-historias-portugal-cuidadores-1879731">https://arquivo.pt/wayback/20190905210731/http://publico.pt/2019/07/13/sociedade/noticia/podcast-historias-portugal-cuidadores-1879731</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">Bevington, D., Brown, J.R. William Shakespeare[EB/OL]. (2025-01-01)[2025-01-03] . <a href="https://www.britannica.com/biography/William-Shakespeare">https://www.britannica.com/biography/William-Shakespeare</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">Bloss, C.S., Wineinger, N.E., Peters, M., Boeldt, D.L., Ariniello, L., Kim, J.Y., Sheard, J., Komatireddy, R., Barrett, P., Topol, E.J. A prospective randomized trial examining health care utilization in individuals using multiple smartphone-enabled biosensors[J].bioRxiv, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">Boobier, T. AI and the future of banking[M]. Chichester: John Wiley &#38; Sons, 2020: 35.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">Cairns, B.R. Infrared spectroscopic studies on solid oxygen[D]. Berkeley: University of California, Berkeley, 1965: 15.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[7]</div><div class="csl-right-inline">Calkin, D.E., Ager, A.A., Thompson, M.P. A comparative risk assessment framework for wildland fire management: the 2010 cohesive strategy science report[R].RMRS-GTR-262, 2011: 8-9.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[8]</div><div class="csl-right-inline">Caplan, P. Cataloging internet resources[J]. The Public-Access Computer Systems Review. 1993, 4(2): 61-66.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[9]</div><div class="csl-right-inline">Christou, A. Improving knowledge graph understanding with contextual views[D]. Ohio: Wright State University, 2024: 18.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[10]</div><div class="csl-right-inline">Cribb, R. Historical atlas of Indonesia[J]. Abingdon: Routledge, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[11]</div><div class="csl-right-inline">Des Marais, D.J., Strauss, H., Summons, R.E., Hayes, J.M. Carbon isotope evidence for the stepwise oxidation of the Proterozoic environment[J]. Nature. 1992, 359: 605-609.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[12]</div><div class="csl-right-inline">Fitzwilliam, H. [Letter to Bess of Hardwick][J].1570Bess of Hardwick.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[13]</div><div class="csl-right-inline">Fourney, M.E. Advances in holographic photoelasticity[A]. Gottenberg, W.G. Symposium on Applications of Holography in Mechanics, August 23-25, 1971, University of Southern California, Los Angeles, California[C]. New York: ASME, 1971: 17-38.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[14]</div><div class="csl-right-inline">Frese, K.S., Katus, H.A., Meder, B. Next-generation sequencing: from understanding biology to personalized medicine[J]. Biology. 2013, 2(1): 378-398.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[15]</div><div class="csl-right-inline">IHME. Global Burden of Disease Study 2019 (GBD2019) data resources[J].Global Health Data Exchange, 2021.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[16]</div><div class="csl-right-inline">Institute for Art and Architecture, Academy of Fine Arts Vienna. Wiener Hitze: architecture and storytelling in times of heat[M]. Zürich: Park Books, 2023: 78.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[17]</div><div class="csl-right-inline">International Electrotechnical Commission (IEC). IEC/IEEE 61636-1:2021, Software interface for maintenance information collection and analysis (SIMICA): exchanging test results and session information via the eXtensible Markup Language (XML)[S] New York: IEEE, 2021.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[18]</div><div class="csl-right-inline">International Organization for Standardization. ISO homepage[EB/OL]. [2020-10-06] . <a href="https://www.iso.org/home.html">https://www.iso.org/home.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[19]</div><div class="csl-right-inline">ISO. ISO/IEC 80079-20-2:2016(fr), Atmosphères explosives — Partie 20-2: Caractéristiques des produits — Méthodes d’essai des poussières combustibles[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[20]</div><div class="csl-right-inline">ISO. ISO/IEC 80079-20-2:2016(en), Explosive atmospheres — Part 20-2: Material characteristics — Combustible dusts test methods[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[21]</div><div class="csl-right-inline">ISO. ISO 21378:2019, Audit data collection[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[22]</div><div class="csl-right-inline">Jenkins, S.D., Ruostekoski, J. Controlled manipulation of light by cooperative response of atoms in an optical lattice[J].arXiv, 2012.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[23]</div><div class="csl-right-inline">Kinchy, A. Seeds, sciences, and struggle: the global politics of transgenic crops[M]. Cambridge, Mass.: MIT Press, 2012: 50.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[24]</div><div class="csl-right-inline">Myburg, A.A., Grattapaglia, D., Tuskan, G.A., Hellsten, U., Hayes, R.D., Grimwood, J., Jenkins, J., Lindquist, E., Tice, H., Bauer, D., Goodstein, D.M., Dubchak, I., Poliakov, A., Mizrachi, E., Kullan, A.R.K., Hussey, S.G., Pinard, D., Van der Merwe, K., Singh, P., Van Jaarsveld, I., Silva-Junior, O.B., Togawa, R.C., Pappas, M.R., Faria, D.A., Sansaloni, C.P., Petroli, C.D., Yang, X., Ranjan, P., Tschaplinski, T.J., Ye, C.Y., Li, T., Sterck, L., Vanneste, K., Murat, F., Soler, M., Clemente, H.S., Saidi, N., Cassan-Wang, H., Dunand, C., Hefer, C.A., Bornberg-Bauer, E., Kersting, A.R., Vining, K., Amarasinghe, V., Ranik, M., Naithani, S., Elser, J., Boyd, A.E., Liston, A., Spatafora, J.W., Dharmwardhana, P., Raja, R., Sullivan, C., Romanel, E., Alves-Ferreira, M., Külheim, C., Foley, W., Carocha, V., Paiva, J., Kudrna, D., Brommonschenkel, S.H., Pasquali, G., Byrne, M., Rigault, P., Tibbits, J., Spokevicius, A., Jones, R.C., Steane, D.A., Vaillancourt, R.E., Potts, B.M., Joubert, F., Barry, K., Pappas, G.J., Strauss, S.H., Jaiswal, P., Grima-Pettenati, J., Salse, J., Van de Peer, Y., Rokhsar, D.S., Schmutz, J. The genome of <i>Eucalyptus grandis</i>[J]. Nature. 2014, 510: 356-362.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[25]</div><div class="csl-right-inline">Park, J.R., Tosaka, Y. Metadata quality control in digital repositories and collections: criteria, semantics, and mechanisms[J]. Cataloging &#38; Classification Quarterly. 2010, 48(8): 696-715.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[26]</div><div class="csl-right-inline">Peebles, P.Z., Jr. Probability, random variables, and random signal principles[M]. 4 edn. New York: McGraw-Hill, 2001.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[27]</div><div class="csl-right-inline">Praetzellis, A. Death by theory: a tale of mystery and archaeological theory[M]. Rev. ed. edn.Rowman &#38; Littlefield Publishing Group, Inc., 2011: 13.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[28]</div><div class="csl-right-inline">Roberson, J.A., Burneson, E.G. Drinking water quality standards, regulations and goals[G]// American Water Works Association. 6 edn.Water quality &#38; treatment: a handbook on drinking water. New York: McGraw-Hill, 2011: 1.1-1.36.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[29]</div><div class="csl-right-inline">Saito, M., Miyazaki, K. Jadeite-bearing metagabbro in serpentinite melange of the “Kurosegawa Belt” in Izumi Town, Yatsushiro City, Kumamoto Prefecture, central Kyushu[J]. Bulletin of the Geological Survey of Japan. 2006, 57(5/6): 169-176.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[30]</div><div class="csl-right-inline">Santer, R.D., Akanyeti, O. Using artificial neural networks to explain the attraction of jewel beetles (Coleoptera: Buprestidae) to colored traps[J]. Insect science. 2025.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[31]</div><div class="csl-right-inline">Shinotsuka, H., Nagata, K., Siriwardana, M., Yoshikawa, H., Shouno, H., Okada, M. Sample structure prediction from measured XPS data using Bayesian estimation and SESSA simulator[J]. Journal of electron spectroscopy and related phenomena. 2023, 267.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[32]</div><div class="csl-right-inline">Sugarman, L., Markham, S. Students in a selective high school: some vocationally oriented data[J].UK Data Service, 1980.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[33]</div><div class="csl-right-inline">Tachibana, R., Shimizu, S., Kobayashi, S., Nakamura, T. Electronic watermarking method and system: 中国, US2002061118A1[P].2001-06-28.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[34]</div><div class="csl-right-inline">Tristram, M., Skarshewski, P., Tristram, I., Mossel, B. Storage and delivery system: 中国, AU2022228203A1[P].2022-10-06.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[35]</div><div class="csl-right-inline">United Nations Department of Economic and Social Affairs. United Nations e-government survey 2024: accelerating digital transformation for sustainable development[R].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[36]</div><div class="csl-right-inline">U.S. Department of Transportation Federal Highway Administration. Guidelines for handling excavated acid-producing material[R].PB 91-194001, Springfield: U.S. Department of Commerce National Information Service, 1990: 25.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[37]</div><div class="csl-right-inline">Veen, P.H. van der, Muller, M., Vincken, K.L., Witkamp, T.D., Mali, W.P.T.M., Van der Graaf, Y., Geerlings, M.I., SMART-MR Study Group. Longitudinal changes in brain volumes and cerebrovascular lesions on MRI in patients with manifest arterial disease: the SMART-MR study[J]. Journal of the Neurological Sciences. 2014, 337(1/2): 112-118.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[38]</div><div class="csl-right-inline">Wang, S. Application of improved SOM neural network in intelligent auditing of hospital financial vouchers[A].2022: 2.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[39]</div><div class="csl-right-inline">Weinstein, L., Swartz, M.N. Pathogenic properties of invading microorganisms[G]// Sodeman, W.A., Jr., Sodeman, W.A. 5 edn.Pathologic physiology: mechanisms of disease. Philadelphia: Saunders, 1974: 457-472.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[40]</div><div class="csl-right-inline">Yu, Y., Pan, E., Wang, X., Wu, Y., Mei, X., Ma, J. Unmixing before fusion: a generalized paradigm for multi-source-based hyperspectral image synthesis[A].2024: 4.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[41]</div><div class="csl-right-inline">Zhong, X., Yan, Q., Li, G. Long time series nighttime light dataset of China: 2000–2020[J].Global Change Research Data Publishing &#38; Repository, 2022.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[42]</div><div class="csl-right-inline">Zotero. [Zotero download][EB/OL]. [2024-04-08] . <a href="https://www.zotero.org/download/">https://www.zotero.org/download/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[43]</div><div class="csl-right-inline">丁文详. 数字革命与竞争国际化[J]. 中国青年报. 2000: 15.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[44]</div><div class="csl-right-inline">中国互联网络信息中心. 第29次中国互联网络发展状况统计报告[R].2012.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[45]</div><div class="csl-right-inline">中国信息通信研究院, 中国电信股份有限公司研究院, 中国移动通信研究院, 中国联合网络通信有限公司研究院. 电信业发展白皮书：2023：新时代高质量发展探索[R].2023.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[46]</div><div class="csl-right-inline">中国科学院文献情报中心. 中国科学院科技论文预发布平台[EB/OL].[2025-03-06] . <a href="https://chinaxiv.org/home.htm">https://chinaxiv.org/home.htm</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[47]</div><div class="csl-right-inline">中国造纸学会. 中国造纸年鉴：2003[M]. 北京: 中国轻工业出版社, 2003.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[48]</div><div class="csl-right-inline">中工武大设计研究有限公司. 阳新县标准地名图[J]. 武汉: 武汉大学出版社, 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[49]</div><div class="csl-right-inline">久保智康. 花枝蝶鸟方镜的镜范：以平安后期的铜镜制作工艺为中心[J]. 顾幼静. 东方博物. 2009(1): 85-92.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[50]</div><div class="csl-right-inline">于潇, 刘义, 柴跃廷, 孙宏波. 互联网药品可信交易环境中主体资质审核备案模式[J]. 清华大学学报（自然科学版）. 2012, 52(11): 1518-1523Yu Xiao, Liu Yi, Chai Yue Ting, Sun Hong Bo.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[51]</div><div class="csl-right-inline">云南省企业联合会, 云南省企业家协会, 云南民族新闻文化发展研究院. 改革开放三十年：云南企业家奋斗史[M]. 芒市: 德宏民族出版社, 2009.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[52]</div><div class="csl-right-inline">井丽南. 支持状态可编程的SDN交换机关键技术研究[D]. 北京: 中国科学院大学, 2022: 43.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[53]</div><div class="csl-right-inline">仉尚航. 开放世界中的实体基础模型[EB/OL].(2024-12-24)[2025-01-02] . <a href="https://www.ppthub.com.cn/view/19309">https://www.ppthub.com.cn/view/19309</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[54]</div><div class="csl-right-inline">何筱梅. 新媒体时代原生广告的策略与发展研究[D]. 武汉: 武汉大学, 2016: 24-25.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[55]</div><div class="csl-right-inline">全国信息与文献标准化技术委员会. GB/T 3792—2021, 信息与文献 资源描述[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[56]</div><div class="csl-right-inline">全国信息技术标准化技术委员会. GB/T 20090.16—2016, 信息技术 先进音视频编码 第16部分：广播电视视频[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[57]</div><div class="csl-right-inline">冀超. 一种荒漠化地区生态植被综合培育种植方法: 中国, CN1318281A[P].2001-10-24.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[58]</div><div class="csl-right-inline">冯友兰. 冯友兰自选集[M].第2版 北京: 首都师范大学出版社, 2008: 第1版自序.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[59]</div><div class="csl-right-inline">刘时银, 郭万钦, 许君利. 中国第二次水川编目科学数据：2006-2011[J].中国科学院寒区早区环境与工程研究所冰冻圈科学国家重点实验室, 2012.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[60]</div><div class="csl-right-inline">刘祥沈. 沈阳市政区图[J]. 武汉: 武汉大学出版社, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[61]</div><div class="csl-right-inline">北京鲁迅博物馆. 北京鲁迅博物馆志愿服务章程[EB/OL].(2021-04-21)[2023-05-02] . <a href="http://www.luxunmuseum.com.cn/html/202104/a11310.htm">http://www.luxunmuseum.com.cn/html/202104/a11310.htm</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[62]</div><div class="csl-right-inline">博伯尔. 银行业的未来与人工智能[M]. 徐超. 北京: 清华大学出版社, 2023: 35.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[63]</div><div class="csl-right-inline">史国华, 樊金宇, 何益, 邢利娜, 高峰. 光コヒーレンス断層拡張現実に基づく手術顕微鏡撮像システム及び方法: 中国, JP2022539784A[P].2022-09-13.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[64]</div><div class="csl-right-inline">吴自银, 温珍河. 中国南部海域海底地形图[J]. 北京: 科学出版社, 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[65]</div><div class="csl-right-inline">周壮, 李盛阳, 吴薇, 郭威龙, 李轩, 夏桂松, 赵子飞. 天宫二号遥感图像自然景物分类数据集[J].国家基础学科公共科学数据中心, 2023.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[66]</div><div class="csl-right-inline">哈里森, 沃尔德伦. 经济数学与金融数学[M]. 谢远涛. 北京: 中国人民大学出版社, 2012: 235-236.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[67]</div><div class="csl-right-inline">国家测绘地理信息局. 一带一路经济走廊及其途经城市分布地势图[J].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[68]</div><div class="csl-right-inline">国家能源局. NB/T 10386—2020, 水电工程水温实时监测系统技术规范[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[69]</div><div class="csl-right-inline">工业和信息化部. GB 18030—2022, 信息技术  中文编码字符集[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[70]</div><div class="csl-right-inline">张伯伟. 全唐五代诗格汇考[M]. 南京: 江苏古籍出版社, 2002: 288.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[71]</div><div class="csl-right-inline">张凯军, 赵永杰, 陈朝岗. 轨道火车及高速轨道火车紧急安全制动辅助装置: 中国, CN202827616U[P].2013-03-27.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[72]</div><div class="csl-right-inline">张群, 程志宝, 石志飞. 惯性增强动力吸振器-浮置板轨道低频减振性能研究[J]. 铁道学报. 2024a, 46(8): 102-111.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[73]</div><div class="csl-right-inline">张群, 程志宝, 石志飞. 惯性增强动力吸振器-浮置板轨道低频减振性能研究[J]. 铁道学报. 2024b.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[74]</div><div class="csl-right-inline">彭守璋. 1901—2023年中国1km分辨率逐月降水量数据集[J].西北农林科技大学水土保持研究所, 2024.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[75]</div><div class="csl-right-inline">徐建委. 历史的起点：《史记》中的时间设置及其意义[J]. 北京大学学报（哲学社会科学版）. 2025, 62(2): 117-127.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[76]</div><div class="csl-right-inline">战德臣, 张丽杰. 大学计算机：计算思维与信息素养[M].第3版 北京: 高等教育出版社, 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[77]</div><div class="csl-right-inline">扬奎斯特, 萨金特. 递归宏观经济理论[M]. 杨斌, 王忠玉, 陈彦斌, 严高剑. 第2版 北京: 中国人民大学出版社, 2010: 798Ljungqvist Lars, Sargent Thomas J.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[78]</div><div class="csl-right-inline">方向明, 曹迎杰. 元宇宙在图书馆的应用：理论研究与实践进展[J].ChinaXiv, 2023.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[79]</div><div class="csl-right-inline">曹凌. 中国佛教疑伪经综录[M]. 上海: 上海古籍出版社, 2011: 19.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[80]</div><div class="csl-right-inline">李华, 王昊, 康佐. 一种拼接式桥梁模型: 中国, CN218214474U[P].2023-01-03.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[81]</div><div class="csl-right-inline">李妍, 王莹. 医疗机构保洁人员“一前五后”手卫生干预效果研究[A].2022: 2.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[82]</div><div class="csl-right-inline">李幼平, 王莉. 循证医学研究方法：附视频[J]. 中华移植杂志（电子版）. 2010, 4(3): 225-228.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[83]</div><div class="csl-right-inline">李约瑟. 题词[G]//苏颂与《本草图经》研究. 长春: 长春出版社, 1991: 扉页.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[84]</div><div class="csl-right-inline">李鸿章. 奏请上海道库洋务外销要款无款可筹仍拨药厘接济事[J].1887.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[85]</div><div class="csl-right-inline">杨洪升. 四库馆私家抄校书考略[J]. 文献. 2013(1): 56-75.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[86]</div><div class="csl-right-inline">楼梦麟, 杨燕. 汶川地震基岩地震动特征分析[G]// 同济大学土木工程防灾国家重点实验室. 汶川地震震害研究. 上海: 同济大学出版社, 2011: 11-12.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[87]</div><div class="csl-right-inline">汤万金, 杨跃翔, 刘文, 郑建国, 王赟松. 人体安全重要技术标准研制最终报告[R].7178999X-2006BAK04A10/10.2013, 2013.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[88]</div><div class="csl-right-inline">汪学军. 中国农业转基因生物研发进展与安全管理[A]. 国家环境保护总局生物安全管理办公室. 中国国家生物安全框架实施国际合作项目研讨会论文集[C]. 北京: 中国环境科学出版社, 2005: 22-25Wang Xue Jun.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[89]</div><div class="csl-right-inline">湖北省建设厅. 湖北省建设厅关于检发实业部农工矿业团体登记规则的布告、训令及湖北省政府的训令[J].1931.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[90]</div><div class="csl-right-inline">王利平, 王福新, 刘洪. 过冷大水滴环境粒径分布模拟方法研究进展[J]. 航空学报. 2024, 45(增刊1).</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[91]</div><div class="csl-right-inline">王夫之. 宋论[M].第刻本版 金陵: 湘乡曾国荃, 1865.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[92]</div><div class="csl-right-inline">王琦. 融合星载GNSS-R和SAR数据的高时空分辨率土壤湿度反演方法研究[D]. 武汉: 武汉大学, 2022: 87.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[93]</div><div class="csl-right-inline">王继民, 罗鹏程, 赵常煜, 郭鑫, 王世奇, 高正. 人文社会科学数据集检索方法研究的数据集[J].北京大学开放研究数据平台, 2025.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[94]</div><div class="csl-right-inline">石顺祥, 许海平, 孙艳玲, 陈利菊, 李家立, 刘继芳. 光折变自适应光外差探测方法: 中国, CN1338652A[P].2002-03-06.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[95]</div><div class="csl-right-inline">程根伟. 1998年长江洪水的成因与减灾对策[G]// 许厚泽, 赵其国. 长江流域洪涝灾害与科技对策. 北京: 科学出版社, 1999: 32-36.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[96]</div><div class="csl-right-inline">童世亨. 京兆直隶图[J]. 上海: 商务印书馆, 1926.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[97]</div><div class="csl-right-inline">肖希明, 石庆功, 刘奕. 民国图书馆学教育的社会贡献[A]. 纪念北京大学图书馆学教育100周年研讨会论文集[C]. 北京: 北京大学信息管理系, 2024: 134-147.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[98]</div><div class="csl-right-inline">肖玲, 张雪, 王永. 数据要素的统计测算方法探究[J].PSSXiv, 2024Xiao Ling, Zhang Xue, Wang Yong.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[99]</div><div class="csl-right-inline">胡健民. 东南极拉斯曼丘陵地区地质图[J]. 北京: 科学出版社, 2021.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[100]</div><div class="csl-right-inline">许振超. “好好干，当一个好工人”[EB/OL].(2025-02-17)[2025-06-22] . <a href="https://cpc.people.com.cn/n1/2025/0217/c443712-40419790.html">https://cpc.people.com.cn/n1/2025/0217/c443712-40419790.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[101]</div><div class="csl-right-inline">訾冬梅, 高秀静. 内蒙古自治区地图册[J].第新版版 北京: 中国地图出版社, 2006.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[102]</div><div class="csl-right-inline">谭其骧. 中国历史地图集[J]. 北京: 地图出版社, 1982, 第2册: 6.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[103]</div><div class="csl-right-inline">贾东琴, 柯平. 面向数字素养的高校图书馆数字服务体系研究[A]. 中国图书馆学会. 中国图书馆学会年会论文集[C]. 北京: 国家图书馆出版社, 2011, 2011年卷: 45-52.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[104]</div><div class="csl-right-inline">赵学功. 当代美国外交[M]. 北京: 社会科学文献出版社, 2001.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[105]</div><div class="csl-right-inline">邓一刚. 全智能节电器: 中国, CN101106276A[P].2008-01-16(CN200510022322.7 20051216): 8-9.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[106]</div><div class="csl-right-inline">郑涵, 于贵瑞, 朱先进, 王秋凤, 张雷明, 陈智, 孙晓敏, 何洪林, 苏文, 王艳芬, 韩士杰, 周国逸, 赵新全, 王辉民, 欧阳竹, 张宪洲, 张扬建, 石培礼, 李英年, 赵亮, 张一平, 闫俊华, 王安志, 张军辉, 郝彦斌, 赵风华, 张法伟, 周广胜, 林光辉, 陈世苹, 刘绍民, 赵斌, 贾根锁, 张旭东, 张玉翠, 古松, 刘文兆, 李彦, 王文杰, 杨大文, 张劲松, 张志强, 赵仲辉, 周石硚, 郭海强, 沈彦俊, 徐自为, 黄辉, 孟平. 2000—2010年中国典型陆地生态系统实际蒸散量和水分利用效率数据[J].Science Data Bank, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[107]</div><div class="csl-right-inline">金燕萍. 社交媒体时代的虚假信息研究[D]. 温州: 温州大学, 2020: 16.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[108]</div><div class="csl-right-inline">钱学森. 创建系统学[M]. 太原: 山西科学技术出版社, 2001: 序2-3.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[109]</div><div class="csl-right-inline">阿扬. 谈谈记忆：与诺贝尔获奖得者埃里克·坎德尔的问答[G]// 《环球科学》杂志社姜海伦. 认识记忆力：关于学习、思考与遗忘的脑科学. 北京: 机械工业出版社, 2023: 15-18.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[110]</div><div class="csl-right-inline">陈建军. 从数字地球到智慧地球[J]. 国土资源导刊. 2010, 7(10): 93.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[111]</div><div class="csl-right-inline">陈晋镳, 张惠民, 朱士兴, 赵震, 王振刚. 蓟县震旦亚界的研究[G]// 中国地质科学院天津地质矿产研究所. 中国震旦亚界. 天津: 天津科学技术出版社, 1980: 56-114.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[112]</div><div class="csl-right-inline">陈登原. 国史旧闻[M]. 北京: 中华书局, 2000, 1: 29.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[113]</div><div class="csl-right-inline">陈缮真. 探索微观世界的无穷奥秘（科技大观）[J]. 人民日报. 2022: 17.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[114]</div><div class="csl-right-inline">顾炎武. 昌平山水记；京东考古录[M]. 北京: 北京古籍出版社, 1980.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[115]</div><div class="csl-right-inline">马克思. 政治经济学批判[G]//第2版马克思恩格斯全集. 北京: 人民出版社, 2013, 35: 302.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[116]</div><div class="csl-right-inline">高等教育文献保障系统. 馆际互借与文献传递服务[EB/OL].[2025-06-21] . <a href="http://home.calis.edu.cn/pages/list.html?id=4101e184-7f64-4798-a5e1-8e37aa6994fc">http://home.calis.edu.cn/pages/list.html?id=4101e184-7f64-4798-a5e1-8e37aa6994fc</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[117]</div><div class="csl-right-inline">黄土高原科学数据中心（西北农林科技大学水土保持研究所）. 青海省县域教育、卫生发展指标（2001—2022年）[J].国家地球系统科学数据中心-黄土高原分中心, 2024.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[118]</div><div class="csl-right-inline">Science[J]. American Association for the Advancement of Science. Washington, D.C.: American Association for the Advancement of Science, 1883, 1883，1（1）—.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[119]</div><div class="csl-right-inline">中国人民解放军武汉市军事管制委员会接管国立武汉大学的文告[J].1949.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[120]</div><div class="csl-right-inline">图书馆学通讯[J]. 中国图书馆学会. 北京: 北京图书馆, 1957–1990, 1957（1）—1990（4）.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[121]</div><div class="csl-right-inline">康熙字典[M].第影印本版 北京: 中华书局, 1962, 巳集上 水部: 50.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[122]</div><div class="csl-right-inline">Public library quarterly[J]. Philadelphia: Taylor &#38; Francis, 1979, 1979，1（1）—.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[123]</div><div class="csl-right-inline">临床内科杂志[J]. 中华医学会湖北分会. 武汉: 中华医学会湖北分会, 1984, 1984，1（1）—.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[124]</div><div class="csl-right-inline">Geoecology and computers: proceedings of the Third International Conference on Advances of Computer Methods in Geotechnical and Geoenvironmental Engineering, Moscow, Russia, 1-4 February 2000[M]. Yufin, S.A. Rotterdam: A. A. Balkema, 2000.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[125]</div><div class="csl-right-inline">最新図書館用語大辭典[M]. 図書館用語辞典編集委員会. 東京: 柏書房株式會社, 2004: 154.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[126]</div><div class="csl-right-inline">Kaplan &#38; Sadock’s comprehensive textbook of psychiatry[M]. Sadock, B.J., Sadock, V.A., Ruiz, P., Kaplan, H.I. 9 edn. Philadelphia: Wolters Kluwer Health/Lippincott Williams &#38; Wilkins, 2009, 1.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[127]</div><div class="csl-right-inline">中国财税文化价值研究：“中国财税文化国际学术研讨会”论文集[M]. 陈志勇. 北京: 经济科学出版社, 2011.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[128]</div><div class="csl-right-inline">周易外传：卷5[G]// 王夫之. 第修订版版船山全书. 长沙: 岳麓书社, 2011, 第1册: 983-1029.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[129]</div><div class="csl-right-inline">台湾光复六十五周年暨抗战史实学术研讨会论文集[M]. 中国社会科学院台湾史研究中心. 北京: 九州出版社, 2012.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[130]</div><div class="csl-right-inline">综合湿地管理：综合湿地管理国际研讨会论文集[M]. 牛志明, Swingland I.R., 雷光春. 北京: 海洋出版社, 2012.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[131]</div><div class="csl-right-inline">A companion to California history[M]. Deverell, W., Igler, D. New York: John Wiley &#38; Sons, 2013: 21-22.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[132]</div><div class="csl-right-inline">Proceedings of the Second International Conference on Soft Computing for Problem Solving (SocProS 2012), December 28-30, 2012[M]. Babu, B.V., Nagar, A., Deep, K., Pant, M., Bansal, J.C., Ray, K., Gupta, U. New Delhi: Springer, 2014.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[133]</div><div class="csl-right-inline">鼻整形应用解剖学[M]. 牛永敢, 孔晓, 王阳, 斯楼斌. 北京: 人民卫生出版社, 2019: 65-66.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[134]</div><div class="csl-right-inline">IEEE P802.11ba/D8.0-2020, IEEE approved draft standard for information technology--telecommunications and information exchange between systems local and metropolitan area networks--specific requirements Part 11: wireless LAN Medium Access Control (MAC) and Physical Layer (PHY) specifications amendment 3: wake-up radio operation[S] New York: IEEE, 2020.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[135]</div><div class="csl-right-inline">大黄[G]// 国家药典委员会. 第2020版版中华人民共和国药典. 北京: 中国医药科技出版社, 2020, 一部: 24-25.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[136]</div><div class="csl-right-inline">Connecting the library to the curriculum[M]. Torres, L., Salisbury, F., Yazbeck, B., Karasmanis, S., Pinder, J., Ondracek, C. Singapore: Springer Nature, 2021: 97.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[137]</div><div class="csl-right-inline">《庄子》读不懂？看完这一篇“导读”就明白了[M].2022.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[138]</div><div class="csl-right-inline">[《昨日之歌》图书封面][M].2023.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[139]</div><div class="csl-right-inline">西黄丸[EB/OL].(2023-10-07)[2025-08-26] . <a href="https://ydz.chp.org.cn/#/item?bookId=1&#38;entryId=1154">https://ydz.chp.org.cn/#/item?bookId=1&#38;entryId=1154</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[140]</div><div class="csl-right-inline">Coastal wetlands map of China continent[J]. Beijing: China Ocean Press, 2024: 50.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[141]</div><div class="csl-right-inline">Library of Congress[EB/OL]. [2020-06-12] . <a href="https://www.loc.gov/">https://www.loc.gov/</a>.</div>
+  </div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《心理学报》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-4 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">Auerbach, J.S. The origins of narcissism and narcissistic personality disorder: A theoretical and empirical reformulation[G]// Bornstein, M.F. 4 edn.Handbook of child psychology: Vol. 4. Socialization, personality, and social development. Washington, DC, US: Wiley, 1993: 43-110.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">Australian Bureau of Statistics. Estimated resident population by age and sex in statistical local areas, New South Wales, June 1990[R].3209.1, Canberra, Australian Capital Territory: Author, 1991.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">Bergmann, P.G. Relativity[J]. The new encyclopedia Britannica. New York: Encyclopedia Britannica, 1993, 26: 501-508.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">Burin, D., Kilteni, K., Rabuffetti, M., Slater, M., Pia, L. Body ownership increases the interference between observed and executed movements[J]. PLOS ONE. 2019, 14(1).</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">Huestegge, S.M., Raettig, T., Huestegge, L. Are face-incongruent voices harder to process? Effects of face–voice gender incongruency on basic cognitive information processing[J]. Experimental Psychology. 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">Klatzky, R. Allocentric and egocentric spatial representations: Definitions, distinctions, and interconnections[G]// Freksa, C., Habel, C., Wender, K.F. Lecture notes in artificial intelligence: Vol. 1404: Spatial cognition: An interdisciplinary approach to representing and processing spatial knowledge. Springer-Verlag, 1998: 1-17.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[7]</div><div class="csl-right-inline">Lanktree, C.B., Briere, J.N. Early data on the Trauma Symptom Checklist for Children (TSC-C)[A]. San Diego, CA: 1991.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[8]</div><div class="csl-right-inline">Laplace, P.S. A philosophical essay on probabilities[M]. Truscott, F. W., 译, Emory, F. L., 译. Dover, 1951.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[9]</div><div class="csl-right-inline">Lichstein, K.L., Johnson, R.S. Relaxation therapy for polypharmacy use in elderly insomniacs and noninsomniacs[A]. Reducing medication in geriatric populations[C]. Uppsala, Sweden: 1990.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[10]</div><div class="csl-right-inline">Mitchell, T.R., Larson, J.R. People in organizations: An introduction to organizational behavior[M]. 3 edn. New York: McGraw-Hill, 1987.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[11]</div><div class="csl-right-inline">Mou, W., McNamara, T.P. Intrinsic frames of reference in spatial memory[J]. Journal of Experimental Psychology: Learning, Memory, and Cognition. US: American Psychological Association, 2002, 28: 162-170.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[12]</div><div class="csl-right-inline">Mou, W., Zhang, K., McNamara, T.P. Frames of reference in spatial memories acquired from language[J]. Journal of Experimental Psychology: Learning, Memory, and Cognition. US: American Psychological Association, 2004, 30: 171-180.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[13]</div><div class="csl-right-inline">Ruby, J., Fulton, C. Beyond redlining: Editing software that works[A]. Washington, DC: 1993.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[14]</div><div class="csl-right-inline">Wang, D.F., Cui, H. Theoretical analysis of the seven factor model of Chinese personality[G]// Wang, D.F., Hou, Y.B. Selected papers on personality and social psychology. Beijing: Peking University Press, 2004, 1: 46-84.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[15]</div><div class="csl-right-inline">Wolchik, S.A., West, S.G., Sandler, I.N., Tein, J.Y., Coatsworth, D., Lengua, L., Weiss, L., Anderson, E.R., Greene, S.M., Griffin, W.A. An experimental evaluation of theory-based mother and mother-child programs for children of divorce[J]. Journal of Consulting and Clinical Psychology. 2000, 68(5): 843-856.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[16]</div><div class="csl-right-inline">Yu, L. Phonological representation and processing in Chinese spoken language production[D].Beijing Normal University, 2000.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[17]</div><div class="csl-right-inline">余林. 汉语语言产生中的语音表征与加工[D].北京师范大学, 2000Yu Lin.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[18]</div><div class="csl-right-inline">张三. 中国心理学的过去与未来[J]. 心理学报. 2008a, 40: 210-215Zhang San.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[19]</div><div class="csl-right-inline">张三. 中国心理学的过去与未来[J]. 心理学报. 2008b, 40(增刊): 210-215Zhang San.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[20]</div><div class="csl-right-inline">张三. 心理学史[M]. 北京: 未名出版社, 2008cZhang San.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[21]</div><div class="csl-right-inline">张三, 李四. 中国心理学的过去与未来[J]. 心理学报. 2008a, 40: 210-215Zhang San, Li Si.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[22]</div><div class="csl-right-inline">张三, 李四. 中国心理学与奥林匹克[J]. 新华日报. 2008b: 2, 5-7Zhang San, Li Si.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[23]</div><div class="csl-right-inline">张三, 李四. 中国心理学的过去与未来[J]. 心理学报. Zhang San, Li Si.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[24]</div><div class="csl-right-inline">拉普拉斯, Pierre-Simon. 概率哲学[M]. 张三, 李四. 北京: 未名出版社, 1951Laplace Pierre-Simon.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[25]</div><div class="csl-right-inline">王登峰, 崔红. 中国人“大七”人格结构的理论分析[G]// 王登峰, 侯玉波. 人格与社会心理学论丛. 北京: 北京大学出版社, 2004, 1: 46-84Wang Deng Feng, Cui Hong.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[26]</div><div class="csl-right-inline">赵一, 钱二, 孙三, 李四, 周五, 吴六, 郑七. 中国心理学的过去与未来[J]. 心理学报. 2008, 40: 210-215Zhao Yi, Qian Er, Sun San, Li Si, Zhou Wu, Wu Liu, Zheng Qi.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[27]</div><div class="csl-right-inline">赵一一, 钱二, 孙三, 李四, 周五, 吴六, 郑七, 王八. 中国心理学的过去与未来[J]. 心理学报. 2008, 40: 210-215Zhao Yi Yi, Qian Er, Sun San, Li Si, Zhou Wu, Wu Liu, Zheng Qi, Wang Ba.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[28]</div><div class="csl-right-inline">邱颖文. 遗传与语言学习[D]. 上海: 华东师范大学, 2009Qiu Ying Wen.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[29]</div><div class="csl-right-inline">The new Grove dictionary of music and musicians[M]. Sadie, S. 6 edn. London : New York: Macmillan, 1980.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[30]</div><div class="csl-right-inline">现代汉语频率词典[M]. 北京: 北京语言学院出版社, 1986.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[31]</div><div class="csl-right-inline">Children of color: Psychological interventions with minority youth[M]. Gibbs, J.T., Huang, L.N. Hoboken, NJ, US: Jossey-Bass, 1989.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[32]</div><div class="csl-right-inline">现代汉语规范辞典[M]. 李行健. 北京: 外语教学与研究出版社, 2004: 255Li Xing Jian.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[33]</div><div class="csl-right-inline">心理学史[M]. 张三. 北京: 未名出版社, 2008dZhang San.</div>
+  </div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《中国社会科学》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-4 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">Brooks, P. Troubling confessions: Speaking guilt in law and literature[M]. Chicago: University of Chicago Press, 2000.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">Chamberlain, H.B. On the search for civil society in China[J]. Modern China. 1993, 19(2): 199-215.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">Polo, M. The travels of Marco Polo[M]. Marsden, William, 译. Hertfordshire: Cumberland House, 1997.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">Schfield, R.S. The impact of scarcity and plenty on population change in England[G]// Rotberg, R.I., Rabb, T.K. Hunger and history: The impact of changing food production and consumption pattern on society. Cambridge, Mass.: Cambridge University Press, 1983: 55-88.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">任东来. 对国际体制和国际制度的理解和翻译[A]. 天津: 2000.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">伤心人（麦孟华）. 说奴隶[J]. 清议报. , 第69册: 第1页.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[7]</div><div class="csl-right-inline">何龄修. 读顾诚〈南明史〉[J]. 中国史研究. 1998(3): 167-173.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[8]</div><div class="csl-right-inline">佚名. 晚清洋务运动事类汇钞五十七种[M]. 北京: 全国图书馆文献缩微复制中心, 1998, 上册.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[9]</div><div class="csl-right-inline">倪素香. 德育学科的比较研究与理论探索[J]. 武汉大学学报. 2002(4): 512-513.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[10]</div><div class="csl-right-inline">唐振常. 师承与变法[G]//识史集. 上海: 上海古籍出版社, 1997.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[11]</div><div class="csl-right-inline">姚际恒. 古今伪书考[J].第光绪三年苏州文学山房活字本版, 3.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[12]</div><div class="csl-right-inline">实藤惠秀. 中国人留学日本史[M]. 谭汝谦, 林启彦. 香港: 香港中文大学出版社, 1982.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[13]</div><div class="csl-right-inline">扬之水. 两宋茶诗与茶事[EB/OL]. 《文学遗产通讯》（网络版试刊）2006年第1期. [2007-09-13] . <a href="http://www.literature.org.cn/Article.asp?ID=199">http://www.literature.org.cn/Article.asp?ID=199</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[14]</div><div class="csl-right-inline">方明东. 罗隆基政治思想研究（1913—1949）[D].北京师范大学历史系, 2000.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[15]</div><div class="csl-right-inline">李眉. 李劼人轶事[J]. 四川工人日报. 1986: 2.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[16]</div><div class="csl-right-inline">李鹏程. 当代文化哲学沉思[M]. 北京: 人民出版社, 1994.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[17]</div><div class="csl-right-inline">杜威·佛克马. 走向新世界主义[G]// 王宁, 薛晓源. 全球化与后殖民批评. 北京: 中央编译出版社, 1999: 247-266.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[18]</div><div class="csl-right-inline">杨钟羲. 雪桥诗话续集[J].第影印本版 沈阳: 辽沈书社, 1991, 5.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[19]</div><div class="csl-right-inline">楼适夷. 读家书，想傅雷（代序）[G]// 傅敏. 第增补本版傅雷家书. 北京: 三联书店, 1998.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[20]</div><div class="csl-right-inline">毛祥麟. 墨余录[J]. 上海: 上海古籍出版社, 1985.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[21]</div><div class="csl-right-inline">汪疑今. 江苏的小农及其副业[J]. 中国经济. 1936, 4(6).</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[22]</div><div class="csl-right-inline">狄葆贤. 平等阁笔记[M]. 上海: 有正书局.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[23]</div><div class="csl-right-inline">王明亮. 关于中国学术期刊标准化数据库系统工程的进展[EB/OL].(1998-08-16)[1998-10-04] . <a href="http://www.cajcd.cn/pub/wml.txt/980810-2.html">http://www.cajcd.cn/pub/wml.txt/980810-2.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[24]</div><div class="csl-right-inline">管志道. 答屠仪部赤水丈书[J].第影印本版 续问辨牍. 济南: 齐鲁书社, 1997, 2.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[25]</div><div class="csl-right-inline">蒋大兴. 公司法的展开与评判——方法·判例·制度[M]. 北京: 法律出版社, 2001.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[26]</div><div class="csl-right-inline">费成康. 葡萄牙人如何进入澳门问题辨正[J]. 社会科学. 1999(9): 63-67.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[27]</div><div class="csl-right-inline">赵景深. 文坛忆旧[M]. 上海: 北新书局, 1948.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[28]</div><div class="csl-right-inline">魏丽英. 论近代西北人口波动的若干主要原因[J]. 社会科学. 兰州: 1990(6): 68-73, 86.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[29]</div><div class="csl-right-inline">鲁迅. 中国小说的历史的变迁[G]//鲁迅全集. 北京: 人民文学出版社, 1981, 第9册.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[30]</div><div class="csl-right-inline">黄义豪. 评黄龟年四劾秦桧[J]. 福建论坛. 1997(3): 26-27.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[31]</div><div class="csl-right-inline">黄仁宇. 为什么称为“中国大历史”？——中文版自序[G]//中国大历史. 北京: 三联书店, 1997.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[32]</div><div class="csl-right-inline">四川会议厅暂行章程[J]. 广益丛报. 1910(第8年第19期): 第1—2页.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[33]</div><div class="csl-right-inline">傅良佐致国务院电[J].1917.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[34]</div><div class="csl-right-inline">上海各路商界总联合会致外交部电[J]. 民国日报. 上海: 1925: 4.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[35]</div><div class="csl-right-inline">西南中委反对在宁召开五全会[J]. 民国日报. 上海: 1933: 第1张第4版.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[36]</div><div class="csl-right-inline">党外人士座谈会记录[J].1950.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[37]</div><div class="csl-right-inline">Nixon to Kissinger[J].1969.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[38]</div><div class="csl-right-inline">旧唐书[J].第标点本版 北京: 中华书局, 1975, 9.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[39]</div><div class="csl-right-inline">中国哲学发展史（先秦卷）[M]. 任继愈. 北京: 人民出版社, 1983.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[40]</div><div class="csl-right-inline">方苞集[J].第标点本版 上海: 上海古籍出版社, 1983, 6.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[41]</div><div class="csl-right-inline">太平御览[J].第影印本版 北京: 中华书局, 1985, 690.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[42]</div><div class="csl-right-inline">荣庆日记[M]. 西安: 西北大学出版社, 1986.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[43]</div><div class="csl-right-inline">清德宗实录[J].第影印本版 北京: 中华书局, 1987, 435.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[44]</div><div class="csl-right-inline">周恩来传[M]. 金冲及. 北京: 人民出版社、中央文献出版社, 1989.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[45]</div><div class="csl-right-inline">广东通志[J].第影印本版 稀见中国地方志汇刊. 北京: 中国书店, 1992, 15.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[46]</div><div class="csl-right-inline">马克思恩格斯全集[M]. 北京: 人民出版社, 1998, 31.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[47]</div><div class="csl-right-inline">上海县续志[J]., 1.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[48]</div><div class="csl-right-inline">嘉定县志[J]., 12.</div>
+  </div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《法学引注手册》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-4 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">Alford, W. To steal a book is an elegant offense: Intellectual property law in Chinese civilization[M].Stanford University Press, 1995.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">Badiou-Monferran, C. La promotion esthétique du pathétique dans la seconde moitié du XVIIe siècle[J]. La Licorne. 1997(43): 75-94.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">Barbara Ward. Progress for a small planet[J]. Harvard Business Review. 1979(Sep.-Oct.): 89.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">Brandeis, L.D. What publicity can do[J]. Harper’s Weekly. 1913: 10.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">Canaris, C.W. Gesamtunwirksamkeit und Teilgültigkeit rechtsgeschäftlicher Regelungen[G]//1990.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">Chevallier, M. L’État de droit[M]. 4 edn. Paris: Montchrestien, 2003.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[7]</div><div class="csl-right-inline">Fischer, T. Absurdes Spektakel um den Tod[J]. Die Zeit. 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[8]</div><div class="csl-right-inline">Habermas, J. Between facts and norms: contributions to a discourse theory of law and democracy[M]. Rehg, William, 译. MIT Press, 1996.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[9]</div><div class="csl-right-inline">Horsley, J. Rule of law in China: incremental progress[G]// Bergsten, C.F., Gill, B., Lardy, N.R., Mitchell, D. China: The balance sheet. Public Affairs Press, 2006.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[10]</div><div class="csl-right-inline">Joyeux-Prunel, B. L’histoire de l’art et le quantitatif[EB/OL]. Histoire &#38; mesure, vol. XXIII, n° 2, 2008. [2010-03-17] . <a href="http://histoiremesure.revues.org/index3543.html">http://histoiremesure.revues.org/index3543.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[11]</div><div class="csl-right-inline">Kaufmann, A. Bemerkungen zur Reform des § 218 StGB aus rechtsphilosophischer Sicht[G]// Baumann, J. 2 edn.Das Abtreibungsverbot des § 218 StGB. 1972.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[12]</div><div class="csl-right-inline">McDonell, S. When China began streaming trials online[EB/OL]. BBC News. 2016-09-30. (2016-09-30)[2022-07-26] . <a href="https://www.bbc.com/news/blogs-china-blog-37515399">https://www.bbc.com/news/blogs-china-blog-37515399</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[13]</div><div class="csl-right-inline">Meidenbauer, M. Wissenschaftliches Publizieren[EB/OL]. [2017-10-10] . <a href="https://www.clio-online.de/sites/files/clio/portal-archiv/site/lang_de/40208143/Default-2.html">https://www.clio-online.de/sites/files/clio/portal-archiv/site/lang_de/40208143/Default-2.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[14]</div><div class="csl-right-inline">Poisson, M. Le droit de la mer[J]. RGDIP. 2015a: 15-47.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[15]</div><div class="csl-right-inline">Poisson, M. Le droit de la mer[G]// Éditions de la mer edn.Le droit des Océans. 2015b: 12-48.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[16]</div><div class="csl-right-inline">Poisson, M. Le droit de la mer appliqué à la Méditerranée[D].l’Université de Marseille, 2016a.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[17]</div><div class="csl-right-inline">Poisson, M. Le droit de la mer en Méditerranée[R].Congrès de Marseille, 2016b: 228-229.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[18]</div><div class="csl-right-inline">Poisson, M. Le droit de la mer en Méditerranée[R].1202, 2016c.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[19]</div><div class="csl-right-inline">Reich, C.A. The new property[J]. Yale Law Journal. 1964, 73(5): 733-787.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[20]</div><div class="csl-right-inline">Rosenthal, A. White House tutors Kremlin in how a presidency works[J]. New York Times. 1990: A1.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[21]</div><div class="csl-right-inline">Roxin, C. Strafrecht Allgemeiner Teil[M]. 4 edn.C. H. Beck, 2006, 1.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[22]</div><div class="csl-right-inline">Schwab, M. [G]// 6 edn.Münchener Kommentar BGB. 2013, 5.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[23]</div><div class="csl-right-inline">Vogel, B. Rechtsgüterschutz und Normgeltung[J]. Zeitschrift für die gesamte Strafrechtswissenschaft. 2017, 129(3): 629-649.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[24]</div><div class="csl-right-inline">Würdinger, M. Über Radarwarngeräte und die Zukunft des Europäischen Privatrechts[J]. Juristische Schulung. Verlag C.H. Beck, 2012(3): 234-240.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[25]</div><div class="csl-right-inline">中国共产党中央委员会. 中共中央关于全面推进依法治国若干重大问题的决定[J].2014.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[26]</div><div class="csl-right-inline">佐藤英明. 一時所得の要件に関する覚書[G]// 金子宏, 中里実, J.マーク・ラムザイヤー. 租税法と市場. 有斐閣, 2014: 220.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[27]</div><div class="csl-right-inline">何海波. 判决书上网[J]. 法制日报. 2000: 2.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[28]</div><div class="csl-right-inline">信春鹰. 关于《中华人民共和国行政诉讼法修正案（草案）》的说明[R].2013.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[29]</div><div class="csl-right-inline">全国人大常委会. 全国人民代表大会常务委员会关于严禁卖淫嫖娼的决定[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[30]</div><div class="csl-right-inline">全国人大常委会. 中华人民共和国公司法[S]第2005年修订版.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[31]</div><div class="csl-right-inline">全国人大常委会. 中华人民共和国公司法[S]第2013年修正版.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[32]</div><div class="csl-right-inline">全国人大常委会. 中华人民共和国主席令第80号, 中华人民共和国刑法修正案（十）[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[33]</div><div class="csl-right-inline">最高人民法院. 最高人民法院关于适用〈中华人民共和国行政诉讼法〉的解释[J].2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[34]</div><div class="csl-right-inline">最高人民法院, 最高人民检察院. 最高人民法院、最高人民检察院关于依法严惩破坏计划生育犯罪活动的通知[J].1993.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[35]</div><div class="csl-right-inline">国务院. 国务院关于在全国建立农村最低生活保障制度的通知[J].2007a.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[36]</div><div class="csl-right-inline">国务院. 国务院关于在全国建立农村最低生活保障制度的通知[J].2007b.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[37]</div><div class="csl-right-inline">国务院. 国务院关于印发打赢蓝天保卫战三年行动计划的通知[J].2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[38]</div><div class="csl-right-inline">国家质量监督检验检疫总局, 中国国家标准化管理委员会. GB/T 7714—2015, 信息与文献 参考文献著录规则[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[39]</div><div class="csl-right-inline">夏新华, 胡旭晟, 刘鄂, 甘正气, 万利容, 刘姗姗. 近代中国宪政历程[M].中国政法大学出版社, 2004.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[40]</div><div class="csl-right-inline">季卫东. 法律程序的意义：对中国法制建设的另一种思考[J]. 中国社会科学. 1993(1): 83-103.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[41]</div><div class="csl-right-inline">崔国斌. 知识产权法官造法批判[J]. 中国法学. 2006(1): 144-164.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[42]</div><div class="csl-right-inline">张新宝. 侵权责任法[M].第4版中国人民大学出版社, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[43]</div><div class="csl-right-inline">[德]莱纳·沃尔夫. 风险法的风险[G]// 刘刚陈霄. 风险规制：德国的理论与实践. 法律出版社, 2012.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[44]</div><div class="csl-right-inline">我妻栄. 新訂担保物権法[M].有斐閣, 1971.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[45]</div><div class="csl-right-inline">我妻栄, 有泉亨. 民法総則物権法[M].日本評論社, 1950.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[46]</div><div class="csl-right-inline">於保不二雄. 付加物及び従物と抵当権[J]. 民商法雑誌. 1954, 29(5): 1.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[47]</div><div class="csl-right-inline">李松锋. 游走在上帝与凯撒之间：美国宪法第一修正案中的政教关系研究[D].中国政法大学, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[48]</div><div class="csl-right-inline">欧中坦. 千方百计上京城：清朝的京控[G]// 高道蕴, 高鸿钧, 贺卫方谢鹏程. 美国学者论中国法律传统. 中国政法大学出版社, 1994.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[49]</div><div class="csl-right-inline">汪波. 哈尔滨市政法机关正对“宝马案”认真调查复查[EB/OL]. 人民网. 2004-01-10. (2004-01-10)[2022-05-03] . <a href="http://www.people.com.cn/GB/shehui/1062/2289764.html">http://www.people.com.cn/GB/shehui/1062/2289764.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[50]</div><div class="csl-right-inline">王保树. 股份有限公司机关构造中的董事和董事会[G]// 梁慧星. 民商法论丛. 法律出版社, 1994, 1: 110.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[51]</div><div class="csl-right-inline">王名扬. 美国行政法[M].北京大学出版社, 2007.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[52]</div><div class="csl-right-inline">瞿同祖. 中国法律与中国社会[M].商务印书馆, 2010.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[53]</div><div class="csl-right-inline">罗豪才, 袁曙宏, 李文栋. 现代行政法的理论基础——论行政机关与相对一方的权利义务平衡[J]. 中国法学. 1993(1): 52-59.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[54]</div><div class="csl-right-inline">[美]富勒. 法律的道德性[M]. 郑戈. 商务印书馆, 2005.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[55]</div><div class="csl-right-inline">[英]劳特派特. 奥本海国际法[M]. 王铁崖, 陈体强. 第8版商务印书馆, 1971, 上卷第一分册.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[56]</div><div class="csl-right-inline">赵耀彤. 一名基层法官眼里好律师的样子[J]. 中国法律评论. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[57]</div><div class="csl-right-inline">邓小平. 精简机构是一场革命[G]//第2版邓小平文选. 人民出版社, 1994, 2.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[58]</div><div class="csl-right-inline">信玄公旗掛松事件[M]. 大審院民事判決録. 1919, 25: 356.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[59]</div><div class="csl-right-inline">89-670, Department of Transportation Act[S]. Stat. , 80: 931, 944-947.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[60]</div><div class="csl-right-inline">Roe <i>v.</i> Wade[M]. U.S. 1973, 410: 113.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[61]</div><div class="csl-right-inline">Natural Resources Defense Council <i>v.</i> Gorsuch[M]. F.2d. 1982, 685: 718.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[62]</div><div class="csl-right-inline">約束手形金[M]. 最高裁判所民事判例集. 1982, 36卷6号: 1113.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[63]</div><div class="csl-right-inline">Chevron U.S.A., Inc. <i>v.</i> Natural Resources Defense Council[M]. U.S. 1984, 467: 837.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[64]</div><div class="csl-right-inline">R. v. Panel on Take-overs and Mergers[M]. QB. 1987, 815.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[65]</div><div class="csl-right-inline">[M]. NStZ-RR. 1999: 185.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[66]</div><div class="csl-right-inline">[M]. NJW. 2000: 1560.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[67]</div><div class="csl-right-inline">Rechtsphilosophie Studienausgabe[M]. Dreier, R., Paulson, S. 2 edn. Heidelberg: UTB Uni-Taschenbücher Verlag, 2003.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[68]</div><div class="csl-right-inline">Administrative Procedure Act § 6[S]. U.S.C. , 5.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[69]</div><div class="csl-right-inline">当代中国行政法的源流：王名扬教授九十华诞贺寿文集[M]. 应松年, 马怀德. 中国法制出版社, 2006.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[70]</div><div class="csl-right-inline">英美法原论[M]. 高鸿钧, 程汉大. 北京大学出版社, 2013.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[71]</div><div class="csl-right-inline">荣宝英诉王阳、永诚财产保险股份有限公司江阴支公司机动车交通事故责任纠纷案[M]. 最高人民法院公报. 2013(8).</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[72]</div><div class="csl-right-inline">陆红霞诉南通市发改委政府信息公开案[M]. 最高人民法院公报. 2015(11).</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[73]</div><div class="csl-right-inline">榆林市凯奇莱能源投资有限公司诉陕西省地质矿产勘查开发局西安地质矿产勘查开发院合作勘查合同纠纷上诉案[M].2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[74]</div><div class="csl-right-inline">GG[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[75]</div><div class="csl-right-inline">StGB[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[76]</div><div class="csl-right-inline">StPO[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[77]</div><div class="csl-right-inline">Strauß-Karikatur, Kunstfreiheit[M]. BVerfGE. , 75: 369.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[78]</div><div class="csl-right-inline">United States <i>v.</i> Dino Nastasi et al.[M].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[79]</div><div class="csl-right-inline">ジュリスト[EB/OL]. [2022-09-01] . <a href="http://www.yuhikaku.co.jp/jurist">http://www.yuhikaku.co.jp/jurist</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[80]</div><div class="csl-right-inline">動産及び債権の譲渡の対抗要件に関する民法の特例に関する法律[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[81]</div><div class="csl-right-inline">包郑照诉苍南县人民政府强制拆除房屋案[M].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[82]</div><div class="csl-right-inline">平成26年版犯罪白書[J].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[83]</div><div class="csl-right-inline">民法总则[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[84]</div><div class="csl-right-inline">法国行政法院网站[EB/OL].[2016-12-18] . <a href="http://english.conseil-etat.fr/Judging">http://english.conseil-etat.fr/Judging</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[85]</div><div class="csl-right-inline">温家宝主持国务院会议 研究房地产业健康发展措施[EB/OL]. 新华网. . <a href="http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm">http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[86]</div><div class="csl-right-inline">被告人李宁、张磊贪污案一审开庭[EB/OL]. 新华网. . <a href="http://www.xinhuanet.com/legal/2019-12/31/c_1125406056.htm">http://www.xinhuanet.com/legal/2019-12/31/c_1125406056.htm</a>.</div>
+  </div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### APA 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-5 second-field-align-flush hangingindent-false">
+  <div class="csl-entry">
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">Ahmann, E., Tuttle, L.J., Saviet, M., Wright, S.D. A descriptive review of ADHD coaching research: Implications for college students[J]. Journal of Postsecondary Education and Disability. 2018, 31(1): 17-39.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[2]</div><div class="csl-right-inline">Alonso-Tapia, J., Nieto, C., Merino-Tejedor, E., Huertas, J.A., Ruiz, M. Situated Goals Questionnaire for University Students (SGQ-U, CMS-U)[J].PsycTESTS, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[3]</div><div class="csl-right-inline">Amano, N., Kondo, H. Lexical characteristics of Japanese language[M].Sansei-do, 2000, 7.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[4]</div><div class="csl-right-inline">American Counseling Association. 2014 ACA code of ethics[R].2014.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[5]</div><div class="csl-right-inline">American Nurses Association. Code of ethics for nurses with interpretive statements[R].2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[6]</div><div class="csl-right-inline">American Psychiatric Association. Diagnostic and statistical manual of mental disorders[R]. 5 edn.American Psychiatric Association, 2013.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[7]</div><div class="csl-right-inline">American Psychological Association. Ethical principles of psychologists and code of conduct[R].2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[8]</div><div class="csl-right-inline">American Psychological Association. APA dictionary of psychology[M].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[9]</div><div class="csl-right-inline">American Psychological Association. Positive transference[J]. APA dictionary of psychology. .</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[10]</div><div class="csl-right-inline">Anderson, M. Getting consistent with consequences[J]. Educational Leadership. 2018, 76(1): 26-33.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[11]</div><div class="csl-right-inline">APA Education [@APAEducation]. College students are forming mental-health Clubs—and they’re making a difference @washingtonpost [Thumbnail with link attached][J]. Twitter. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[12]</div><div class="csl-right-inline">APA Style [@APA_Style]. Tweets[EB/OL]. Twitter. [2019-11-01] . <a href="https://twitter.com/APA_Style">https://twitter.com/APA_Style</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[13]</div><div class="csl-right-inline">Aristotle. Poetics[M]. Butcher, S. H., 译. The Internet Classics Archive, 1994.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[14]</div><div class="csl-right-inline">Australian Government Productivity Commission, New Zealand Productivity Commission. Strengthening trans-Tasman economic relations[R].2012.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[15]</div><div class="csl-right-inline">Author, A. How workout buddies can help stave off loneliness[J]. The Washington Post. 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[16]</div><div class="csl-right-inline">Avramova, N. The secret to a long, happy, health life? Think age-positive[EB/OL]. CNN. 2019-01-03. (2019-01-03) . <a href="https://www.cnn.com/2019/01/03/health/respect-towards-elderly-leads-to-long-life-intl/index.html">https://www.cnn.com/2019/01/03/health/respect-towards-elderly-leads-to-long-life-intl/index.html</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[17]</div><div class="csl-right-inline">Badlands National Park [@BadlandsNPS]. Biologists have identified more than 400 different plant species growing in @BadlandsNPS #DYK #biodoversity[J]. Twitter. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[18]</div><div class="csl-right-inline">Baer, R.A. Unpublished raw data on the correlations between the Five Facet Mindfulness Questionnaire and the Kentucky Inventory of Mindfulness Skills[J].University of Kentucky, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[19]</div><div class="csl-right-inline">Balsam, K.F., Martell, C.R., Jones, K.P., Safren, S.A. Affirmative cognitive behavior therapy with sexual and gender minority people[G]// Iwamasa, G.Y., Hays, P.A. 2 edn.Culturally responsive cognitive behavior therapy: Practice and supervision. American Psychological Association, 2019: 287-314.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[20]</div><div class="csl-right-inline">De Beauvoir, S. Simone de Beauvoir discusses the art of writing[J].1960.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[21]</div><div class="csl-right-inline">Bergeson, S. Really cool neutral plasmas[J]. Science. 2019, 363(6422): 33-34.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[22]</div><div class="csl-right-inline">Beyoncé. Formation[M]. Lemonade. Parkwood; Columbia, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[23]</div><div class="csl-right-inline">Blackwell, D.L., Lucas, J.W., Clarke, T.C. Summary health statistics for U.S. adults: National Health Interview Survey, 2012[R].Vital and health statistics series Centers for Disease Control and Prevention, 2014.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[24]</div><div class="csl-right-inline">Blair, C.B. Stress, self-regulation and psychopathology in middle childhood[R].5R01HD081252-04, Eunice Kennedy Shriver National Institute of Child Health &#38; Human Development, 2015–2020.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[25]</div><div class="csl-right-inline">Boddy, J., Neumann, T., Jennings, S., Morrow, V., Alderson, P., Rees, R., Gibson, W. Ethics principles[EB/OL]. The research ethics guidebook: A resource for social scientists. . <a href="http://www.ethicsguidebook.ac.uk/EthicsPrinciples">http://www.ethicsguidebook.ac.uk/EthicsPrinciples</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[26]</div><div class="csl-right-inline">Bologna, C. What happens to your mind and body when you feel homesick?[EB/OL]. HuffPost. 2018-06-27. (2018-06-27) . <a href="https://www.huffingtonpost.com/entry/what-happens-mind-body-homesick_us_5b201ebde4b09d7a3d77eee1">https://www.huffingtonpost.com/entry/what-happens-mind-body-homesick_us_5b201ebde4b09d7a3d77eee1</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[27]</div><div class="csl-right-inline">Borenstein, M., Hedges, L., Higgins, J., Rothstein, H. Comprehensive meta-analysis[J].Biostat, 2014.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[28]</div><div class="csl-right-inline">Bowie, D. Blackstar[M].Columbia, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[29]</div><div class="csl-right-inline">British Cardiovascular Society Working Group. British Cardiovascular Society Working Group report: Out-of-hours cardiovascular care: Management of cardiac emergencies and hospital in-patients[R].British Cardiovascular Society, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[30]</div><div class="csl-right-inline">Bronfenbrenner, U. The social ecology of human development: A retrospective conclusion[G]// Bronfenbrenner, U. Making human beings human: Bioecological perspectives on human development. SAGE Publications, 2005: 27-40.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[31]</div><div class="csl-right-inline">Brown, L.S. Feminist therapy[M]. 2 edn.American Psychological Association, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[32]</div><div class="csl-right-inline">Burgess, R. Rethinking global health: Frameworks of power[M].Routledge, 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[33]</div><div class="csl-right-inline">Burin, D., Kilteni, K., Rabuffetti, M., Slater, M., Pia, L. Body ownership increases the interference between observed and executed movements[J]. PLOS ONE. 2019, 14(1).</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[34]</div><div class="csl-right-inline">Bustillos, M. On video games and storytelling: An interview with Tom Bissell[J]. The New Yorker. 2013.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[35]</div><div class="csl-right-inline">Cable, D. The racial dot map[J]. University of Virginia: Weldon Cooper Center for Public Service, 2013.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[36]</div><div class="csl-right-inline">Cain, S. Quiet: The power of introverts in a world that can’t stop talking[M].Random House Audio, 2012.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[37]</div><div class="csl-right-inline">Canada Council for the Arts. What we heard: Summary of key findings: 2013 Canada Council’s Inter-Arts Office Consultation[R].2013.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[38]</div><div class="csl-right-inline">Canan, E., Vasilev, J. Lecture notes on resource allocation[J]. Department of Management Control and Information Systems, University of Chile: 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[39]</div><div class="csl-right-inline">Carcavilla González, N. Auditory sensory therapy: Brain activation through music[G]// Garcia Meilán, J.J. Guía práctica de terapias estimulativas en el Alzhéimer. Editorial Síntesis, 2015: 67-86.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[40]</div><div class="csl-right-inline">Cardoza, D., Morris, J.K., Myers, H.F., Rodriguez, N. Acculturative Stress Inventory (ASI)[J].ETS TestLink, 2000.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[41]</div><div class="csl-right-inline">Centers for Disease Control and Prevention. People at high risk of developing flu-related complications[EB/OL]. (2018-01-23) . <a href="https://www.cdc.gov/flu/about/disease/high_risk.htm">https://www.cdc.gov/flu/about/disease/high_risk.htm</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[42]</div><div class="csl-right-inline">Chaves-Morillo, V., Gómez Calero, C., Fernández-Muñoz, J.J., Toledano-Muñoz, A., Fernández-Heute, J., Martinez-Monge, N., Palacios-Ceña, D., Peñacoba-Puente, C. Sensorineural anosmia: Relationship between subtype, recognition time, and age[J]. Clínica y Salud. 2018, 28(3): 155-161.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[43]</div><div class="csl-right-inline">Childish Gambino. This is America[M].mcDJ; RCA, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[44]</div><div class="csl-right-inline">Christian, B., Griffiths, T. Algorithms to live by: The computer science of human decisions[M].Henry Holt and Co., 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[45]</div><div class="csl-right-inline">Cuellar, N.G. Study abroad programs[J]. Journal of Transcultural Nursing. 2016, 27(3): 209.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[46]</div><div class="csl-right-inline">De Boer, D., LaFavor, T. The art and significance of successfully identifying resilient individuals A person-focused approach[J]. Perspectives on resilience: Conceptualization, measurement, and enhancement. Portland, OR, United States: 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[47]</div><div class="csl-right-inline">De Vries, R., Nieuwenhuijze, M., Buitendijk, S.E., The members of Midwifery Science Work Group. What does it take to have a strong and independent profession of midwifery? Lessons from the Netherlands[J]. Midwifery. 2013, 29(10): 1122-1128.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[48]</div><div class="csl-right-inline">Delacroix, E. Faust attempts to seduce Marguerite[M].1826–1827.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[49]</div><div class="csl-right-inline">D’Souza, A., Wiseheart, M. Cognitive effects of music and dance training in children[J].ICPSR, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[50]</div><div class="csl-right-inline">Epocrates. Epocrates medical references[J].App Store, 2019a.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[51]</div><div class="csl-right-inline">Epocrates. Interaction Check: Aspirin + Sertraline[J]. Epocrates medical references. Google Play Store, 2019b.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[52]</div><div class="csl-right-inline">Fiske, S.T., Gilbert, D.T., Lindzey, G. Handbook of social psychology[M]. 5 edn.John Wiley &#38; Sons, 2010, 1.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[53]</div><div class="csl-right-inline">Fistek, A., Jester, E., Sonnenberg, K. Everybody’s got a little music in them: Using music therapy to connect, engage, and motivate[J]. Milwaukee, WI, United States: 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[54]</div><div class="csl-right-inline">Freud, S. The interpretation of dreams: The complete and definitive text[M]. Strachey, J.Strachey, J., 译. Basic Books, 2010.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[55]</div><div class="csl-right-inline">Fried, D., Polyakova, A. Democratic defense against disinformation[R].Atlantic Council, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[56]</div><div class="csl-right-inline">Gaiman, N. 100,000+ Rohingya refugees could be at serious risk during Bangladesh’s monsoon season. My fellow UNHCR Goodwill Ambassador Cate Blanchett is [Image attached][J]. Facebook. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[57]</div><div class="csl-right-inline">GDJ. Neural network deep learning prismatic[M].2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[58]</div><div class="csl-right-inline">Glass, I. Amusement park[J]. This American Life. WBEZ Chicago, 2011.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[59]</div><div class="csl-right-inline">Goldin-Meadow, S. Gesture and cognitive development[G]// Liben, L.S., Mueller, U. 7 edn.Handbook of child psychology and developmental science. John Wiley &#38; Sons, 2015, 2: 339-380.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[60]</div><div class="csl-right-inline">Goldman, C. The complicated calibration of love, especially in adoption[J]. Chicago Tribune. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[61]</div><div class="csl-right-inline">Google. Google Maps directions for driving from La Paz, Bolivia, to Lima, Peru[J].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[62]</div><div class="csl-right-inline">Graham, G. Behaviorism[J]. Zalta, E.N. Summer 2019 ed. edn. The Stanford encyclopedia of philosophy. Stanford University, 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[63]</div><div class="csl-right-inline">Guarino, B. How will humanity react to alien life? Psychologists have some predictions[J]. The Washington Post. 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[64]</div><div class="csl-right-inline">Harris, L. Instructional leadership perceptions and practices of elementary school leaders[D].University of Virginia, 2014.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[65]</div><div class="csl-right-inline">Harwell, M. Don’t expect too much: The limited usefulness of common SES measures and a prescription for change[R].National Education Policy Center, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[66]</div><div class="csl-right-inline">Heidegger, M. On the essence of truth[G]// Krell, D.F.Sallis, J., 译. Basic writings. Harper Perennial Modern Thought, 2008: 111-138.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[67]</div><div class="csl-right-inline">Hess, A. Cats who take direction[J]. The New York Times. 2019: C1.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[68]</div><div class="csl-right-inline">Hiremath, S.C., Kumar, S., Lu, F., Salehi, A. Using metaphors to present concepts across different intellectual domains: 中国, 9,367,592[P]. U.S.: 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[69]</div><div class="csl-right-inline">Ho, H.K. Teacher preparation for early childhood special education in Taiwan[J].ERIC, 2014.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[70]</div><div class="csl-right-inline">Hollander, M.M. Resistance to authority: Methodological innovations and new lessons from the Milgram experiment[D].University of Wisconsin–Madison, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[71]</div><div class="csl-right-inline">Housand, B. Game on! Integrating games and simulations in the classroom[J]. SlideShare: 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[72]</div><div class="csl-right-inline">Huestegge, S.M., Raettig, T., Huestegge, L. Are face-incongruent voices harder to process? Effects of face–voice gender incongruency on basic cognitive information processing[J]. Experimental Psychology. 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[73]</div><div class="csl-right-inline">Hutcheson, V.H. Dealing with dual differences: Social coping strategies of gifted and lesbian, gay, bisexual, transgender, and queer adolescents[D].The College of William &#38; Mary, 2012.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[74]</div><div class="csl-right-inline">Kalnay, E., Kanamitsu, M., Kistler, R., Collins, W., Deaven, D., Gandin, L., Iredell, M., Saha, S., White, G., Wollen, J., Zhu, Y., Chelliah, M., Ebisuzaki, W., Higgins, W., Janowiak, J., Mo, K.C., Ropelewski, C., Wang, J., Leetma, A., Aaron, A., Court, B.B.C., Joseph, D. The NCEP/NCAR 40-year reanalysis project[J]. Bulletin of the American Meteorological Society. 1996, 77(3): 437-471.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[75]</div><div class="csl-right-inline">King, M.L., Jr. I have a dream[M].American Rhetoric, 1963.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[76]</div><div class="csl-right-inline">Klymkowsky, M. Can we talk scientifically about free will?[J]. Sci-Ed. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[77]</div><div class="csl-right-inline">KS in NJ. From this article, it sounds like men are figuring something out that women have known forever. I know of many[J]. The Washington Post. 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[78]</div><div class="csl-right-inline">Lamar, K. Humble[M]. Damn. Aftermath Entertainment; Interscope Records; Top Dawg Entertainment, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[79]</div><div class="csl-right-inline">Leuker, C., Samartzidis, L., Hertwig, R., Pleskac, T.J. When money talks: Judging risk and coercion in high-paying clinical trials[J].PsyArXiv, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[80]</div><div class="csl-right-inline">Lewin, K. Group decision and social change[G]// Gold, M. The complete social scientist: A Kurt Lewin reader. American Psychological Association, 1999: 265-284.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[81]</div><div class="csl-right-inline">Lichtenstein, J. Profile of veteran business owners: More young veterans appear to be starting businesses[R].1, U.S. Small Business Administration, Office of Advocacy, 2013.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[82]</div><div class="csl-right-inline">Lippincott, T., Poindexter, E.K. Emotion recognition as a function of facial cues: Implications for practice[J]. Department of Psychology, University of Washington: 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[83]</div><div class="csl-right-inline">Mack, R., Spake, G. Citing open source images and formatting references for presentations[J]. Canvas@FNU: 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[84]</div><div class="csl-right-inline">Maddox, S., Hurling, J., Stewart, E., Edwards, A. If mama ain’t happy, nobody’s happy: The effect of parental depression on mood dysregulation in children[J]. New Orleans, LA, United States: 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[85]</div><div class="csl-right-inline">Madigan, S. Narrative therapy[M]. 2 edn.American Psychological Association, 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[86]</div><div class="csl-right-inline">Martin Lillie, C.M. Be kind to yourself: How self-compassion can improve your resiliency[EB/OL]. Mayo Clinic. 2016-12-29. (2016-12-29) . <a href="https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/self-compassion-can-improve-your-resiliency/art-20267193">https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/self-compassion-can-improve-your-resiliency/art-20267193</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[87]</div><div class="csl-right-inline">McCauley, S.M., Christiansen, M.H. Language learning as language use: A cross-linguistic model of child language development[J]. Psychological Review. 2019, 126(1): 1-51.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[88]</div><div class="csl-right-inline">McCurry, S. Afghan girl[M].1985.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[89]</div><div class="csl-right-inline">Meadows, D.H. Thinking in systems: A primer[M]. Wright, D. Chelsea Green Publishing, 2008.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[90]</div><div class="csl-right-inline">Mehrholz, J., Pohl, M., Platz, T., Kugler, J., Elsner, B. Electromechanical and robot-assisted arm training for improving activities of daily living, arm function, and arm muscle strength after stroke[J]. Cochrane Database of Systematic Reviews. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[91]</div><div class="csl-right-inline">Merriam-Webster. Merriam-Webster.com dictionary[M].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[92]</div><div class="csl-right-inline">Merriam-Webster. Self-report[J]. Merriam-Webster.com dictionary. .</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[93]</div><div class="csl-right-inline">Mirabito, L.A., Heck, N.C. Bringing LGBTQ youth theater into the spotlight[J]. Psychology of Sexual Orientation and Gender Diversity. 2016, 3(4): 499-500.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[94]</div><div class="csl-right-inline">Morey, M.C. Physical activity and exercise in older adults[J]. UpToDate. 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[95]</div><div class="csl-right-inline">National Aeronautics and Space Administration [@nasa]. I’m NASA Astronaut Scott Tingle. Ask me anything about adjusting to being back on Earth after my first spaceflight![J]. Reddit. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[96]</div><div class="csl-right-inline">National Cancer Institute. Facing forward: Life after cancer treatment[R].18-2424, U.S. Department of Health and Human Services, National Institutes of Health, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[97]</div><div class="csl-right-inline">National Center for Education Statistics. Fast response survey system (FRSS): Teacher’s use of educational technology in U.S. public schools, 2009[J].National Archive of Data on Arts and Culture, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[98]</div><div class="csl-right-inline">National Institute of Mental Health. Suicide affects all ages, genders, races, and ethnicities. Check out these 5 Action Steps for Helping Someone in Emotional Pain[J]. Facebook. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[99]</div><div class="csl-right-inline">National Nurses United. What employers should do to protect nurses from Zika[EB/OL]. . <a href="https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika">https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[100]</div><div class="csl-right-inline">News From Science. These frogs walk instead of hop. https://scimag.2KlriwH[J]. Facebook. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[101]</div><div class="csl-right-inline">Oregan Youth Authority. Recidivism outcomes[J].2011.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[102]</div><div class="csl-right-inline">O’Shea, M. Understanding proactive behavior in the workplace as a function of gender[J]. Department of Management, University of Kansas: 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[103]</div><div class="csl-right-inline">Pachur, T., Scheibehenne, B. Unpacking buyer-seller differences in valuation from experience: A cognitive modeling approach[J]. Psychonomic Bulletin &#38; Review. .</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[104]</div><div class="csl-right-inline">Pearson, J. Fat talk and its effects on state-based body image in women[J]. Sydney, NSW, Australia: 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[105]</div><div class="csl-right-inline">Perkins, D. <i>The good place</i> ends its remarkable second season with irrational hope, unexpected gifts, and a smile[EB/OL]. (2018-02-01) . <a href="https://www.avclub.com/the-good-place-ends-its-remarkable-second-season-with-i-1822649316">https://www.avclub.com/the-good-place-ends-its-remarkable-second-season-with-i-1822649316</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[106]</div><div class="csl-right-inline">Pew Research Center. American trends panel Wave 26[J].2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[107]</div><div class="csl-right-inline">Piaget, J. Intellectual evolution from adolescence to adulthood[J]. Bliss, J., 译, Furth, H., 译. Human Development. 1972, 15(1): 1-12.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[108]</div><div class="csl-right-inline">Piaget, J., Inhelder, B. The psychology of the child[M].Quadrige, 1966.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[109]</div><div class="csl-right-inline">Piaget, J., Inhelder, B. The psychology of the child[M]. Weaver, H., 译. 2 edn.Basic Books, 1969.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[110]</div><div class="csl-right-inline">Project Implicit. Gender-Science IAT[J].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[111]</div><div class="csl-right-inline">Rinaldi, J. Photograph series of a boy who finds his footing after abuse by those he trusted[M].2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[112]</div><div class="csl-right-inline">Rossman, J., Palmer, R. Sorting through our space junk[M].2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[113]</div><div class="csl-right-inline">Rowling, J.K. Harry Potter and the sorceror’s stone[M].Pottermore Publishing, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[114]</div><div class="csl-right-inline">Sacchett, C., Humphreys, G.W. Calling a squirrel and squirrel but a canoe a wigwam: A category-specific deficit for artefactual objects and body parts[J]. Cognitive Neuropsychology. 1992, 9(1): 73-86.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[115]</div><div class="csl-right-inline">Sacchett, C., Humphreys, G.W. Calling a squirrel and squirrel but a canoe a wigwam: A category-specific deficit for artefactual objects and body parts[G]// Balota, D.A., Marsh, E.J. Cognitive psychology: Key readings in cognition. Psychology Press, 2004: 100-108.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[116]</div><div class="csl-right-inline">Santos, F. Reframing refugee children’s stories[J]. The New York Times. 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[117]</div><div class="csl-right-inline">Segaert, A., Bauer, A. The extent and nature of veteran homelessness in Canada[R].Employment and Social Development Canada, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[118]</div><div class="csl-right-inline">Shakespeare, W. Much ado about nothing[M]. Mowat, B.A., Werstine, P. Washington Square Press, 1995.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[119]</div><div class="csl-right-inline">Shore, M.F. Marking time in the land of plenty: Reflections on mental health in the United States[J]. American Journal of Orthopsychiatry. 2014, 84(6): 611-618.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[120]</div><div class="csl-right-inline">Smithsonian’s National Zoo and Conservation Biology Institute. Home[EB/OL]. Facebook. [2019-07-22] . <a href="https://www.facebookcom/nationalzoo">https://www.facebookcom/nationalzoo</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[121]</div><div class="csl-right-inline">SR Research. Eyelink 1000 plus[J].2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[122]</div><div class="csl-right-inline">Stults-Kolehmainen, M.A., Sinha, R. The effects of stress on physical activity and exercise[J].PubMed Central, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[123]</div><div class="csl-right-inline">Tactile Labs. Latero tactile display[J].2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[124]</div><div class="csl-right-inline">Tafoya, N., Del Vecchio, A. Back to the future: An examination of the Native American Holocaust experience[G]// McGoldrick, M., Giordano, J., Garcia-Preto, N. 3 edn.Ethnicity and family therapy. Guilford Press, 2005: 55-63.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[125]</div><div class="csl-right-inline">Tellegen, A., Ben-Porath, Y.S. Minnesota Multiphasic Personality Inventory-2 Restructured Form (MMPI-2-RF): Technical Manual[R].Pearson, 2011.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[126]</div><div class="csl-right-inline">The New York Public Library [@nypl]. The raven[J]. Instagram. .</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[127]</div><div class="csl-right-inline">U.S. Census Bureau. U.S. and world population clock[EB/OL]. U.S. Department of Commerce. [2019-07-03] . <a href="https://www.census.gov/popclock/">https://www.census.gov/popclock/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[128]</div><div class="csl-right-inline">U.S. Food and Drug Administration. FDA authorizes first interoperable insulin pup intended to allow patients to customize treatment through their individual diabetes management devices[R].U.S. Food and Drug Administration, 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[129]</div><div class="csl-right-inline">U.S. Securities and Exchange Commission. Agency financial report: Fiscal Year 2017[R].2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[130]</div><div class="csl-right-inline">Vedantam, S. Hidden brain[J].NPR, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[131]</div><div class="csl-right-inline">Weinstock, R., Leong, G.B., Silva, J.A. Defining forensic psychiatry: Roles and responsibilities[G]// Rosner, R. 2 edn.Principles and practise of forensic psychiatry. CRC Press, 2003: 7-13.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[132]</div><div class="csl-right-inline">Weir, K. Forgiveness can improve mental and physical health[J]. Monitor on Psychology. 2017, 48(1): 30.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[133]</div><div class="csl-right-inline">White, B. I treasure every minute we spent together #koko [image attached][J]. Twitter. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[134]</div><div class="csl-right-inline">Wood, G. American gothic[M].1930.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[135]</div><div class="csl-right-inline">World Health Organization. Questions and answers on immunization and vaccine safety[EB/OL]. (2018-03) . <a href="https://www.who.int/features/qa/84/en/">https://www.who.int/features/qa/84/en/</a>.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[136]</div><div class="csl-right-inline">World Health Organization. International statistical classification of diseases and related health problems[R]. 11 edn.World Health Organization, 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[137]</div><div class="csl-right-inline">Yoo, J., Miyamoto, Y., Rigotti, A., Ryff, C. Linking positive affect to blood lipids: A cultural perspective[J]. Department of Psychology, University of Wisconsin-Madison: 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[138]</div><div class="csl-right-inline">Yousafzai, M. We are displaced: My journey and stories from refugee girls around the world[M].2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[139]</div><div class="csl-right-inline">Zeitz MOCAA [@zeitzmocaa]. Grade 6 learners from Parkfields Primary School in Hanover Park visited the museum for a tour and workshop hosted by[J]. Instagram. 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[140]</div><div class="csl-right-inline">Brown v. Board of Education[M]. U.S. 1954, 347: 483.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[141]</div><div class="csl-right-inline">88-352, Civil Rights Act of 1964[S]. Stat. , 78: 241.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[142]</div><div class="csl-right-inline">Patsy Mink Equal Opportunity in Education Act[S]. U.S.C , 20.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[143]</div><div class="csl-right-inline">Brain and intelligence: The ecology of child development[M]. Richardson, F. National Educational Press, 1973: 113-123.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[144]</div><div class="csl-right-inline">One flew over the cuckoo’s nest[M].United Artists, 1975.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[145]</div><div class="csl-right-inline">Tarasoff v. Regents of the University of California[M]. Cal.3d. 1976, 17: 425.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[146]</div><div class="csl-right-inline">Marking time in the land of plenty: Reflections on mental health in the United States[J]. American Journal of Orthopsychiatry. 1981, 51(3): 391-402.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[147]</div><div class="csl-right-inline">Durflinger v. Artiles[M]. F.Supp. 1984, 563: 332.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[148]</div><div class="csl-right-inline">Goodbye children[M].Nouvelles Éditions de Films, 1987.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[149]</div><div class="csl-right-inline">United nations convention on the rights of the child[J].1989.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[150]</div><div class="csl-right-inline">American With Disabilities Act of 1990[S]. U.S.C , 42.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[151]</div><div class="csl-right-inline">Daubert v. Merrell Dow Pharmaceuticals, Inc.[M]. F.2d. 1991, 951: 1128.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[152]</div><div class="csl-right-inline">Texas v. Morales[M]. S.W.2d. 1992, 826: 201.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[153]</div><div class="csl-right-inline">Who shot Mr. Burns? (Part One)[J]. The Simpsons. Gracie Films; Twentieth Century Fox Film Corporation, 1995.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[154]</div><div class="csl-right-inline">The complete social scientist: A Kurt Lewin reader[M]. Gold, M. American Psychological Association, 1999.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[155]</div><div class="csl-right-inline">Burriola v. Greater Toledo YMCA[M]. F.Supp.2d. 2001, 133: 1034.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[156]</div><div class="csl-right-inline">The lord of the rings: The fellowship of the ring[M].WingNut Films; The Saul Zaentz Company, 2001.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[157]</div><div class="csl-right-inline">The wire[J].Blown Deadline Productions; HBO, 2002–2008.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[158]</div><div class="csl-right-inline">The Qur’an[M]. Abdel Haleem, M. A. S., 译. Oxford University Press, 2004.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[159]</div><div class="csl-right-inline">Florida Mental Health Act[S]. Fla. Stat.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[160]</div><div class="csl-right-inline">111-2, Lilly Leadbetter Fair Play Act of 2009[S]. Stat. , 123: 5.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[161]</div><div class="csl-right-inline">Protection of human subjects[J]. C.F.R. 2009, 45.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[162]</div><div class="csl-right-inline">The Brandenburg concertos: Concertos BVW 1043 &#38; 1060[M].Decca, 2010Bach, J. S.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[163]</div><div class="csl-right-inline">Symphony No. 3 in E-flat major[M]. Beethoven: Complete Symphonies. Brilliant Classics, 2012van Beethoven, L.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[164]</div><div class="csl-right-inline">Brené Brown: Listening to shame[M].YouTube, 2012.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[165]</div><div class="csl-right-inline">H.R. 1100, Mental Health on Campus Improvement Act[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[166]</div><div class="csl-right-inline">Exec. Order No. 13,676[J]. C.F.R. 2014, 3: 294.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[167]</div><div class="csl-right-inline">Strengthening the federal student loan program for borrowers: Hearing before the U.S. Senate Committee on Health, Education, Labor &#38; Pensions[J].2014.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[168]</div><div class="csl-right-inline">Every Student Succeeds Act[S]. U.S.C , 20.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[169]</div><div class="csl-right-inline">H.R. Rep. No. 114-358[R].2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[170]</div><div class="csl-right-inline">Obergefell v. Hodges[M]. U.S. 2015, 576.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[171]</div><div class="csl-right-inline">The Torah: The five books of Moses[M]. 3 edn.The Jewish Publication Society, 2015.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[172]</div><div class="csl-right-inline">Federal real property reform: How cutting red tape and better management count achieve billions in savings, U.S. Senate Committee on Homeland Security and Governmental Affairs[J].2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[173]</div><div class="csl-right-inline">S. Res. 438[S]. Cong. Rec. , 162: 2394.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[174]</div><div class="csl-right-inline">The year we thought about love[M].2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[175]</div><div class="csl-right-inline">Defining and delimiting the exemptions for executive, administrative, professional, outside sales and computer employees[S]. F.R. , 81: 32391.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[176]</div><div class="csl-right-inline">How to diagram a sentence (absolute basics)[M].YouTube, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[177]</div><div class="csl-right-inline">How do geckos walk on water?[M].YouTube, 2016.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[178]</div><div class="csl-right-inline">Accelerated experiental dynamic psychotherapy (AEDP) supervision[M].American Pychological Association, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[179]</div><div class="csl-right-inline">Entrenchment and the psychology of language learning: How we reorganize and adapt linguistic knowledge[M]. Schmid, H.J. American Psychological Association; De Gruyter Mouton, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[180]</div><div class="csl-right-inline">King James Bible[M].King James Bible Online, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[181]</div><div class="csl-right-inline">Military veteran psychological health and social care: Contemporary approaches[M]. Hacker Hughes, J. Routledge, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[182]</div><div class="csl-right-inline">Lemons[J]. Black-ish. Wilmore Films; Artists First; Cinema Gypsy Productions; ABC Studios, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[183]</div><div class="csl-right-inline">Happiness[M].Vimeo, 2017.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[184]</div><div class="csl-right-inline">American psychologist[J]. McDaniel, S.H., Salas, E., Kazak, A.E. 2018, 73(4).</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[185]</div><div class="csl-right-inline">APA handbook of the psychology of women[M]. Travis, C.B., White, J.W. American Psychological Association, 2018, 1.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[186]</div><div class="csl-right-inline">Archives of scientific psychology[J]. Lilienfeld, S.O. 2018, 6(1): 51-104.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[187]</div><div class="csl-right-inline">Evaluating adverse drug effects[M].American Psychiatric Association, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[188]</div><div class="csl-right-inline">Guided participation in pediatric nursing practice: Relationship-based teaching and learning with parents, children and adolescents[M]. Pridham, K.F., Limbo, R., Schroeder, M. Springer Publishing Company, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[189]</div><div class="csl-right-inline">Somewhere else[J].2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[190]</div><div class="csl-right-inline">Why you should make useless things[M].TED Conferences, 2018.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[191]</div><div class="csl-right-inline">The Stanford encyclopedia of philosophy[M]. Zalta, E.N. Summer 2019 ed. edn.Stanford University, 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[192]</div><div class="csl-right-inline">List of oldest companies[J]. Wikipedia. 2019.</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[193]</div><div class="csl-right-inline">S.C. Const. art. XI, § 3[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[194]</div><div class="csl-right-inline">U.N. Charter art. 1, para. 3[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[195]</div><div class="csl-right-inline">U.S. Const. amend. I-X[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[196]</div><div class="csl-right-inline">U.S. Const. amend. XIX[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[197]</div><div class="csl-right-inline">U.S. Const. amend. XVIII (repealed 1933)[S].</div>
+  </div>
+  <div class="csl-entry">
+    <div class="csl-left-margin">[198]</div><div class="csl-right-inline">U.S. Const. art. I, § 3[S].</div>
+  </div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->

--- a/src/兰州大学-资源环境学院/items.json
+++ b/src/兰州大学-资源环境学院/items.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "zh-two-authors",
+    "type": "article-journal",
+    "language": "zh-CN",
+    "title": "中文双作者测试文献",
+    "author": [
+      {
+        "family": "张",
+        "given": "明"
+      },
+      {
+        "family": "王",
+        "given": "辉"
+      }
+    ],
+    "container-title": "测试期刊",
+    "issued": {
+      "date-parts": [[2010]]
+    },
+    "volume": "1",
+    "issue": "1",
+    "page": "1-10"
+  },
+  {
+    "id": "zh-three-authors",
+    "type": "article-journal",
+    "language": "zh-CN",
+    "title": "中文三作者测试文献",
+    "author": [
+      {
+        "family": "张",
+        "given": "明"
+      },
+      {
+        "family": "王",
+        "given": "辉"
+      },
+      {
+        "family": "李",
+        "given": "强"
+      }
+    ],
+    "container-title": "测试期刊",
+    "issued": {
+      "date-parts": [[2011]]
+    },
+    "volume": "2",
+    "issue": "1",
+    "page": "11-20"
+  },
+  {
+    "id": "en-two-authors",
+    "type": "article-journal",
+    "language": "en-US",
+    "title": "English two-author test article",
+    "author": [
+      {
+        "family": "Smith",
+        "given": "John"
+      },
+      {
+        "family": "Jones",
+        "given": "David"
+      }
+    ],
+    "container-title": "Test Journal",
+    "issued": {
+      "date-parts": [[2012]]
+    },
+    "volume": "3",
+    "issue": "1",
+    "page": "21-30"
+  },
+  {
+    "id": "en-three-authors",
+    "type": "article-journal",
+    "language": "en-US",
+    "title": "English three-author test article",
+    "author": [
+      {
+        "family": "Smith",
+        "given": "John"
+      },
+      {
+        "family": "Jones",
+        "given": "David"
+      },
+      {
+        "family": "Brown",
+        "given": "Michael"
+      }
+    ],
+    "container-title": "Test Journal",
+    "issued": {
+      "date-parts": [[2013]]
+    },
+    "volume": "4",
+    "issue": "1",
+    "page": "31-40"
+  }
+]

--- a/src/兰州大学-资源环境学院/metadata.json
+++ b/src/兰州大学-资源环境学院/metadata.json
@@ -1,0 +1,30 @@
+{
+  "dir": "兰州大学-资源环境学院",
+  "file": "兰州大学-资源环境学院.csl",
+  "style_class": "in-text",
+  "title": "兰州大学（作者年份-文末编号）",
+  "id": "https://zotero-chinese.com/styles/lanzhou-university-author-date-numbered-bibliography",
+  "link_self": "https://zotero-chinese.com/styles/lanzhou-university-author-date-numbered-bibliography",
+  "link_template": "https://zotero-chinese.com/styles/GB-T-7714—2005（顺序编码，双语）",
+  "link_documentation": "https://ge.lzu.edu.cn/yjsxw/upload/files/20230404/61cd8e5356084aa28c55ed238ba871bc.pdf",
+  "author": [
+    {
+      "name": "韩小土"
+    }
+  ],
+  "contributor": [],
+  "citation_format": "author-date",
+  "field": "generic-base",
+  "summary": "在兰州大学 CSL 样式基础上修改：正文采用作者-年份引用；文末按作者拼写排序并保留序号；正文三名及以上作者显示首作者 et al.；文末列出全部作者。",
+  "updated": "2026-07-02T21:40:00+08:00",
+  "citations": "(Smith et al., 2013)<br>\n(Smith and Jones, 2012)<br>\n(张明等，2011）<br>\n(张明和王辉，2010）<br>\n",
+  "bibliography": "<div class=\"csl-bib-body maxoffset-3 second-field-align-flush hangingindent-false\">\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[1]</div><div class=\"csl-right-inline\">Smith, J., Jones, D. English two-author test article[J]. Test Journal. 2012, 3(1): 21-30.</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[2]</div><div class=\"csl-right-inline\">Smith, J., Jones, D., Brown, M. English three-author test article[J]. Test Journal. 2013, 4(1): 31-40.</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[3]</div><div class=\"csl-right-inline\">张明, 王辉. 中文双作者测试文献[J]. 测试期刊. 2010, 1(1): 1-10.</div>\n  </div>\n  <div class=\"csl-entry\">\n    <div class=\"csl-left-margin\">[4]</div><div class=\"csl-right-inline\">张明, 王辉, 李强. 中文三作者测试文献[J]. 测试期刊. 2011, 2(1): 11-20.</div>\n  </div>\n</div>",
+  "tags": [
+    "姓名小写",
+    "有标题",
+    "期刊全称",
+    "无URL",
+    "无DOI",
+    "无英文翻译"
+  ]
+}

--- a/src/兰州大学-资源环境学院/兰州大学-资源环境学院.csl
+++ b/src/兰州大学-资源环境学院/兰州大学-资源环境学院.csl
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" initialize-with-hyphen="false" demote-non-dropping-particle="sort-only" sort-separator=", " default-locale="en-US">
+  <info>
+    <title>兰州大学（作者年份-文末编号）</title>
+    <title-short>Lanzhou University Author-Date Numbered Bibliography</title-short>
+    <id>https://zotero-chinese.com/styles/lanzhou-university-author-date-numbered-bibliography</id>
+    <link href="https://zotero-chinese.com/styles/lanzhou-university-author-date-numbered-bibliography" rel="self"/>
+    <link href="https://zotero-chinese.com/styles/GB-T-7714—2005（顺序编码，双语）" rel="template"/>
+    <link href="https://ge.lzu.edu.cn/yjsxw/upload/files/20230404/61cd8e5356084aa28c55ed238ba871bc.pdf" rel="documentation"/>
+    <author>
+      <name>韩小土</name>
+      <email>redleafnew@163.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <summary>在兰州大学 CSL 样式基础上修改：正文采用作者-年份引用；文末按作者拼写排序并保留序号；正文三名及以上作者显示首作者 et al.；文末列出全部作者。</summary>
+    <updated>2026-07-02T21:40:00+08:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="and">and</term>
+      <term name="et-al">et al.</term>
+      <term name="edition"> %s edn.</term>
+    </terms>
+  </locale>
+  <locale xml:lang="zh">
+    <terms>
+      <term name="and">和</term>
+      <term name="et-al">等</term>
+      <term name="edition">第%s版</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+    </terms>
+  </locale>
+  <locale>
+    <terms>
+      <term name="edition">第%s版</term>
+      <term name="citation-range-delimiter">-</term>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name initialize-with="." name-as-sort-order="all" delimiter=", ">
+        <name-part name="family" text-case="capitalize-first"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="trailing-contributor">
+    <names variable="recipient">
+      <name name-as-sort-order="all" delimiter=", "/>
+      <label form="short" prefix=", " text-case="lowercase"/>
+      <substitute>
+        <names variable="interviewer"/>
+        <names variable="composer"/>
+        <names variable="original-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title">
+    <text variable="title"/>
+  </macro>
+  <macro name="titleField">
+    <choose>
+      <if type="report">
+        <text macro="title"/>
+      </if>
+      <else-if type="thesis">
+        <text macro="title"/>
+      </else-if>
+      <else-if type="bill legislation standard" match="any">
+        <group delimiter=", ">
+          <number variable="number"/>
+          <text macro="title"/>
+        </group>
+      </else-if>
+      <else-if type="book graphic legal_case motion_picture song" match="any">
+        <text macro="title"/>
+      </else-if>
+      <else-if type="paper-conference">
+        <text macro="title"/>
+      </else-if>
+      <else-if type="chapter">
+        <text macro="title"/>
+      </else-if>
+      <else-if type="webpage">
+        <text macro="title"/>
+      </else-if>
+      <else-if type="patent">
+        <text macro="title"/>
+        <number variable="number" prefix=": 中国, "/>
+      </else-if>
+      <else>
+        <text macro="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="titleFieldSuffix">
+    <choose>
+      <if type="report">
+        <text value="[R]."/>
+      </if>
+      <else-if type="thesis">
+        <text value="[D]."/>
+      </else-if>
+      <else-if type="bill legislation standard" match="any">
+        <text value="[S]"/>
+      </else-if>
+      <else-if type="book graphic legal_case motion_picture song" match="any">
+        <text value="[M]."/>
+      </else-if>
+      <else-if type="paper-conference">
+        <text value="[A]."/>
+      </else-if>
+      <else-if type="chapter">
+        <text value="[G]//"/>
+      </else-if>
+      <else-if type="webpage">
+        <text value="[EB/OL]."/>
+      </else-if>
+      <else-if type="patent">
+        <text value="[P]."/>
+      </else-if>
+      <else>
+        <text value="[J]."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="secondaryAuthor">
+    <names variable="editor">
+      <name initialize-with="." name-as-sort-order="all" delimiter=", ">
+        <name-part name="family" text-case="capitalize-first"/>
+      </name>
+    </names>
+    <names variable="translator">
+      <name name-as-sort-order="all" delimiter=", " suffix=", 译"/>
+    </names>
+  </macro>
+  <macro name="publisherMain">
+    <choose>
+      <if type="chapter">
+        <text variable="container-title" suffix=". "/>
+      </if>
+      <else-if type="paper-conference">
+        <text variable="container-title" prefix=" " suffix="[C]. "/>
+      </else-if>
+      <else-if type="report">
+        <group delimiter=", ">
+          <text variable="collection-title"/>
+          <number variable="number" suffix=", "/>
+        </group>
+      </else-if>
+      <else-if type="bill legislation standard" match="any">
+        <text variable="container-title" prefix=". "/>
+      </else-if>
+      <else>
+        <text variable="container-title" prefix=" " suffix=". "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisherSupp">
+    <text variable="publisher-place" prefix=" " suffix=": "/>
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <choose>
+        <if type="webpage" variable="container-title" match="all">
+          <date variable="issued" suffix=". ">
+            <date-part name="year"/>
+            <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
+            <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
+          </date>
+        </if>
+        <else-if type="webpage"/>
+        <else-if type="patent">
+          <date variable="issued">
+            <date-part name="year"/>
+            <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
+            <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
+          </date>
+        </else-if>
+        <else-if variable="publisher">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </else-if>
+        <else-if type="bill legislation standard" match="any"/>
+        <else>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </else>
+      </choose>
+    </group>
+    <group>
+      <number variable="volume" prefix=", "/>
+      <number variable="issue" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <macro name="pageField">
+    <number variable="page"/>
+  </macro>
+  <macro name="referenceDate">
+    <choose>
+      <if type="webpage">
+        <date variable="issued" prefix="(" suffix=")">
+          <date-part name="year"/>
+          <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
+          <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
+        </date>
+        <date variable="accessed" prefix="[" suffix="]">
+          <date-part name="year"/>
+          <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
+          <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
+        </date>
+      </if>
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="doi:"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="entry-layout-zh">
+    <group delimiter=" ">
+      <group>
+        <group delimiter=" ">
+          <text macro="author" suffix=". "/>
+          <group>
+            <choose>
+              <if type="bill chapter legislation paper-conference standard" match="any">
+                <group>
+                  <text macro="titleField"/>
+                  <text macro="titleFieldSuffix"/>
+                </group>
+              </if>
+            </choose>
+            <group>
+              <choose>
+                <if type="bill chapter legislation paper-conference standard" match="any"/>
+                <else>
+                  <group>
+                    <text macro="titleField"/>
+                    <text macro="titleFieldSuffix"/>
+                  </group>
+                </else>
+              </choose>
+              <text macro="secondaryAuthor" prefix=" " suffix=". "/>
+              <group>
+                <label variable="edition"/>
+                <number variable="edition"/>
+              </group>
+              <group>
+                <text macro="publisherMain"/>
+                <text macro="publisherSupp"/>
+              </group>
+              <choose>
+                <if type="bill legislation standard" match="any"/>
+                <else>
+                  <text macro="pageField" prefix=": "/>
+                </else>
+              </choose>
+            </group>
+            <choose>
+              <if type="bill legislation standard" match="any">
+                <text macro="pageField" prefix=": "/>
+              </if>
+            </choose>
+          </group>
+        </group>
+        <text macro="referenceDate"/>
+      </group>
+      <choose>
+        <if type="webpage">
+          <text macro="access" prefix=". "/>
+        </if>
+      </choose>
+    </group>
+    <text macro="trailing-contributor"/>
+  </macro>
+  <macro name="entry-layout-en">
+    <group delimiter=" ">
+      <group delimiter=" ">
+        <group delimiter=" ">
+          <text macro="author" suffix=". "/>
+          <group>
+            <choose>
+              <if type="bill chapter legislation paper-conference standard" match="any">
+                <group>
+                  <text macro="titleField"/>
+                  <text macro="titleFieldSuffix"/>
+                </group>
+              </if>
+            </choose>
+            <group>
+              <choose>
+                <if type="bill chapter legislation paper-conference standard" match="any"/>
+                <else>
+                  <group>
+                    <text macro="titleField"/>
+                    <text macro="titleFieldSuffix"/>
+                  </group>
+                </else>
+              </choose>
+              <text macro="secondaryAuthor" prefix=" " suffix=". "/>
+              <number variable="edition"/>
+              <group delimiter=" ">
+                <text macro="publisherMain"/>
+                <text macro="publisherSupp"/>
+              </group>
+              <choose>
+                <if type="bill legislation standard" match="any"/>
+                <else>
+                  <text macro="pageField" prefix=": "/>
+                </else>
+              </choose>
+            </group>
+            <choose>
+              <if type="bill legislation standard" match="any">
+                <text macro="pageField" prefix=": "/>
+              </if>
+            </choose>
+          </group>
+        </group>
+        <text macro="referenceDate"/>
+      </group>
+      <choose>
+        <if type="webpage">
+          <text macro="access" prefix=". "/>
+        </if>
+      </choose>
+    </group>
+    <text macro="trailing-contributor"/>
+  </macro>
+  <macro name="citation-author-en">
+    <names variable="author" et-al-min="3" et-al-use-first="1">
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="citation-author-zh">
+    <names variable="author" et-al-min="3" et-al-use-first="1">
+      <name and="text" delimiter="、" delimiter-precedes-last="never"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="citation-year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
+    <sort>
+      <key macro="citation-author-en"/>
+      <key variable="issued"/>
+    </sort>
+    <layout locale="zh" prefix="（" suffix="）" delimiter="；">
+      <group delimiter="，">
+        <text macro="citation-author-zh"/>
+        <text macro="citation-year"/>
+      </group>
+    </layout>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="citation-author-en"/>
+        <text macro="citation-year"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography second-field-align="flush" entry-spacing="0">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+      <key variable="title"/>
+    </sort>
+    <layout locale="zh">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout-zh" suffix="."/>
+    </layout>
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout-en" suffix="."/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
新增兰州大学作者-年份引用、文末编号参考文献样式。

主要规则：
- 正文采用作者-年份格式
- 中文 2 作者用“和”，3 作者及以上用“等”
- 英文 2 作者用 and，3 作者及以上用 et al.
- 文末参考文献按作者排序，并保留序号
- 文末列出全部作者
- 双语混排依赖 Zotero 条目的 language 字段，中文 zh-CN，英文 en-US

## 新增样式 PR

请按照 [`CONTRIBUTING.md`](https://github.com/zotero-chinese/styles/blob/main/CONTRIBUTING.md) 的要求填组织文件。

- 样式的官网链接：[<https://ge.lzu.edu.cn/xueweishouyu/guizhangzhidu/lunwenguanli/2020/1223/158947.html>]


- 样式的发布日期：2020-12-23

- 请上传一份格式规范文件：

<!-- 将文件拖拽至此处 -->
[格式规范.doc](https://github.com/user-attachments/files/29621142/default.doc)
