### PR TITLE
新增 GB/T 7714—2025 著者-出版年, 页码括号内样式

### DIFF
--- a/src/GB-T-7714—2025（著者-出版年，双语，页码在括号内）/GB-T-7714—2025（著者-出版年，双语，页码在括号内）.csl
+++ b/src/GB-T-7714—2025（著者-出版年，双语，页码在括号内）/GB-T-7714—2025（著者-出版年，双语，页码在括号内）.csl
@@ -1,0 +1,600 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" name-as-sort-order="all" sort-separator=" " initialize-with=" " page-range-format="expanded" default-locale="zh-CN">
+  <info>
+    <title>GB/T 7714—2025（著者-出版年，双语，页码在括号内）</title>
+    <id>https://zotero-chinese.com/styles/GB-T-7714—2025（著者-出版年，双语，页码在括号内）</id>
+    <link href="https://zotero-chinese.com/styles/GB-T-7714—2025（著者-出版年，双语，页码在括号内）" rel="self"/>
+    <link href="https://zotero-chinese.com/styles/GB-T-7714—2025（著者-出版年，双语）" rel="template"/>
+    <link href="https://std.samr.gov.cn/gb/search/gbDetailed?id=4507EFE13D37CB6AE06397BE0A0A601F" rel="documentation"/>
+    <author>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <summary>GB/T 7714—2025 信息与文献 参考文献著录规则（2026-07-01实施）。引注页码显示在括号内。</summary>
+    <updated>2026-07-31T16:06:19+08:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="volume" form="short">v.</term>
+    </terms>
+  </locale>
+  <locale xml:lang="zh">
+    <terms>
+      <term name="and others"> 等</term>
+      <term name="anonymous" form="short">佚名</term>
+      <term name="no date" form="short">无日期</term>
+      <term name="edition" form="short">版</term>
+      <term name="version" form="short">v.</term>
+      <term name="volume" form="short">第%s卷</term> <!-- CSL-M 扩展-->
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+    </terms>
+  </locale>
+  <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+    </date>
+    <terms>
+      <term name="and others">et al.</term>
+      <term name="citation-range-delimiter">-</term> <!-- CSL-M 扩展-->
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <!-- 主要责任者 -->
+  <macro name="author">
+    <names variable="composer">
+      <name delimiter="，"/>
+      <substitute>
+        <names variable="author"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <names variable="host"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+            <names variable="editorial-director"/>
+            <names variable="compiler"/>
+            <names variable="collection-editor"/>
+          </if>
+        </choose>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-intext-en">
+    <names variable="composer">
+      <name form="short" delimiter="，" and="text"/>
+      <substitute>
+        <names variable="author"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <names variable="host"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+            <names variable="editorial-director"/>
+            <names variable="compiler"/>
+            <names variable="collection-editor"/>
+          </if>
+        </choose>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-intext-zh">
+    <names variable="composer">
+      <name delimiter="，" and="text"/>
+      <et-al term="and others"/>
+      <substitute>
+        <names variable="author"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <names variable="host"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+            <names variable="editorial-director"/>
+            <names variable="compiler"/>
+            <names variable="collection-editor"/>
+          </if>
+        </choose>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="anon">
+    <text term="anonymous" form="short" strip-periods="true" text-case="capitalize-first"/>
+  </macro>
+  <macro name="date-intext">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <choose>
+          <if variable="volume issue" match="any">
+            <date variable="issued">
+              <date-part name="year" range-delimiter="&#8212;"/>
+            </date>
+            <text variable="year-suffix"/>
+          </if>
+          <else-if variable="available-date">
+            <date variable="available-date">
+              <date-part name="year" range-delimiter="&#8212;"/>
+            </date>
+            <text variable="year-suffix"/>
+          </else-if>
+          <else>
+            <date variable="issued">
+              <date-part name="year" range-delimiter="&#8212;"/>
+            </date>
+            <text variable="year-suffix"/>
+          </else>
+        </choose>
+      </if>
+      <else-if variable="issued">
+        <date variable="issued">
+          <date-part name="year" range-delimiter="&#8212;"/>
+        </date>
+        <text variable="year-suffix"/>
+      </else-if>
+      <else-if variable="accessed">
+        <group prefix="[" suffix="]">
+          <date variable="accessed">
+            <date-part name="year" range-delimiter="&#8212;"/>
+          </date>
+          <text variable="year-suffix"/>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter="-">
+          <text term="no date" form="short"/>
+          <text variable="year-suffix"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <!-- 题名 -->
+  <macro name="title">
+    <group delimiter=". ">
+      <group delimiter="：">
+        <text variable="title"/>
+        <choose>
+          <if variable="container-title" type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
+            <group delimiter="&#8195;">
+              <text macro="volume"/>
+              <text variable="volume-title"/>
+            </group>
+          </if>
+        </choose>
+        <choose>
+          <if type="article article-journal standard" match="none">
+            <!-- 预印本、期刊文章、标准的编号在其他位置 -->
+            <text macro="number"/>
+          </if>
+        </choose>
+      </group>
+      <choose>
+        <if type="map">
+          <text variable="scale"/>
+        </if>
+      </choose>
+    </group>
+    <group delimiter="/" prefix="[" suffix="]">
+      <text macro="entry-type-id"/>
+      <text macro="entry-medium-id"/>
+    </group>
+  </macro>
+  <!-- 多卷书的卷次 -->
+  <macro name="volume">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper periodical" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <label variable="volume" form="short"/>
+            <text variable="volume"/>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- 报告编号、标准号、专利申请号、档号 -->
+  <macro name="number">
+    <choose>
+      <if type="patent" variable="call-number" match="all">
+        <!-- 专利优先使用申请号 -->
+        <text variable="call-number"/>
+      </if>
+      <else-if variable="number">
+        <text variable="number"/>
+      </else-if>
+      <else-if type="collection manuscript personal_communication" variable="archive" match="any">
+        <!-- 档案的档号 -->
+        <text variable="archive_location"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 文献类型标识 -->
+  <macro name="entry-type-id">
+    <choose>
+      <if type="article">
+        <!-- 预印本 -->
+        <text value="PP"/>
+      </if>
+      <else-if type="article-journal article-magazine periodical" match="any">
+        <text value="J"/>
+      </else-if>
+      <else-if type="article-newspaper">
+        <text value="N"/>
+      </else-if>
+      <else-if type="book chapter classic entry-dictionary entry-encyclopedia" match="any">
+        <text value="M"/>
+      </else-if>
+      <else-if type="collection manuscript personal_communication" match="any">
+        <text value="A"/>
+      </else-if>
+      <else-if type="dataset">
+        <text value="DS"/>
+      </else-if>
+      <else-if type="map">
+        <text value="CM"/>
+      </else-if>
+      <else-if type="paper-conference">
+        <text value="C"/>
+      </else-if>
+      <else-if type="patent">
+        <text value="P"/>
+      </else-if>
+      <else-if type="post post-weblog webpage" match="any">
+        <text value="EB"/>
+      </else-if>
+      <else-if type="report">
+        <text value="R"/>
+      </else-if>
+      <else-if type="software">
+        <text value="CP"/>
+      </else-if>
+      <else-if type="standard">
+        <text value="S"/>
+      </else-if>
+      <else-if type="thesis">
+        <text value="D"/>
+      </else-if>
+      <else-if variable="archive">
+        <text value="A"/>
+      </else-if>
+      <else-if variable="CSTR DOI URL" match="any">
+        <text value="EB"/>
+      </else-if>
+      <else>
+        <text value="Z"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 文献载体标识 -->
+  <macro name="entry-medium-id">
+    <choose>
+      <if variable="medium">
+        <text variable="medium"/>
+      </if>
+      <else-if variable="URL DOI" match="any">
+        <text value="OL"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributors">
+    <names variable="translator">
+      <name delimiter="，"/>
+      <label form="short" prefix="，"/>
+    </names>
+  </macro>
+  <!-- 图书主要责任者 -->
+  <macro name="container-contributors">
+    <names variable="container-author">
+      <name delimiter="，"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler"/>
+        <names variable="collection-editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 图书题名 -->
+  <macro name="container-booklike">
+    <choose>
+      <if variable="container-title">
+        <group delimiter=". ">
+          <text macro="container-contributors"/>
+          <group delimiter="：">
+            <text variable="container-title"/>
+            <text macro="volume"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <!-- 连续出版物中的出处项 -->
+  <macro name="container-periodical">
+    <choose>
+      <if type="article-newspaper">
+        <!-- 报纸的出处项：“刊名，出版日期（版次）：页码” -->
+        <group delimiter="，">
+          <text variable="container-title" strip-periods="true"/>
+          <text macro="date"/>
+        </group>
+        <text variable="page" prefix="（" suffix="）"/>
+      </if>
+      <else>
+        <!-- 期刊、杂志的出处项：“刊名，卷（期）：页码” -->
+        <group delimiter="：">
+          <group>
+            <group delimiter="，">
+              <text variable="container-title" strip-periods="true"/>
+              <choose>
+                <if variable="volume issue" match="none">
+                  <!-- 无卷号和期号，视为在线出版文章，优先使用在线出版日期 -->
+                  <choose>
+                    <if variable="available-date">
+                      <date variable="available-date" form="numeric"/>
+                    </if>
+                    <else>
+                      <date variable="issued" form="numeric"/>
+                    </else>
+                  </choose>
+                </if>
+              </choose>
+              <text variable="volume"/>
+            </group>
+            <text variable="issue" prefix="（" suffix="）"/>
+          </group>
+          <choose>
+            <if variable="page">
+              <text variable="page"/>
+            </if>
+            <else>
+              <!-- 无页码有文章编号的，应将文章编号按页码著录 -->
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <!-- 版本项 -->
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="version">
+    <label variable="version" form="short" text-case="capitalize-first" strip-periods="true"/>
+    <text variable="version"/>
+  </macro>
+  <!-- 7.5 出版信息 7.7 页码 -->
+  <macro name="publisher">
+    <choose>
+      <if type="article dataset" match="any">
+        <text variable="publisher"/>
+      </if>
+      <else-if type="book chapter classic entry-dictionary entry-encyclopedia map paper-conference periodical thesis" variable="publisher" match="any">
+        <group delimiter="：">
+          <group delimiter="：">
+            <text variable="publisher-place"/>
+            <text variable="publisher"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="patent report" match="any">
+        <group delimiter="：">
+          <text macro="date"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="collection manuscript personal_communication" variable="archive" match="any">
+        <!-- 档案中的收藏者所在地、收藏者、形成日期 -->
+        <group delimiter="，">
+          <group delimiter="：">
+            <text variable="archive-place"/>
+            <text variable="archive"/>
+          </group>
+          <text macro="date"/>
+        </group>
+      </else-if>
+      <else-if type="post post-weblog webpage" variable="CSTR DOI URL" match="none">
+        <group delimiter="：">
+          <group delimiter="：">
+            <text variable="publisher-place"/>
+            <text variable="publisher"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 出版日期 -->
+  <macro name="date">
+    <choose>
+      <if variable="issued">
+        <choose>
+          <if type="report" variable="publisher" match="all">
+            <!-- 以图书、图书中的析出文献形式出现的报告 -->
+          </if>
+          <else-if type="article-newspaper collection patent manuscript personal_communication report" variable="archive" match="any">
+            <date variable="issued" form="numeric"/>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- 地图的尺寸 -->
+  <macro name="dimensions">
+    <choose>
+      <if type="map">
+        <text variable="dimensions"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- 7.6 创建/发布日期或修改日期、引用日期 -->
+  <macro name="creation-accessed-date">
+    <date variable="issued" form="numeric" prefix="（" suffix="）"/>
+    <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 7.8 获取和访问路径 7.9 永久标识符 -->
+  <macro name="access">
+    <group delimiter=". ">
+      <text variable="URL"/>
+      <choose>
+        <if variable="CSTR"> <!-- 扩展：CSTR -->
+          <text variable="CSTR" prefix="CSTR:"/>
+        </if>
+        <else>
+          <text variable="DOI" prefix="DOI:"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 参考文献表格式 -->
+  <macro name="entry-layout">
+    <group delimiter=". ">
+      <group delimiter="，">
+        <text macro="author"/>
+        <text macro="date-intext"/>
+      </group>
+      <choose>
+        <if type="article-journal article-magazine article-newspaper" match="any">
+          <!-- 8.5 连续出版物中的析出文献 -->
+          <text macro="title"/>
+          <text macro="secondary-contributors"/>
+          <text macro="container-periodical"/>
+        </if>
+        <else-if type="post post-weblog webpage" match="any">
+          <!-- 8.11 网站和网页 -->
+          <text macro="title"/>
+          <text macro="creation-accessed-date"/>
+        </else-if>
+        <else-if type="chapter entry-dictionary entry-encyclopedia" variable="container-title" match="any">
+          <!-- 8.3 图书中的析出文献或 -->
+          <group delimiter="//">
+            <group delimiter=". ">
+              <text macro="title"/>
+              <text macro="secondary-contributors"/>
+            </group>
+            <text macro="container-booklike"/>
+          </group>
+          <text macro="edition"/>
+          <text macro="publisher"/>
+        </else-if>
+        <else-if type="periodical">
+          <!-- 8.4 连续出版物 -->
+          <text macro="title"/>
+          <text variable="volume"/> <!-- 年卷期或其他标识，如“1957（1）—1990（4）” -->
+          <text macro="publisher"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <!-- 8.6 会议录 -->
+          <group delimiter="//">
+            <group delimiter=". ">
+              <text macro="title"/>
+            </group>
+            <group delimiter="：">
+              <text variable="event-title"/>
+              <text variable="page"/>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="standard">
+          <!-- 8.9 标准 -->
+          <group delimiter="&#8195;">
+            <text variable="number"/>
+            <text macro="title"/>
+          </group>
+        </else-if>
+        <else-if type="article dataset" match="any">
+          <!-- 8.14 数据集、8.15 预印本 -->
+          <text macro="title"/>
+          <text macro="version"/>
+          <group>
+            <text macro="publisher"/>
+            <text macro="creation-accessed-date"/>
+          </group>
+        </else-if>
+        <else-if type="book classic map patent report" variable="publisher" match="any">
+          <!-- 8.2 图书 -->
+          <text macro="title"/>
+          <text macro="secondary-contributors"/>
+          <text macro="edition"/>
+          <text macro="publisher"/>
+          <text macro="dimensions"/>
+        </else-if>
+        <else-if type="collection manuscript personal_communication" variable="archive" match="any">
+          <!-- 8.12 档案 -->
+          <text macro="title"/>
+          <text macro="publisher"/>
+        </else-if>
+        <else-if variable="CSTR DOI URL" match="any">
+          <!-- 其他电子资源 -->
+          <text macro="title"/>
+          <text macro="version"/>
+          <text macro="creation-accessed-date"/>
+        </else-if>
+        <else>
+          <text macro="title"/>
+          <text macro="secondary-contributors"/>
+          <text macro="edition"/>
+          <text macro="publisher"/>
+        </else>
+      </choose>
+      <text macro="access"/>
+    </group>
+  </macro>
+  <citation et-al-min="2" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
+    <sort>
+      <key macro="author-intext-en"/>
+      <key macro="date-intext"/>
+    </sort>
+    <layout prefix="（" suffix="）" delimiter="；" locale="en"> <!-- CSL-M 扩展 -->
+      <group delimiter="，">
+        <text macro="author-intext-en"/>
+        <text macro="date-intext"/>
+        <text variable="locator"/>
+      </group>
+    </layout>
+    <layout prefix="（" suffix="）" delimiter="；">
+      <group delimiter="，">
+        <text macro="author-intext-zh"/>
+        <text macro="date-intext"/>
+        <text variable="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key macro="date-intext"/>
+    </sort>
+    <layout locale="en"> <!-- CSL-M 扩展 -->
+      <text macro="entry-layout" suffix="."/>
+    </layout>
+    <layout>
+      <text macro="entry-layout" suffix="."/>
+    </layout>
+  </bibliography>
+</style>

--- a/src/GB-T-7714—2025（著者-出版年，双语，页码在括号内）/cites.json
+++ b/src/GB-T-7714—2025（著者-出版年，双语，页码在括号内）/cites.json
@@ -1,0 +1,32 @@
+[
+	[
+		{
+			"id": "cps.2.1:1",
+			"label": "page",
+			"locator": "42"
+		}
+	],
+	[
+		{
+			"id": "cps.2.1:1",
+			"label": "page",
+			"locator": "42",
+			"mode": "composite"
+		}
+	],
+	[
+		{
+			"id": "cps.2.1:2",
+			"label": "page",
+			"locator": "42"
+		}
+	],
+	[
+		{
+			"id": "cps.2.1:2",
+			"label": "page",
+			"locator": "42",
+			"mode": "composite"
+		}
+	]
+]

--- a/src/GB-T-7714—2025（著者-出版年，双语，页码在括号内）/index.md
+++ b/src/GB-T-7714—2025（著者-出版年，双语，页码在括号内）/index.md
@@ -1,0 +1,604 @@
+<!-- 此文件由脚本自动生成，请勿手动修改！ -->
+<!-- markdownlint-disable -->
+<!-- prettier-ignore -->
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE FILE -->
+
+## 样式预览
+
+### 引注
+
+（张三，2008，42）<br>
+张三 （2008，42）<br>
+（Jason，2008，42）<br>
+Jason （2008，42）<br>
+
+
+### 参考文献表
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-true">
+  <div class="csl-entry">张三，2008. 引注测试 2.1:1[M].</div>
+  <div class="csl-entry">Jason J，2008. Citation test 2.1:2[M].</div>
+</div>
+
+## 默认测试
+
+### 引注
+
+（张三，2008，42）<br>
+张三 （2008，42）<br>
+（Jason，2008，42）<br>
+Jason （2008，42）<br>
+张三 等 （2008a）<br>
+Wang et al. （2009a）<br>
+（赵一 等，2008a；Wolchik et al.，2009a）<br>
+张三 等 （2008b）<br>
+Wang et al. （2009b）<br>
+（赵一 等，2008b；Wolchik et al.，2009b）<br>
+张三 等 （2019a）<br>
+张三 等 （2019b）<br>
+Qian et al. （2020a）<br>
+Qian et al. （2020b）<br>
+（张三 等，2019a；Qian et al.，2020a）<br>
+张三 等 （2020a）<br>
+张三 等 （2020b）<br>
+Qian et al. （2009a）<br>
+Qian et al. （2009b）<br>
+（张三 等，2020a）<br>
+（Qian et al.，2009a）<br>
+（Wong，2007）<br>
+（Wong，2008）<br>
+（Edeline et al.，2002a, 2002b, 2005, n.d.）<br>
+（Bai，2002；Chen，2006；Deng et al.，2005）<br>
+
+
+### GB/T 7714—2025 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-true">
+  <div class="csl-entry">阿扬，2023. 谈谈记忆：与诺贝尔获奖得者埃里克·坎德尔的问答[M]. 姜海伦，译//《环球科学》杂志社. 认识记忆力：关于学习、思考与遗忘的脑科学. 北京：机械工业出版社：15-18.</div>
+  <div class="csl-entry">北京鲁迅博物馆，2021. 北京鲁迅博物馆志愿服务章程[EB/OL]. （2021-04-21）[2023-05-02]. <a href="http://www.luxunmuseum.com.cn/html/202104/a11310.htm">http://www.luxunmuseum.com.cn/html/202104/a11310.htm</a>.</div>
+  <div class="csl-entry">博伯尔，2023. 银行业的未来与人工智能[M]. 徐超，译. 北京：清华大学出版社：35.</div>
+  <div class="csl-entry">曹凌，2011. 中国佛教疑伪经综录[M]. 上海：上海古籍出版社：19.</div>
+  <div class="csl-entry">陈登原，2000. 国史旧闻：第1卷[M]. 北京：中华书局：29.</div>
+  <div class="csl-entry">陈建军，2010. 从数字地球到智慧地球[J/OL]. 国土资源导刊，7（10）：93. <a href="http://d.g.wanfangdata.com.cn/Periodical_hunandz201010038.aspx">http://d.g.wanfangdata.com.cn/Periodical_hunandz201010038.aspx</a>. DOI:<a href="https://doi.org/10.3969/j.issn.1672-5603.2010.10.038">10.3969/j.issn.1672-5603.2010.10.038</a>.</div>
+  <div class="csl-entry">陈晋镳，张惠民，朱士兴，等，1980. 蓟县震旦亚界的研究[M]//中国地质科学院天津地质矿产研究所. 中国震旦亚界. 天津：天津科学技术出版社：56-114.</div>
+  <div class="csl-entry">陈缮真，2022. 探索微观世界的无穷奥秘（科技大观）[N/OL]. 人民日报，2022-08-16（17）. <a href="http://paper.people.com.cn/rmrb/html/2022-08/16/nw.D110000renmrb_20220816_3-17.htm">http://paper.people.com.cn/rmrb/html/2022-08/16/nw.D110000renmrb_20220816_3-17.htm</a>.</div>
+  <div class="csl-entry">陈志勇，2011. 中国财税文化价值研究：“中国财税文化国际学术研讨会”论文集[M/OL]. 北京：经济科学出版社. <a href="http://apabi.lib.pku.edu.cn/usp/pku/pub.mvc?pid=book.detail&#38;metaid=m.20110628-BPO-889-0135&#38;cult=CN">http://apabi.lib.pku.edu.cn/usp/pku/pub.mvc?pid=book.detail&#38;metaid=m.20110628-BPO-889-0135&#38;cult=CN</a>.</div>
+  <div class="csl-entry">程根伟，1999. 1998年长江洪水的成因与减灾对策[M]//许厚泽，赵其国. 长江流域洪涝灾害与科技对策. 北京：科学出版社：32-36.</div>
+  <div class="csl-entry">邓一刚，2008. 全智能节电器：CN200610171314.3[P]. 2008-01-16：8-9.</div>
+  <div class="csl-entry">丁文详，2000. 数字革命与竞争国际化[N]. 中国青年报，2000-11-20（15）.</div>
+  <div class="csl-entry">方向明，曹迎杰，2023. 元宇宙在图书馆的应用：理论研究与实践进展[PP/OL]. ChinaXiv（2023-03-03）[2024-09-30]. <a href="http://www.chinaxiv.org/abs/202303.00020">http://www.chinaxiv.org/abs/202303.00020</a>. CSTR:32003.36.ChinaXiv.202303.00020.V1.</div>
+  <div class="csl-entry">冯友兰，2008. 冯友兰自选集[M]. 2 版. 北京：首都师范大学出版社：第1版自序.</div>
+  <div class="csl-entry">高等教育文献保障系统，[2025]. 馆际互借与文献传递服务[EB/OL]. [2025-06-21]. <a href="http://home.calis.edu.cn/pages/list.html?id=4101e184-7f64-4798-a5e1-8e37aa6994fc">http://home.calis.edu.cn/pages/list.html?id=4101e184-7f64-4798-a5e1-8e37aa6994fc</a>.</div>
+  <div class="csl-entry">工业和信息化部，2022. GB 18030—2022 信息技术  中文编码字符集[S/OL]. <a href="http://c.gb688.cn/bzgk/gb/showGb?type=online&#38;hcno=A1931A578FE14957104988029B0833D3">http://c.gb688.cn/bzgk/gb/showGb?type=online&#38;hcno=A1931A578FE14957104988029B0833D3</a>.</div>
+  <div class="csl-entry">顾炎武，1980. 昌平山水记；京东考古录[M]. 北京：北京古籍出版社.</div>
+  <div class="csl-entry">国家测绘地理信息局，[2025]. 一带一路经济走廊及其途经城市分布地势图[CM/OL]. <a href="http://ydyl.china.com.cn/2016-10/27/content_39582227.htm">http://ydyl.china.com.cn/2016-10/27/content_39582227.htm</a>.</div>
+  <div class="csl-entry">国家能源局，2020. NB/T 10386—2020 水电工程水温实时监测系统技术规范[S].</div>
+  <div class="csl-entry">哈里森，沃尔德伦，2012. 经济数学与金融数学[M]. 谢远涛，译. 北京：中国人民大学出版社：235-236.</div>
+  <div class="csl-entry">何筱梅，2016. 新媒体时代原生广告的策略与发展研究[D/OL]. 武汉：武汉大学：24-25. <a href="http://paperright.lib.whu.edu.cn/read/pdfindex1.jsp?fid=2f1d8c4e156d9863466de341e4790782">http://paperright.lib.whu.edu.cn/read/pdfindex1.jsp?fid=2f1d8c4e156d9863466de341e4790782</a>.</div>
+  <div class="csl-entry">胡健民，2021. 东南极拉斯曼丘陵地区地质图. 1:25000[CM]. 北京：科学出版社. 128cm×84cm.</div>
+  <div class="csl-entry">湖北省建设厅，1931. 湖北省建设厅关于检发实业部农工矿业团体登记规则的布告、训令及湖北省政府的训令：LS031-001-0001-001[A/OL]. 武汉：湖北省档案馆，1931-11-07. <a href="https://www.hbda.gov.cn/pdf/LS031-001-0001-001.PDF.PDF">https://www.hbda.gov.cn/pdf/LS031-001-0001-001.PDF.PDF</a>.</div>
+  <div class="csl-entry">黄土高原科学数据中心（西北农林科技大学水土保持研究所），2024. 青海省县域教育、卫生发展指标（2001—2022年）[DS/OL]. 国家地球系统科学数据中心-黄土高原分中心（2024-12-25）[2025-07-10]. <a href="https://loess.geodata.cn/data/datadetails.html?dataguid=58691800703558">https://loess.geodata.cn/data/datadetails.html?dataguid=58691800703558</a>. DOI:<a href="https://doi.org/10.12041/geodata.58691800703558.ver1.db">10.12041/geodata.58691800703558.ver1.db</a>.</div>
+  <div class="csl-entry">冀超，2001. 一种荒漠化地区生态植被综合培育种植方法：CN01129210.5[P/OL]. 2001-10-24. <a href="http://211.152.9.47/sipoasp/zlijs/hyjs-yx-new.asp?recid=01129210.5&#38;leixin=0">http://211.152.9.47/sipoasp/zlijs/hyjs-yx-new.asp?recid=01129210.5&#38;leixin=0</a>.</div>
+  <div class="csl-entry">贾东琴，柯平，2011. 面向数字素养的高校图书馆数字服务体系研究[C]//中国图书馆学会. 中国图书馆学会年会论文集：2011年卷. 北京：国家图书馆出版社：45-52.</div>
+  <div class="csl-entry">金燕萍，2020. 社交媒体时代的虚假信息研究[D/OL]. 温州：温州大学：16. <a href="https://d.wanfangdata.com.cn/thesis/D02216281">https://d.wanfangdata.com.cn/thesis/D02216281</a>.</div>
+  <div class="csl-entry">井丽南，2022. 支持状态可编程的SDN交换机关键技术研究[D/OL]. 北京：中国科学院大学：43. <a href="http://dpaper.las.ac.cn/Dpaper/detail/detailNew?paperID=20209289">http://dpaper.las.ac.cn/Dpaper/detail/detailNew?paperID=20209289</a>. CSTR:35001.37.01.33142.20220037.</div>
+  <div class="csl-entry">久保智康，2009. 花枝蝶鸟方镜的镜范：以平安后期的铜镜制作工艺为中心[J]. 顾幼静，译. 东方博物（1）：85-92.</div>
+  <div class="csl-entry">李鸿章，1887. 奏请上海道库洋务外销要款无款可筹仍拨药厘接济事：04-01-35-0399-039[A]. 北京：中国第一历史档案馆，1887.</div>
+  <div class="csl-entry">李华，王昊，康佐，2023. 一种拼接式桥梁模型：CN202222658126.0[P/OL]. 2023-01-03. <a href="http://patentscope2.wipo.int/search/en/detail.jsf?docId=CN390029302&#38;_cid=JP1-MAY1P5-04922-1">http://patentscope2.wipo.int/search/en/detail.jsf?docId=CN390029302&#38;_cid=JP1-MAY1P5-04922-1</a>.</div>
+  <div class="csl-entry">李妍，王莹，2022. 医疗机构保洁人员“一前五后”手卫生干预效果研究[C]//中华预防医学会医院感染控制分会第31次全国医院感染学术年会：2.</div>
+  <div class="csl-entry">李幼平，王莉，2010. 循证医学研究方法：附视频[J/OL]. 中华移植杂志（电子版），4（3）：225-228. <a href="http://www.cqvip.com/Read/Read.aspx?id=36658332">http://www.cqvip.com/Read/Read.aspx?id=36658332</a>.</div>
+  <div class="csl-entry">李约瑟，1991. 题词[M]//苏克福，管成学，邓明鲁. 苏颂与《本草图经》研究. 长春：长春出版社：扉页.</div>
+  <div class="csl-entry">刘时银，郭万钦，许君利，2012. 中国第二次水川编目科学数据：2006-2011[DS/OL]. V1.0. 中国科学院寒区早区环境与工程研究所冰冻圈科学国家重点实验室（2012）[2024-11-25]. <a href="https://data.tpdc.ac.cn/zh-hans/data/f92a4346-a33f-497d-9470-2b357ccb4246/">https://data.tpdc.ac.cn/zh-hans/data/f92a4346-a33f-497d-9470-2b357ccb4246/</a>. DOI:<a href="https://doi.org/10.3972/glacier.001.2013.db">10.3972/glacier.001.2013.db</a>.</div>
+  <div class="csl-entry">刘祥沈，2016. 沈阳市政区图. 1:170000[CM]. 武汉：武汉大学出版社. 138cm×96cm.</div>
+  <div class="csl-entry">楼梦麟，杨燕，2011. 汶川地震基岩地震动特征分析[M/OL]//同济大学土木工程防灾国家重点实验室. 汶川地震震害研究. 上海：同济大学出版社：11-12. <a href="http://apabi.lib.pku.edu.cn/usp/pku/pub.mvc?pid=book.detail&#38;metaid=m.20120406-YPT-889-0010">http://apabi.lib.pku.edu.cn/usp/pku/pub.mvc?pid=book.detail&#38;metaid=m.20120406-YPT-889-0010</a>.</div>
+  <div class="csl-entry">马克思，2013. 政治经济学批判[M]//马克思，恩格斯. 马克思恩格斯全集：第35卷. 2 版. 北京：人民出版社：302.</div>
+  <div class="csl-entry">牛永敢，孔晓，王阳，等，2019. 鼻整形应用解剖学[M]. 北京：人民卫生出版社：65-66.</div>
+  <div class="csl-entry">牛志明，Swingland I R，雷光春，2012. 综合湿地管理：综合湿地管理国际研讨会论文集[M]. 北京：海洋出版社.</div>
+  <div class="csl-entry">彭守璋，2024. 1901—2023年中国1km分辨率逐月降水量数据集[DS/OL]. 西北农林科技大学水土保持研究所（2024-07-19）[2024-11-25]. <a href="https://www.geodata.cn/main/face_science_detail?guid=192891852410344&#38;typeName=face_science">https://www.geodata.cn/main/face_science_detail?guid=192891852410344&#38;typeName=face_science</a>.</div>
+  <div class="csl-entry">钱学森，2001. 创建系统学[M]. 太原：山西科学技术出版社：序2-3.</div>
+  <div class="csl-entry">全国信息技术标准化技术委员会，2016. GB/T 20090.16—2016 信息技术 先进音视频编码 第16部分：广播电视视频[S].</div>
+  <div class="csl-entry">全国信息与文献标准化技术委员会，2021. GB/T 3792—2021 信息与文献 资源描述[S].</div>
+  <div class="csl-entry">石顺祥，许海平，孙艳玲，等，2002. 光折变自适应光外差探测方法：CN01128777.2[P/OL]. 2002-03-06. <a href="http://211.152.9.47/sipoasp/zljs/hyjs-yx-new.asp?recid=01128777.2&#38;leixin=0">http://211.152.9.47/sipoasp/zljs/hyjs-yx-new.asp?recid=01128777.2&#38;leixin=0</a>.</div>
+  <div class="csl-entry">史国华，樊金宇，何益，等，2022. 光コヒーレンス断層拡張現実に基づく手術顕微鏡撮像システム及び方法：JP2021578120A[P/OL]. 2022-09-13. <a href="https://pss-system.cponline.cnipa.gov.cn/documents/detail?prevPageTit=changgui">https://pss-system.cponline.cnipa.gov.cn/documents/detail?prevPageTit=changgui</a>.</div>
+  <div class="csl-entry">谭其骧，1982. 中国历史地图集：第2册[CM]. 北京：地图出版社：6.</div>
+  <div class="csl-entry">汤万金，杨跃翔，刘文，等，2013. 人体安全重要技术标准研制最终报告：7178999X-2006BAK04A10/10.2013[R/OL]. 2013-09-30. <a href="http://www.nstrs.cn/xiangxiBG.aspx?id=41707">http://www.nstrs.cn/xiangxiBG.aspx?id=41707</a>.</div>
+  <div class="csl-entry">童世亨，1926. 京兆直隶图[CM/OL]. 上海：商务印书馆. <a href="http://gdt-lib-whu-edu-cn.vpn.whu.edu.cn:8118/imginfo.html?ty%3Dmap%26id%3D4861">http://gdt-lib-whu-edu-cn.vpn.whu.edu.cn:8118/imginfo.html?ty%3Dmap%26id%3D4861</a>.</div>
+  <div class="csl-entry">図書館用語辞典編集委員会，2004. 最新図書館用語大辭典[M]. 東京：柏書房株式會社：154.</div>
+  <div class="csl-entry">汪学军，2005. 中国农业转基因生物研发进展与安全管理[C]//国家环境保护总局生物安全管理办公室. 中国国家生物安全框架实施国际合作项目研讨会论文集. 北京：中国环境科学出版社：22-25.</div>
+  <div class="csl-entry">王夫之，1865. 宋论[M]. 刻本. 金陵：湘乡曾国荃.</div>
+  <div class="csl-entry">王继民，罗鹏程，赵常煜，等，2025. 人文社会科学数据集检索方法研究的数据集[DS/OL]. V2.2. 北京大学开放研究数据平台（2025-06-11）[2025-07-10]. <a href="http://opendata.pku.edu.cn/dataset.xhtml?persistentId=doi:10.18170/DVN/R96MSN">http://opendata.pku.edu.cn/dataset.xhtml?persistentId=doi:10.18170/DVN/R96MSN</a>.</div>
+  <div class="csl-entry">王利平，王福新，刘洪，2024. 过冷大水滴环境粒径分布模拟方法研究进展[J]. 航空学报，45（增刊1）：730570.</div>
+  <div class="csl-entry">王琦，2022. 融合星载GNSS-R和SAR数据的高时空分辨率土壤湿度反演方法研究[D]. 武汉：武汉大学：87.</div>
+  <div class="csl-entry">吴自银，温珍河，2019. 中国南部海域海底地形图. 1:3000000[CM]. 北京：科学出版社. 100cm×70cm.</div>
+  <div class="csl-entry">肖玲，张雪，王永，2024. 数据要素的统计测算方法探究[PP/OL]. PSSXiv（2024-07-02）[2024-09-30]. <a href="https://zsyyb.cn/abs/202408.01096">https://zsyyb.cn/abs/202408.01096</a>. CSTR:32012.36.PSSXiv.202408.01096.</div>
+  <div class="csl-entry">肖希明，石庆功，刘奕，2024. 民国图书馆学教育的社会贡献[C]//纪念北京大学图书馆学教育100周年研讨会论文集. 北京：北京大学信息管理系：134-147.</div>
+  <div class="csl-entry">徐建委，2025. 历史的起点：《史记》中的时间设置及其意义[J/OL]. 北京大学学报（哲学社会科学版），62（2）：117-127. <a href="https://ncpssd.org/Literature/articleinfo?id=BJDXXBZXSHKXB2025002012&#38;synUpdateType=&#38;type=journalArticle&#38;typename=%E4%B8%AD%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&#38;nav=1&#38;langType=1&#38;pageUrl=https%253A%252F%252Fncpssd.org%252Fjournal%252Fdetails%253Fgch%253D81274X%2526nav%253D1%2526langType%253D1">https://ncpssd.org/Literature/articleinfo?id=BJDXXBZXSHKXB2025002012&#38;synUpdateType=&#38;type=journalArticle&#38;typename=%E4%B8%AD%E6%96%87%E6%9C%9F%E5%88%8A%E6%96%87%E7%AB%A0&#38;nav=1&#38;langType=1&#38;pageUrl=https%253A%252F%252Fncpssd.org%252Fjournal%252Fdetails%253Fgch%253D81274X%2526nav%253D1%2526langType%253D1</a>.</div>
+  <div class="csl-entry">许振超，2025. “好好干，当一个好工人”[EB/OL]. （2025-02-17）[2025-06-22]. <a href="https://cpc.people.com.cn/n1/2025/0217/c443712-40419790.html">https://cpc.people.com.cn/n1/2025/0217/c443712-40419790.html</a>.</div>
+  <div class="csl-entry">扬奎斯特，萨金特，2010. 递归宏观经济理论[M]. 杨斌，王忠玉，陈彦斌，等，译. 2 版. 北京：中国人民大学出版社：798.</div>
+  <div class="csl-entry">杨洪升，2013. 四库馆私家抄校书考略[J]. 文献（1）：56-75.</div>
+  <div class="csl-entry">杨立华，2022. 《庄子》读不懂？看完这一篇“导读”就明白了[EB/OL]. （2022-10-26）[2023-05-02]. <a href="https://www.bilibili.com/video/BV1t84y1B7vv/">https://www.bilibili.com/video/BV1t84y1B7vv/</a>.</div>
+  <div class="csl-entry">佚名，1949. 中国人民解放军武汉市军事管制委员会接管国立武汉大学的文告[A/OL]. 武汉：武汉大学档案馆，1949. <a href="https://archive.whu.edu.cn/index/forwardView/20/51">https://archive.whu.edu.cn/index/forwardView/20/51</a>.</div>
+  <div class="csl-entry">佚名，1962. 康熙字典：巳集上 水部[M]. 影印本. 北京：中华书局：50.</div>
+  <div class="csl-entry">Anon，1979. Public library quarterly[J/OL]. 1979，1（1）—. Philadelphia：Taylor &#38; Francis. <a href="http://www.tandfonline.com/loi/wplq">http://www.tandfonline.com/loi/wplq</a>.</div>
+  <div class="csl-entry">佚名，2011. 周易外传：卷5[M]//王夫之. 船山全书：第1册. 修订版. 长沙：岳麓书社：983-1029.</div>
+  <div class="csl-entry">佚名，2020. 大黄[M]//国家药典委员会. 中华人民共和国药典：一部. 2020版. 北京：中国医药科技出版社：24-25.</div>
+  <div class="csl-entry">Anon，2020. IEEE P802.11ba/D8.0-2020 IEEE approved draft standard for information technology--telecommunications and information exchange between systems local and metropolitan area networks--specific requirements Part 11: wireless LAN Medium Access Control (MAC) and Physical Layer (PHY) specifications amendment 3: wake-up radio operation[S].</div>
+  <div class="csl-entry">Anon，[2020]. Library of Congress[EB/OL]. [2020-06-12]. <a href="https://www.loc.gov/">https://www.loc.gov/</a>.</div>
+  <div class="csl-entry">佚名，2023a. [《昨日之歌》图书封面][EB/OL]. （2023-03-06）[2025-06-22]. <a href="http://www.luxunmuseum.com.cn/uploads/allimg/150813/1-150Q31952110-L.jpg">http://www.luxunmuseum.com.cn/uploads/allimg/150813/1-150Q31952110-L.jpg</a>.</div>
+  <div class="csl-entry">佚名，2023b. 西黄丸[EB/OL]. （2023-10-07）[2025-08-26]. <a href="https://ydz.chp.org.cn/#/item?bookId=1&#38;entryId=1154">https://ydz.chp.org.cn/#/item?bookId=1&#38;entryId=1154</a>.</div>
+  <div class="csl-entry">Anon，2024. Coastal wetlands map of China continent[CM]. Beijing：China Ocean Press：50.</div>
+  <div class="csl-entry">于潇，刘义，柴跃廷，等，2012. 互联网药品可信交易环境中主体资质审核备案模式[J]. 清华大学学报（自然科学版），52（11）：1518-1523.</div>
+  <div class="csl-entry">云南省企业联合会，云南省企业家协会，云南民族新闻文化发展研究院，2009. 改革开放三十年：云南企业家奋斗史[M]. 芒市：德宏民族出版社.</div>
+  <div class="csl-entry">战德臣，张丽杰，2019. 大学计算机：计算思维与信息素养[M]. 3 版. 北京：高等教育出版社.</div>
+  <div class="csl-entry">张伯伟，2002. 全唐五代诗格汇考[M]. 南京：江苏古籍出版社：288.</div>
+  <div class="csl-entry">张凯军，赵永杰，陈朝岗，2013. 轨道火车及高速轨道火车紧急安全制动辅助装置：CN201220158825.2[P]. 2013-03-27.</div>
+  <div class="csl-entry">张群，程志宝，石志飞，2024a. 惯性增强动力吸振器-浮置板轨道低频减振性能研究[J/OL]. 铁道学报，2024-05-09. <a href="http://kns.cnki.net/kcms/detail/11.2104.u.20240507.1737.002.html">http://kns.cnki.net/kcms/detail/11.2104.u.20240507.1737.002.html</a>.</div>
+  <div class="csl-entry">张群，程志宝，石志飞，2024b. 惯性增强动力吸振器-浮置板轨道低频减振性能研究[J]. 铁道学报，46（8）：102-111.</div>
+  <div class="csl-entry">仉尚航，2024. 开放世界中的实体基础模型[EB/OL]. （2024-12-24）[2025-01-02]. <a href="https://www.ppthub.com.cn/view/19309">https://www.ppthub.com.cn/view/19309</a>.</div>
+  <div class="csl-entry">赵学功，2001. 当代美国外交[M/OL]. 北京：社会科学文献出版社. <a href="http://www.cadal.zju.edu.cn/book/trySinglePage/33023884/1">http://www.cadal.zju.edu.cn/book/trySinglePage/33023884/1</a>.</div>
+  <div class="csl-entry">郑涵，于贵瑞，朱先进，等，2018. 2000—2010年中国典型陆地生态系统实际蒸散量和水分利用效率数据[DS/OL]. V1. Science Data Bank（2018）[2025-02-14]. <a href="https://cstr.cn/31253.11.sciencedb.610">https://cstr.cn/31253.11.sciencedb.610</a>.</div>
+  <div class="csl-entry">中工武大设计研究有限公司，2019. 阳新县标准地名图[CM]. 武汉：武汉大学出版社. 97cm×67cm.</div>
+  <div class="csl-entry">中国互联网络信息中心，2012. 第29次中国互联网络发展状况统计报告[R/OL]. 2012-01-16. <a href="https://www.cnnic.net.cn/NMediaFile/old_attach/P020120612484958777344.pdf">https://www.cnnic.net.cn/NMediaFile/old_attach/P020120612484958777344.pdf</a>.</div>
+  <div class="csl-entry">中国科学院文献情报中心，[2025]. 中国科学院科技论文预发布平台[EB/OL]. [2025-03-06]. <a href="https://chinaxiv.org/home.htm">https://chinaxiv.org/home.htm</a>.</div>
+  <div class="csl-entry">中国社会科学院台湾史研究中心，2012. 台湾光复六十五周年暨抗战史实学术研讨会论文集[M]. 北京：九州出版社.</div>
+  <div class="csl-entry">中国图书馆学会，1957—1990. 图书馆学通讯[J]. 1957（1）—1990（4）. 北京：北京图书馆.</div>
+  <div class="csl-entry">中国信息通信研究院，中国电信股份有限公司研究院，中国移动通信研究院，等，2023. 电信业发展白皮书：2023：新时代高质量发展探索[R/OL]. 2023-12-28. <a href="http://www.caict.ac.cn/kxyj/qwfb/bps/202312/P020240326615399026294.pdf">http://www.caict.ac.cn/kxyj/qwfb/bps/202312/P020240326615399026294.pdf</a>.</div>
+  <div class="csl-entry">中国造纸学会，2003. 中国造纸年鉴：2003[M/OL]. 北京：中国轻工业出版社. <a href="http://www.cadal.zju.edu.cn/book/view/25010080">http://www.cadal.zju.edu.cn/book/view/25010080</a>.</div>
+  <div class="csl-entry">中华医学会湖北分会，1984. 临床内科杂志[J]. 1984，1（1）—. 武汉：中华医学会湖北分会.</div>
+  <div class="csl-entry">周壮，李盛阳，吴薇，等，2023. 天宫二号遥感图像自然景物分类数据集[DS/OL]. V1.0. 国家基础学科公共科学数据中心（2023-09-10）[2025-07-15]. <a href="https://www.nbsdc.cn/general/dataLinks/CSTR:16666.11.nbsdc.tfpbwtqf">https://www.nbsdc.cn/general/dataLinks/CSTR:16666.11.nbsdc.tfpbwtqf</a>.</div>
+  <div class="csl-entry">訾冬梅，高秀静，2006. 内蒙古自治区地图册[CM]. 新版. 北京：中国地图出版社.</div>
+  <div class="csl-entry">American Association for the Advancement of Science，1883. Science[J]. 1883，1（1）—. Washington, D.C.：American Association for the Advancement of Science.</div>
+  <div class="csl-entry">American Institute of Aeronautics and Astronautics (AIAA)，2022. AIAA G-136-2022 Guide to lithium battery safety for space applications[S].</div>
+  <div class="csl-entry">António M，Pepper L，2019. Histórias de Portugal: livros caídos[EB/OL]. （2019-07-13）[2025-01-02]. <a href="https://arquivo.pt/wayback/20190905210731/http://publico.pt/2019/07/13/sociedade/noticia/podcast-historias-portugal-cuidadores-1879731">https://arquivo.pt/wayback/20190905210731/http://publico.pt/2019/07/13/sociedade/noticia/podcast-historias-portugal-cuidadores-1879731</a>.</div>
+  <div class="csl-entry">Babu B V，Nagar A，Deep K，et al.，2014. Proceedings of the Second International Conference on Soft Computing for Problem Solving (SocProS 2012), December 28-30, 2012[M]. New Delhi：Springer.</div>
+  <div class="csl-entry">Bevington D，Brown J R，2025. William Shakespeare[EB/OL]. （2025-01-01）[2025-01-03]. <a href="https://www.britannica.com/biography/William-Shakespeare">https://www.britannica.com/biography/William-Shakespeare</a>.</div>
+  <div class="csl-entry">Bloss C S，Wineinger N E，Peters M，et al.，2015. A prospective randomized trial examining health care utilization in individuals using multiple smartphone-enabled biosensors[PP/OL]. bioRxiv（2015-10-28）[2018-07-12]. <a href="https://doi.org/10.1101/029983">https://doi.org/10.1101/029983</a>.</div>
+  <div class="csl-entry">Boobier T，2020. AI and the future of banking[M]. Chichester：John Wiley &#38; Sons：35.</div>
+  <div class="csl-entry">Cairns B R，1965. Infrared spectroscopic studies on solid oxygen[D]. Berkeley：University of California, Berkeley：15.</div>
+  <div class="csl-entry">Calkin D E，Ager A A，Thompson M P，2011. A comparative risk assessment framework for wildland fire management: the 2010 cohesive strategy science report：RMRS-GTR-262[R/OL]. 2011：8-9. <a href="https://www.fs.usda.gov/rm/pubs/rmrs_gtr262.pdf">https://www.fs.usda.gov/rm/pubs/rmrs_gtr262.pdf</a>.</div>
+  <div class="csl-entry">Caplan P，1993. Cataloging internet resources[J]. The Public-Access Computer Systems Review，4（2）：61-66.</div>
+  <div class="csl-entry">Christou A，2024. Improving knowledge graph understanding with contextual views[D/OL]. Ohio：Wright State University：18. <a href="http://rave.ohiolink.edu/etdc/view?acc_num=wright1715878159408301">http://rave.ohiolink.edu/etdc/view?acc_num=wright1715878159408301</a>.</div>
+  <div class="csl-entry">Cribb R，2015. Historical atlas of Indonesia[CM]. Abingdon：Routledge.</div>
+  <div class="csl-entry">Des Marais D J，Strauss H，Summons R E，et al.，1992. Carbon isotope evidence for the stepwise oxidation of the Proterozoic environment[J]. Nature，359：605-609.</div>
+  <div class="csl-entry">Deverell W，Igler D，2013. A companion to California history[M/OL]. New York：John Wiley &#38; Sons：21-22. <a href="https://onlinelibrary.wiley.com/doi/book/10.1002/9781444305036">https://onlinelibrary.wiley.com/doi/book/10.1002/9781444305036</a>.</div>
+  <div class="csl-entry">Fitzwilliam H，1570. [Letter to Bess of Hardwick][A/OL]. 1570-07-28. <a href="https://www.bessofhardwick.org/letter.jsp?letter=25">https://www.bessofhardwick.org/letter.jsp?letter=25</a>.</div>
+  <div class="csl-entry">Fourney M E，1971. Advances in holographic photoelasticity[C]//Gottenberg W G. Symposium on Applications of Holography in Mechanics, August 23-25, 1971, University of Southern California, Los Angeles, California. New York：ASME：17-38.</div>
+  <div class="csl-entry">Frese K S，Katus H A，Meder B，2013. Next-generation sequencing: from understanding biology to personalized medicine[J/OL]. Biology，2（1）：378-398. <a href="http://www.mdpi.com/2079-7737/2/1/378">http://www.mdpi.com/2079-7737/2/1/378</a>. DOI:<a href="https://doi.org/10.3390/biology2010378">10.3390/biology2010378</a>.</div>
+  <div class="csl-entry">IHME，2021. Global Burden of Disease Study 2019 (GBD2019) data resources[DS/OL]. Global Health Data Exchange（2021）[2024-11-25]. <a href="https://ghdx.healthdata.org/gbd-2019">https://ghdx.healthdata.org/gbd-2019</a>.</div>
+  <div class="csl-entry">Institute for Art and Architecture, Academy of Fine Arts Vienna，2023. Wiener Hitze: architecture and storytelling in times of heat[M]. Zürich：Park Books：78.</div>
+  <div class="csl-entry">International Electrotechnical Commission (IEC)，2021. IEC/IEEE 61636-1:2021 Software interface for maintenance information collection and analysis (SIMICA): exchanging test results and session information via the eXtensible Markup Language (XML)[S].</div>
+  <div class="csl-entry">International Organization for Standardization，[2020]. ISO homepage[EB/OL]. [2020-10-06]. <a href="https://www.iso.org/home.html">https://www.iso.org/home.html</a>.</div>
+  <div class="csl-entry">ISO，2016a. ISO/IEC 80079-20-2:2016(en) Explosive atmospheres — Part 20-2: Material characteristics — Combustible dusts test methods[S].</div>
+  <div class="csl-entry">ISO，2016b. ISO/IEC 80079-20-2:2016(fr) Atmosphères explosives — Partie 20-2: Caractéristiques des produits — Méthodes d’essai des poussières combustibles[S].</div>
+  <div class="csl-entry">ISO，2019. ISO 21378:2019 Audit data collection[S].</div>
+  <div class="csl-entry">Jenkins S D，Ruostekoski J，2012. Controlled manipulation of light by cooperative response of atoms in an optical lattice[PP/OL]. V2. arXiv（2012-03-18）[2020-06-24]. <a href="https://doi.org/10.48550/arXiv.1112.6136">https://doi.org/10.48550/arXiv.1112.6136</a>.</div>
+  <div class="csl-entry">Kinchy A，2012. Seeds, sciences, and struggle: the global politics of transgenic crops[M/OL]. Cambridge, Mass.：MIT Press：50. <a href="http://lib.myilibrary.com?ID=381443">http://lib.myilibrary.com?ID=381443</a>.</div>
+  <div class="csl-entry">Myburg A A，Grattapaglia D，Tuskan G A，et al.，2014. The genome of <i>Eucalyptus grandis</i>[J/OL]. Nature，510：356-362. <a href="https://www.nature.com/articles/nature13308.pdf">https://www.nature.com/articles/nature13308.pdf</a>. DOI:<a href="https://doi.org/10.1038/nature13308">10.1038/nature13308</a>.</div>
+  <div class="csl-entry">Park J-R，Tosaka Y，2010. Metadata quality control in digital repositories and collections: criteria, semantics, and mechanisms[J/OL]. Cataloging &#38; Classification Quarterly，48（8）：696-715. <a href="https://www.tandfonline.com/doi/full/10.1080/01639374.2010.508711">https://www.tandfonline.com/doi/full/10.1080/01639374.2010.508711</a>.</div>
+  <div class="csl-entry">Peebles P Z Jr，2001. Probability, random variables, and random signal principles[M]. 4th ed. New York：McGraw-Hill.</div>
+  <div class="csl-entry">Praetzellis A，2011. Death by theory: a tale of mystery and archaeological theory[M/OL]. Rev. ed. Rowman &#38; Littlefield Publishing Group, Inc.：13. <a href="http://lib.myilibrary.com/Open.aspx?id=293666">http://lib.myilibrary.com/Open.aspx?id=293666</a>.</div>
+  <div class="csl-entry">Roberson J A，Burneson E G，2011. Drinking water quality standards, regulations and goals[M/OL]//American Water Works Association. Water quality &#38; treatment: a handbook on drinking water. 6th ed. New York：McGraw-Hill：1.1-1.36. <a href="http://lib.myilibrary.com/Open.aspx?id=291430">http://lib.myilibrary.com/Open.aspx?id=291430</a>.</div>
+  <div class="csl-entry">Sadock B J，Sadock V A，Ruiz P，et al.，2009. Kaplan &#38; Sadock’s comprehensive textbook of psychiatry：v.1[M]. 9th ed. Philadelphia：Wolters Kluwer Health/Lippincott Williams &#38; Wilkins.</div>
+  <div class="csl-entry">Saito M，Miyazaki K，2006. Jadeite-bearing metagabbro in serpentinite melange of the “Kurosegawa Belt” in Izumi Town, Yatsushiro City, Kumamoto Prefecture, central Kyushu[J]. Bulletin of the Geological Survey of Japan，57（5/6）：169-176.</div>
+  <div class="csl-entry">Santer R D，Akanyeti O，2025. Using artificial neural networks to explain the attraction of jewel beetles (Coleoptera: Buprestidae) to colored traps[J/OL]. Insect science，2025. <a href="https://webofscience.clarivate.cn/wos/woscc/full-record/WOS:001398099800001">https://webofscience.clarivate.cn/wos/woscc/full-record/WOS:001398099800001</a>. DOI:<a href="https://doi.org/10.1111/1744-7917.13496">10.1111/1744-7917.13496</a>.</div>
+  <div class="csl-entry">Shinotsuka H，Nagata K，Siriwardana M，et al.，2023. Sample structure prediction from measured XPS data using Bayesian estimation and SESSA simulator[J/OL]. Journal of electron spectroscopy and related phenomena，267：147370. <a href="https://doi.org/10.1016/j.elspec.2023.147370">https://doi.org/10.1016/j.elspec.2023.147370</a>.</div>
+  <div class="csl-entry">Sugarman L，Markham S，1980. Students in a selective high school: some vocationally oriented data[DS/OL]. UK Data Service（1980）[2025-07-10]. <a href="https://beta.ukdataservice.ac.uk/datacatalogue/studies/study?id=996">https://beta.ukdataservice.ac.uk/datacatalogue/studies/study?id=996</a>. DOI:<a href="https://doi.org/10.5255/UKDA-SN-996-1">10.5255/UKDA-SN-996-1</a>.</div>
+  <div class="csl-entry">Tachibana R，Shimizu S，Kobayashi S，et al.，2001. Electronic watermarking method and system：US89404301A[P/OL]. 2001-06-28. <a href="https://worldwide.espacenet.com/patent/search/family/018694900/publication/US2002061118A1?q=US89404301A">https://worldwide.espacenet.com/patent/search/family/018694900/publication/US2002061118A1?q=US89404301A</a>.</div>
+  <div class="csl-entry">Torres L，Salisbury F，Yazbeck B，et al.，2021. Connecting the library to the curriculum[M/OL]. Singapore：Springer Nature：97. <a href="https://link.springer.com/book/10.1007/978-981-16-3868-8">https://link.springer.com/book/10.1007/978-981-16-3868-8</a>.</div>
+  <div class="csl-entry">Tristram M，Skarshewski P，Tristram I，et al.，2022. Storage and delivery system：AU2022228203A[P/OL]. 2022-10-06. <a href="https://worldwide.espacenet.com/patent/search/family/061561249/publication/AU2022228203A1?q=AU2022228203A">https://worldwide.espacenet.com/patent/search/family/061561249/publication/AU2022228203A1?q=AU2022228203A</a>.</div>
+  <div class="csl-entry">United Nations Department of Economic and Social Affairs，[2025]. United Nations e-government survey 2024: accelerating digital transformation for sustainable development[R/OL]. <a href="https://publicadministration.un.org/egovkb/en-us/Reports/UN-E-Government-Survey-2024">https://publicadministration.un.org/egovkb/en-us/Reports/UN-E-Government-Survey-2024</a>.</div>
+  <div class="csl-entry">U.S. Department of Transportation Federal Highway Administration，1990. Guidelines for handling excavated acid-producing material：PB 91-194001[R]. Springfield：U.S. Department of Commerce National Information Service：25.</div>
+  <div class="csl-entry">Veen P H van der，Muller M，Vincken K L，et al.，2014. Longitudinal changes in brain volumes and cerebrovascular lesions on MRI in patients with manifest arterial disease: the SMART-MR study[J/OL]. Journal of the Neurological Sciences，337（1/2）：112-118. <a href="https://pubmed.ncbi.nlm.nih.gov/24314719/">https://pubmed.ncbi.nlm.nih.gov/24314719/</a>. DOI:<a href="https://doi.org/10.1016/j.jns.2013.11.029">10.1016/j.jns.2013.11.029</a>.</div>
+  <div class="csl-entry">Wang S，2022. Application of improved SOM neural network in intelligent auditing of hospital financial vouchers[C/OL]//2022 6th Asian Conference on Artificial Intelligence Technology：2. <a href="https://ieeexplore.ieee.org/document/10137867">https://ieeexplore.ieee.org/document/10137867</a>. DOI:<a href="https://doi.org/10.1109/ACAIT56212.2022.10137867">10.1109/ACAIT56212.2022.10137867</a>.</div>
+  <div class="csl-entry">Weinstein L，Swartz M N，1974. Pathogenic properties of invading microorganisms[M]//Sodeman W A Jr，Sodeman W A. Pathologic physiology: mechanisms of disease. 5th ed. Philadelphia：Saunders：457-472.</div>
+  <div class="csl-entry">Yu Y，Pan E，Wang X，et al.，2024. Unmixing before fusion: a generalized paradigm for multi-source-based hyperspectral image synthesis[C/OL]//CVPR：4. <a href="https://openaccess.thecvf.com/content/CVPR2024/html/Yu_Unmixing_Before_Fusion_A_Generalized_Paradigm_for_Multi-Source-based_Hyperspectral_Image_CVPR_2024_paper.html">https://openaccess.thecvf.com/content/CVPR2024/html/Yu_Unmixing_Before_Fusion_A_Generalized_Paradigm_for_Multi-Source-based_Hyperspectral_Image_CVPR_2024_paper.html</a>.</div>
+  <div class="csl-entry">Yufin S A，2000. Geoecology and computers: proceedings of the Third International Conference on Advances of Computer Methods in Geotechnical and Geoenvironmental Engineering, Moscow, Russia, 1-4 February 2000[M]. Rotterdam：A. A. Balkema.</div>
+  <div class="csl-entry">Zhong X，Yan Q，Li G，2022. Long time series nighttime light dataset of China: 2000–2020[DS/OL]. Global Change Research Data Publishing &#38; Repository（2022）[2024-11-25]. <a href="https://www.geodoi.ac.cn/edoi.aspx?DOI=10.3974/geodb.2022.06.01.V1">https://www.geodoi.ac.cn/edoi.aspx?DOI=10.3974/geodb.2022.06.01.V1</a>.</div>
+  <div class="csl-entry">Zotero，[2024]. [Zotero download][EB/OL]. [2024-04-08]. <a href="https://www.zotero.org/download/">https://www.zotero.org/download/</a>.</div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《心理学报》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-true">
+  <div class="csl-entry">拉普拉斯, Pierre-Simon，1951. 概率哲学[M]. 张三，李四，译. 北京：未名出版社.</div>
+  <div class="csl-entry">李行健，2004. 现代汉语规范辞典[M/OL]. 北京：外语教学与研究出版社：255. <a href="http://book.ucdrs.superlib.net/views/specific/2929/bookDetail.jsp?dxNumber=000007502301&#38;d=6CE8370C1575089E8C1CA0C567C13999&#38;fenlei=08021204">http://book.ucdrs.superlib.net/views/specific/2929/bookDetail.jsp?dxNumber=000007502301&#38;d=6CE8370C1575089E8C1CA0C567C13999&#38;fenlei=08021204</a>.</div>
+  <div class="csl-entry">邱颖文，2009. 遗传与语言学习[D]. 上海：华东师范大学.</div>
+  <div class="csl-entry">王登峰，崔红，2004. 中国人“大七”人格结构的理论分析[M]//王登峰，侯玉波. 人格与社会心理学论丛：第1卷. 北京：北京大学出版社：46-84.</div>
+  <div class="csl-entry">佚名，1986. 现代汉语频率词典[M/OL]. 北京：北京语言学院出版社. <a href="http://book.ucdrs.superlib.net/views/specific/2929/bookDetail.jsp?dxNumber=000001022685&#38;d=71C299B1BB1D244BF2DDA9151F541912&#38;fenlei=0802080332">http://book.ucdrs.superlib.net/views/specific/2929/bookDetail.jsp?dxNumber=000001022685&#38;d=71C299B1BB1D244BF2DDA9151F541912&#38;fenlei=0802080332</a>.</div>
+  <div class="csl-entry">余林，2000. 汉语语言产生中的语音表征与加工[D]. 北京师范大学.</div>
+  <div class="csl-entry">张三，2008a. 中国心理学的过去与未来[J]. 心理学报，40：210-215.</div>
+  <div class="csl-entry">张三，2008b. 中国心理学的过去与未来[J]. 心理学报，40（增刊）：210-215.</div>
+  <div class="csl-entry">张三，2008c. 心理学史[M]. 北京：未名出版社.</div>
+  <div class="csl-entry">张三，2008d. 心理学史[M]. 北京：未名出版社.</div>
+  <div class="csl-entry">张三，李四，2008a. 中国心理学的过去与未来[J]. 心理学报，40：210-215.</div>
+  <div class="csl-entry">张三，李四，2008b. 中国心理学与奥林匹克[N]. 新华日报，2008-08-08（2, 5-7）.</div>
+  <div class="csl-entry">张三，李四. 中国心理学的过去与未来[J]. 心理学报.</div>
+  <div class="csl-entry">赵一，钱二，孙三，等，2008. 中国心理学的过去与未来[J]. 心理学报，40：210-215.</div>
+  <div class="csl-entry">赵一一，钱二，孙三，等，2008. 中国心理学的过去与未来[J]. 心理学报，40：210-215.</div>
+  <div class="csl-entry">Auerbach J S，1993. The origins of narcissism and narcissistic personality disorder: A theoretical and empirical reformulation[M/OL]//Bornstein M F. Handbook of child psychology: Vol. 4. Socialization, personality, and social development. 4th ed. Washington, DC, US：Wiley：43-110. DOI:<a href="https://doi.org/10.1037/10138-002">10.1037/10138-002</a>.</div>
+  <div class="csl-entry">Australian Bureau of Statistics，1991. Estimated resident population by age and sex in statistical local areas, New South Wales, June 1990：3209.1[R]. Canberra, Australian Capital Territory：Author.</div>
+  <div class="csl-entry">Bergmann P G，1993. Relativity[M]//The new encyclopedia Britannica：v.26. New York：Encyclopedia Britannica：501-508.</div>
+  <div class="csl-entry">Burin D，Kilteni K，Rabuffetti M，et al.，2019. Body ownership increases the interference between observed and executed movements[J/OL]. PLOS ONE，14（1）：e0209899. DOI:<a href="https://doi.org/10.1371/journal.pone.0209899">10.1371/journal.pone.0209899</a>.</div>
+  <div class="csl-entry">Gibbs J T，Huang L N，1989. Children of color: Psychological interventions with minority youth[M]. Hoboken, NJ, US：Jossey-Bass.</div>
+  <div class="csl-entry">Huestegge S M，Raettig T，Huestegge L，2019. Are face-incongruent voices harder to process? Effects of face–voice gender incongruency on basic cognitive information processing[J/OL]. Experimental Psychology，2019. DOI:<a href="https://doi.org/10.1027/1618-3169/a000440">10.1027/1618-3169/a000440</a>.</div>
+  <div class="csl-entry">Klatzky R，1998. Allocentric and egocentric spatial representations: Definitions, distinctions, and interconnections[M]//Freksa C，Habel C，Wender K F. Lecture notes in artificial intelligence: Vol. 1404: Spatial cognition: An interdisciplinary approach to representing and processing spatial knowledge. Springer-Verlag：1-17.</div>
+  <div class="csl-entry">Lanktree C B，Briere J N，1991. Early data on the Trauma Symptom Checklist for Children (TSC-C)[C]//Paper presented at the meeting of the American Professional Society on the Abuse of Children.</div>
+  <div class="csl-entry">Laplace P-S，1951. A philosophical essay on probabilities[M]. Truscott F W，Emory F L，trans. Dover.</div>
+  <div class="csl-entry">Lichstein K L，Johnson R S，1990. Relaxation therapy for polypharmacy use in elderly insomniacs and noninsomniacs[C]//Reducing medication in geriatric populations. Uppsala, Sweden.</div>
+  <div class="csl-entry">Mitchell T R，Larson J R，1987. People in organizations: An introduction to organizational behavior[M]. 3rd ed. New York：McGraw-Hill.</div>
+  <div class="csl-entry">Mou W，McNamara T P，2002. Intrinsic frames of reference in spatial memory[J/OL]. Journal of Experimental Psychology: Learning, Memory, and Cognition，28：162-170. DOI:<a href="https://doi.org/10.1037/0278-7393.28.1.162">10.1037/0278-7393.28.1.162</a>.</div>
+  <div class="csl-entry">Mou W，Zhang K，McNamara T P，2004. Frames of reference in spatial memories acquired from language[J/OL]. Journal of Experimental Psychology: Learning, Memory, and Cognition，30：171-180. DOI:<a href="https://doi.org/10.1037/0278-7393.30.1.171">10.1037/0278-7393.30.1.171</a>.</div>
+  <div class="csl-entry">Ruby J，Fulton C，1993. Beyond redlining: Editing software that works[C]//Poster session presented at the annual meeting of the Society for Scholarly Publishing.</div>
+  <div class="csl-entry">Sadie S，1980. The new Grove dictionary of music and musicians[M]. 6th ed. London : New York：Macmillan.</div>
+  <div class="csl-entry">Wang D F，Cui H，2004. Theoretical analysis of the seven factor model of Chinese personality[M]//Wang D F，Hou Y B. Selected papers on personality and social psychology：v.1. Beijing：Peking University Press：46-84.</div>
+  <div class="csl-entry">Wolchik S A，West S G，Sandler I N，et al.，2000. An experimental evaluation of theory-based mother and mother-child programs for children of divorce[J]. Journal of Consulting and Clinical Psychology，68（5）：843-856.</div>
+  <div class="csl-entry">Yu L，2000. Phonological representation and processing in Chinese spoken language production[D/OL]. Beijing Normal University. <a href="https://gongjushu.cnki.net/rbook/Search/SimpleSearch?key=%E8%BE%9E%E5%85%B8&#38;t=0&#38;c=0&#38;tn=%E8%AF%8D%E7%9B%AE">https://gongjushu.cnki.net/rbook/Search/SimpleSearch?key=%E8%BE%9E%E5%85%B8&#38;t=0&#38;c=0&#38;tn=%E8%AF%8D%E7%9B%AE</a>.</div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《中国社会科学》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-true">
+  <div class="csl-entry">狄葆贤，无日期. 平等阁笔记[M]. 上海：有正书局.</div>
+  <div class="csl-entry">杜威·佛克马，1999. 走向新世界主义[M]//王宁，薛晓源. 全球化与后殖民批评. 北京：中央编译出版社：247-266.</div>
+  <div class="csl-entry">方明东，2000. 罗隆基政治思想研究（1913—1949）[D]. 北京师范大学历史系.</div>
+  <div class="csl-entry">费成康，1999. 葡萄牙人如何进入澳门问题辨正[J/OL]. 社会科学（9）：63-67. <a href="https://kns.cnki.net/kcms2/article/abstract?v=wYgW8A8u9vp6Ema3Mwkv_hcFaP9q0L4fxESweZeAxPzw-huXM6FBnwEe2FoehE7Sd2LliAejUiZxsTfPnTIWzV4aatJcFq9w5tigPkT1ccDGdgVxQVqPXxPflnX1ldPM7zYuFexEd8g=&#38;uniplatform=NZKPT&#38;language=CHS">https://kns.cnki.net/kcms2/article/abstract?v=wYgW8A8u9vp6Ema3Mwkv_hcFaP9q0L4fxESweZeAxPzw-huXM6FBnwEe2FoehE7Sd2LliAejUiZxsTfPnTIWzV4aatJcFq9w5tigPkT1ccDGdgVxQVqPXxPflnX1ldPM7zYuFexEd8g=&#38;uniplatform=NZKPT&#38;language=CHS</a>.</div>
+  <div class="csl-entry">管志道，1997. 答屠仪部赤水丈书[M]//续问辨牍：第2卷. 影印本. 济南：齐鲁书社.</div>
+  <div class="csl-entry">何龄修，1998. 读顾诚〈南明史〉[J]. 中国史研究（3）：167-173.</div>
+  <div class="csl-entry">黄仁宇，1997. 为什么称为“中国大历史”？——中文版自序[M]//中国大历史. 北京：三联书店.</div>
+  <div class="csl-entry">黄义豪，1997. 评黄龟年四劾秦桧[J]. 福建论坛（3）：26-27.</div>
+  <div class="csl-entry">蒋大兴，2001. 公司法的展开与评判——方法·判例·制度[M]. 北京：法律出版社.</div>
+  <div class="csl-entry">金冲及，1989. 周恩来传[M]. 北京：人民出版社、中央文献出版社.</div>
+  <div class="csl-entry">李眉，1986. 李劼人轶事[N]. 四川工人日报，1986-08-22（2）.</div>
+  <div class="csl-entry">李鹏程，1994. 当代文化哲学沉思[M]. 北京：人民出版社.</div>
+  <div class="csl-entry">楼适夷，1998. 读家书，想傅雷（代序）[M]//傅敏. 傅雷家书. 增补本. 北京：三联书店.</div>
+  <div class="csl-entry">鲁迅，1981. 中国小说的历史的变迁[M]//鲁迅全集：第9册. 北京：人民文学出版社.</div>
+  <div class="csl-entry">毛祥麟，1985. 墨余录[M]. 上海：上海古籍出版社.</div>
+  <div class="csl-entry">倪素香，2002. 德育学科的比较研究与理论探索[J]. 武汉大学学报（4）：512-513.</div>
+  <div class="csl-entry">任东来，2000. 对国际体制和国际制度的理解和翻译[C]//全球化与亚太区域化国际研讨会.</div>
+  <div class="csl-entry">任继愈，1983. 中国哲学发展史（先秦卷）[M]. 北京：人民出版社.</div>
+  <div class="csl-entry">伤心人（麦孟华），无日期. 说奴隶[N]. 清议报（第1页）.</div>
+  <div class="csl-entry">实藤惠秀，1982. 中国人留学日本史[M]. 谭汝谦，林启彦，译. 香港：香港中文大学出版社.</div>
+  <div class="csl-entry">唐振常，1997. 师承与变法[M]//识史集. 上海：上海古籍出版社.</div>
+  <div class="csl-entry">汪疑今，1936. 江苏的小农及其副业[J]. 中国经济，4（6）.</div>
+  <div class="csl-entry">王明亮，1998. 关于中国学术期刊标准化数据库系统工程的进展[EB/OL]. （1998-08-16）[1998-10-04]. <a href="http://www.cajcd.cn/pub/wml.txt/980810-2.html">http://www.cajcd.cn/pub/wml.txt/980810-2.html</a>.</div>
+  <div class="csl-entry">魏丽英，1990. 论近代西北人口波动的若干主要原因[J/OL]. 社会科学（6）：68-73, 86. DOI:<a href="https://doi.org/10.15891/j.cnki.cn62-1093/c.1990.06.017">10.15891/j.cnki.cn62-1093/c.1990.06.017</a>.</div>
+  <div class="csl-entry">谢兴尧，1986. 荣庆日记[M]. 西安：西北大学出版社.</div>
+  <div class="csl-entry">扬之水，[2007]. 两宋茶诗与茶事[EB/OL]. [2007-09-13]. <a href="http://www.literature.org.cn/Article.asp?ID=199">http://www.literature.org.cn/Article.asp?ID=199</a>.</div>
+  <div class="csl-entry">杨钟羲，1991. 雪桥诗话续集：第5卷[M]. 影印本. 沈阳：辽沈书社.</div>
+  <div class="csl-entry">姚际恒，无日期. 古今伪书考：第3卷[M]. 光绪三年苏州文学山房活字本.</div>
+  <div class="csl-entry">佚名，1910. 四川会议厅暂行章程[N]. 广益丛报，1910-09-03（第1—2页）.</div>
+  <div class="csl-entry">佚名，1917. 傅良佐致国务院电：北洋档案 1011—5961[A]. 中国第二历史档案馆，1917-09-15.</div>
+  <div class="csl-entry">佚名，1925. 上海各路商界总联合会致外交部电[N]. 民国日报，1925-08-14（4）.</div>
+  <div class="csl-entry">佚名，1933. 西南中委反对在宁召开五全会[N]. 民国日报，1933-08-11（第1张第4版）.</div>
+  <div class="csl-entry">佚名，1950. 党外人士座谈会记录：李劼人档案[A]. 中共四川省委统战部档案室，1950-07.</div>
+  <div class="csl-entry">Anon，1969. Nixon to Kissinger：Box 1032, NSC Files, Nixon Presidential Material Project (NPMP)[A]. National Archives II, College Park, MD，1969-02-01.</div>
+  <div class="csl-entry">佚名，1975. 旧唐书：第9卷 玄宗纪下[M]. 标点本. 北京：中华书局.</div>
+  <div class="csl-entry">佚名，1983. 方苞集：第6卷 答程夔州书[M]. 标点本. 上海：上海古籍出版社.</div>
+  <div class="csl-entry">佚名，1985. 太平御览：第690卷 服章部七[M]. 影印本. 北京：中华书局.</div>
+  <div class="csl-entry">佚名，1987. 清德宗实录：第435卷[M]. 影印本. 北京：中华书局.</div>
+  <div class="csl-entry">佚名，1992. 广东通志[M]//稀见中国地方志汇刊：第15卷. 影印本. 北京：中国书店.</div>
+  <div class="csl-entry">佚名，1998a. 晚清洋务运动事类汇钞五十七种：上册[M]. 北京：全国图书馆文献缩微复制中心.</div>
+  <div class="csl-entry">佚名，1998b. 马克思恩格斯全集：第31卷[M]. 北京：人民出版社.</div>
+  <div class="csl-entry">佚名，无日期-a. 嘉定县志：第12卷 风俗[M].</div>
+  <div class="csl-entry">佚名，无日期-b. 上海县续志：第1卷 疆域[M].</div>
+  <div class="csl-entry">赵景深，1948. 文坛忆旧[M]. 上海：北新书局.</div>
+  <div class="csl-entry">Brooks P，2000. Troubling confessions: Speaking guilt in law and literature[M]. Chicago：University of Chicago Press.</div>
+  <div class="csl-entry">Chamberlain H B，1993. On the search for civil society in China[J/OL]. Modern China，19（2）：199-215. DOI:<a href="https://doi.org/10.1177/009770049301900206">10.1177/009770049301900206</a>.</div>
+  <div class="csl-entry">Polo M，1997. The travels of Marco Polo[M]. Marsden W，trans. Hertfordshire：Cumberland House.</div>
+  <div class="csl-entry">Schfield R S，1983. The impact of scarcity and plenty on population change in England[M]//Rotberg R I，Rabb T K. Hunger and history: The impact of changing food production and consumption pattern on society. Cambridge, Mass.：Cambridge University Press：55-88.</div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### 《法学引注手册》 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-true">
+  <div class="csl-entry">崔国斌，2006. 知识产权法官造法批判[J/OL]. 中国法学（1）：144-164. <a href="https://link.cnki.net/doi/10.14111/j.cnki.zgfx.2006.01.013">https://link.cnki.net/doi/10.14111/j.cnki.zgfx.2006.01.013</a>. DOI:<a href="https://doi.org/10.14111/j.cnki.zgfx.2006.01.013">10.14111/j.cnki.zgfx.2006.01.013</a>.</div>
+  <div class="csl-entry">[德]莱纳·沃尔夫，2012. 风险法的风险[M/OL]. 陈霄，译//刘刚. 风险规制：德国的理论与实践. 法律出版社. <a href="https://book.douban.com/subject/20327000/">https://book.douban.com/subject/20327000/</a>.</div>
+  <div class="csl-entry">邓小平，1994. 精简机构是一场革命[M]//邓小平文选：第2卷. 2 版. 人民出版社.</div>
+  <div class="csl-entry">高鸿钧，程汉大，2013. 英美法原论[M]. 北京大学出版社.</div>
+  <div class="csl-entry">国家质量监督检验检疫总局，中国国家标准化管理委员会，2015. GB/T 7714—2015 信息与文献 参考文献著录规则[S].</div>
+  <div class="csl-entry">国务院，2007a. 国务院关于在全国建立农村最低生活保障制度的通知：国发〔2007〕19号[EB/OL]. （2007-07-11）[2022-10-17]. <a href="https://www.pkulaw.com/chl/dc46bb66e13150b8bdfb.html">https://www.pkulaw.com/chl/dc46bb66e13150b8bdfb.html</a>.</div>
+  <div class="csl-entry">国务院，2007b. 国务院关于在全国建立农村最低生活保障制度的通知：国发〔2007〕19号[EB/OL]. （2007-07-11）[2022-10-27]. <a href="https://www.pkulaw.com/chl/dc46bb66e13150b8bdfb.html">https://www.pkulaw.com/chl/dc46bb66e13150b8bdfb.html</a>.</div>
+  <div class="csl-entry">国务院，2018. 国务院关于印发打赢蓝天保卫战三年行动计划的通知：国发〔2018〕22号[EB/OL]. （2018-06-27）[2023-06-19]. <a href="https://www.pkulaw.com/chl/4a14adc2c14e5e68bdfb.html">https://www.pkulaw.com/chl/4a14adc2c14e5e68bdfb.html</a>.</div>
+  <div class="csl-entry">何海波，2000. 判决书上网[N]. 法制日报，2000-05-21（2）.</div>
+  <div class="csl-entry">季卫东，1993. 法律程序的意义：对中国法制建设的另一种思考[J]. 中国社会科学（1）：83-103.</div>
+  <div class="csl-entry">李松锋，2015. 游走在上帝与凯撒之间：美国宪法第一修正案中的政教关系研究[D]. 中国政法大学.</div>
+  <div class="csl-entry">罗豪才，袁曙宏，李文栋，1993. 现代行政法的理论基础——论行政机关与相对一方的权利义务平衡[J/OL]. 中国法学（1）：52-59. <a href="https://www.cnki.net/kcms/detail/detail.aspx?dbcode=CJFD&#38;dbname=CJFD1993&#38;filename=ZGFX199301009&#38;v=MDE4Njk5TE1ybzlGYllRS0RIODR2UjRUNmo1NE8zenFxQnRHRnJDVVI3aWZZK1pxRkNqbFZiN01QeXJOZHJLeEY=">https://www.cnki.net/kcms/detail/detail.aspx?dbcode=CJFD&#38;dbname=CJFD1993&#38;filename=ZGFX199301009&#38;v=MDE4Njk5TE1ybzlGYllRS0RIODR2UjRUNmo1NE8zenFxQnRHRnJDVVI3aWZZK1pxRkNqbFZiN01QeXJOZHJLeEY=</a>. DOI:<a href="https://doi.org/10.14111/j.cnki.zgfx.1993.01.010">10.14111/j.cnki.zgfx.1993.01.010</a>.</div>
+  <div class="csl-entry">[美]富勒，2005. 法律的道德性[M]. 郑戈，译. 商务印书馆.</div>
+  <div class="csl-entry">欧中坦，1994. 千方百计上京城：清朝的京控[M]. 谢鹏程，译//高道蕴，高鸿钧，贺卫方. 美国学者论中国法律传统. 中国政法大学出版社.</div>
+  <div class="csl-entry">瞿同祖，2010. 中国法律与中国社会[M/OL]. 商务印书馆. <a href="https://book.douban.com/subject/6004646/">https://book.douban.com/subject/6004646/</a>.</div>
+  <div class="csl-entry">全国人大常委会，1991. 全国人民代表大会常务委员会关于严禁卖淫嫖娼的决定[EB/OL]. （1991-09-04）[2022-10-27]. <a href="https://www.pkulaw.com/chl/7d823d434f747555bdfb.html">https://www.pkulaw.com/chl/7d823d434f747555bdfb.html</a>.</div>
+  <div class="csl-entry">全国人大常委会，2005. 中华人民共和国公司法[EB/OL]. （2005-10-27）[2022-10-14]. <a href="https://www.pkulaw.com/chl/e54c465cca59c137bdfb.html">https://www.pkulaw.com/chl/e54c465cca59c137bdfb.html</a>.</div>
+  <div class="csl-entry">全国人大常委会，2013. 中华人民共和国公司法[EB/OL]. （2013-12-28）[2022-10-27]. <a href="https://www.pkulaw.com/chl/1b2641cb68c3ed21bdfb.html">https://www.pkulaw.com/chl/1b2641cb68c3ed21bdfb.html</a>.</div>
+  <div class="csl-entry">全国人大常委会，2017. 中华人民共和国刑法修正案（十）：中华人民共和国主席令第80号[EB/OL]. （2017-11-04）[2022-10-14]. <a href="https://www.pkulaw.com/chl/3ae7651e2659029abdfb.html">https://www.pkulaw.com/chl/3ae7651e2659029abdfb.html</a>.</div>
+  <div class="csl-entry">汪波，2004. 哈尔滨市政法机关正对“宝马案”认真调查复查[EB/OL]. （2004-01-10）[2022-05-03]. <a href="http://www.people.com.cn/GB/shehui/1062/2289764.html">http://www.people.com.cn/GB/shehui/1062/2289764.html</a>.</div>
+  <div class="csl-entry">王保树，1994. 股份有限公司机关构造中的董事和董事会[M]//梁慧星. 民商法论丛：第1卷. 法律出版社：110.</div>
+  <div class="csl-entry">王名扬，2007. 美国行政法[M]. 北京大学出版社.</div>
+  <div class="csl-entry">我妻栄，1971. 新訂担保物権法[M]. 有斐閣.</div>
+  <div class="csl-entry">我妻栄，有泉亨，1950. 民法総則物権法[M]. 日本評論社.</div>
+  <div class="csl-entry">夏新华，胡旭晟，刘鄂，等，2004. 近代中国宪政历程[M/OL]. 中国政法大学出版社. <a href="https://book.douban.com/subject/1663375/">https://book.douban.com/subject/1663375/</a>.</div>
+  <div class="csl-entry">信春鹰，2013. 关于《中华人民共和国行政诉讼法修正案（草案）》的说明[R/OL]. 2013-12-23. <a href="https://www.pkulaw.com/protocol/e0c81a0878b582cddca4c85351d16972bdfb.html">https://www.pkulaw.com/protocol/e0c81a0878b582cddca4c85351d16972bdfb.html</a>.</div>
+  <div class="csl-entry">佚名，1919. 信玄公旗掛松事件[EB/OL]//大審院民事判決録：第25卷. <a href="https://ja.wikipedia.org/wiki/信玄公旗掛松事件">https://ja.wikipedia.org/wiki/信玄公旗掛松事件</a>.</div>
+  <div class="csl-entry">Anon，1966. Department of Transportation Act：89-670[Z]//Stat.：v.80. 931, 944-947.</div>
+  <div class="csl-entry">Anon，1973. Roe <i>v.</i> Wade[Z]//U.S.：v.410. 113.</div>
+  <div class="csl-entry">Anon，1982. Natural Resources Defense Council <i>v.</i> Gorsuch[Z]//F.2d：v.685. 718.</div>
+  <div class="csl-entry">佚名，1982. 約束手形金[EB/OL]//最高裁判所民事判例集：36卷6号. <a href="https://www.courts.go.jp/app/hanrei_jp/detail2?id=55158">https://www.courts.go.jp/app/hanrei_jp/detail2?id=55158</a>.</div>
+  <div class="csl-entry">Anon，1984. Chevron U.S.A., Inc. <i>v.</i> Natural Resources Defense Council[Z]//U.S.：v.467. 837.</div>
+  <div class="csl-entry">Anon，1987. R. v. Panel on Take-overs and Mergers[Z]//QB：v.815.</div>
+  <div class="csl-entry">佚名，1999. [Z]//NStZ-RR. 185.</div>
+  <div class="csl-entry">佚名，2000. [Z]//NJW. 1560.</div>
+  <div class="csl-entry">Anon，2006. Administrative Procedure Act § 6[Z]//U.S.C.：v.5.</div>
+  <div class="csl-entry">佚名，2013. 荣宝英诉王阳、永诚财产保险股份有限公司江阴支公司机动车交通事故责任纠纷案：（2013）锡民终字第497号[Z]//最高人民法院公报.</div>
+  <div class="csl-entry">佚名，2015. 陆红霞诉南通市发改委政府信息公开案[EB/OL]//最高人民法院公报. <a href="https://www.pkulaw.com/pfnl/a25051f3312b07f383ab74a250eadc412f753fb855fabeadbdfb.html">https://www.pkulaw.com/pfnl/a25051f3312b07f383ab74a250eadc412f753fb855fabeadbdfb.html</a>.</div>
+  <div class="csl-entry">佚名，[2016a]. 法国行政法院网站[EB/OL]. [2016-12-18]. <a href="http://english.conseil-etat.fr/Judging">http://english.conseil-etat.fr/Judging</a>.</div>
+  <div class="csl-entry">佚名，2017. 榆林市凯奇莱能源投资有限公司诉陕西省地质矿产勘查开发局西安地质矿产勘查开发院合作勘查合同纠纷上诉案：（2011）民一终字第 81 号[Z].</div>
+  <div class="csl-entry">佚名，[2022b]. ジュリスト[EB/OL]. [2022-09-01]. <a href="http://www.yuhikaku.co.jp/jurist">http://www.yuhikaku.co.jp/jurist</a>.</div>
+  <div class="csl-entry">佚名，无日期-a. 被告人李宁、张磊贪污案一审开庭[EB/OL]. <a href="http://www.xinhuanet.com/legal/2019-12/31/c_1125406056.htm">http://www.xinhuanet.com/legal/2019-12/31/c_1125406056.htm</a>.</div>
+  <div class="csl-entry">佚名，无日期-b. 民法总则[Z].</div>
+  <div class="csl-entry">佚名，无日期-c. 包郑照诉苍南县人民政府强制拆除房屋案：（1988）浙法民上字 7 号[Z].</div>
+  <div class="csl-entry">Anon，n.d. United States <i>v.</i> Dino Nastasi et al.：3:15-cr-00213-FDW-DCK[Z].</div>
+  <div class="csl-entry">佚名，无日期-d. StGB[Z].</div>
+  <div class="csl-entry">佚名，无日期-e. StPO[Z].</div>
+  <div class="csl-entry">佚名，无日期-f. GG[Z].</div>
+  <div class="csl-entry">佚名，无日期-g. Strauß-Karikatur, Kunstfreiheit[Z]//BVerfGE：第75卷. 369.</div>
+  <div class="csl-entry">佚名，无日期-h. 動産及び債権の譲渡の対抗要件に関する民法の特例に関する法律[EB/OL]. <a href="https://elaws.e-gov.go.jp/document?lawid=410AC0000000104_20220401_503AC0000000037">https://elaws.e-gov.go.jp/document?lawid=410AC0000000104_20220401_503AC0000000037</a>.</div>
+  <div class="csl-entry">佚名，无日期-i. 平成26年版犯罪白書[EB/OL]. <a href="https://hakusyo1.moj.go.jp/jp/61/nfm/mokuji.html">https://hakusyo1.moj.go.jp/jp/61/nfm/mokuji.html</a>.</div>
+  <div class="csl-entry">佚名，无日期-j. 温家宝主持国务院会议 研究房地产业健康发展措施[EB/OL]. <a href="http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm">http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm</a>.</div>
+  <div class="csl-entry">应松年，马怀德，2006. 当代中国行政法的源流：王名扬教授九十华诞贺寿文集[M]. 中国法制出版社.</div>
+  <div class="csl-entry">[英]劳特派特，1971. 奥本海国际法：上卷第一分册[M]. 王铁崖，陈体强，译. 8 版. 商务印书馆.</div>
+  <div class="csl-entry">於保不二雄，1954. 付加物及び従物と抵当権[J/OL]. 民商法雑誌，29（5）：1. <a href="https://dl.ndl.go.jp/info:ndljp/pid/3564970?tocOpened=1">https://dl.ndl.go.jp/info:ndljp/pid/3564970?tocOpened=1</a>.</div>
+  <div class="csl-entry">张新宝，2016. 侵权责任法[M]. 4 版. 中国人民大学出版社.</div>
+  <div class="csl-entry">赵耀彤，2018. 一名基层法官眼里好律师的样子[EB/OL]. （2018-12-01）[2022-05-03]. <a href="http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm">http://news.xinhuanet.com/newscenter/2006-05/17/content_4562304.htm</a>.</div>
+  <div class="csl-entry">中国共产党中央委员会，2014. 中共中央关于全面推进依法治国若干重大问题的决定[EB/OL]. （2014-10-23）[2023-06-19]. <a href="https://www.pkulaw.com/chl/8e624467ca77636dbdfb.html">https://www.pkulaw.com/chl/8e624467ca77636dbdfb.html</a>.</div>
+  <div class="csl-entry">最高人民法院，2018. 最高人民法院关于适用〈中华人民共和国行政诉讼法〉的解释：法释〔2018〕1号[EB/OL]. （2018-02-06）[2022-10-27]. <a href="https://www.pkulaw.com/chl/0a15442a31eb74f6bdfb.html">https://www.pkulaw.com/chl/0a15442a31eb74f6bdfb.html</a>.</div>
+  <div class="csl-entry">最高人民法院，最高人民检察院，1993. 最高人民法院、最高人民检察院关于依法严惩破坏计划生育犯罪活动的通知：法发〔1993〕36号[EB/OL]. （1993-11-12）[2022-10-14]. <a href="https://www.pkulaw.com/chl/98ef6bfbd5f5ecdebdfb.html">https://www.pkulaw.com/chl/98ef6bfbd5f5ecdebdfb.html</a>.</div>
+  <div class="csl-entry">佐藤英明，2014. 一時所得の要件に関する覚書[M]//金子宏，中里実，J.マーク・ラムザイヤー. 租税法と市場. 有斐閣：220.</div>
+  <div class="csl-entry">Alford W，1995. To steal a book is an elegant offense: Intellectual property law in Chinese civilization[M]. Stanford University Press.</div>
+  <div class="csl-entry">Badiou-Monferran C，1997. La promotion esthétique du pathétique dans la seconde moitié du XVIIe siècle[J]. La Licorne（43）：75-94.</div>
+  <div class="csl-entry">Barbara Ward，1979. Progress for a small planet[J/OL]. Harvard Business Review（Sep.-Oct.）：89. <a href="https://www.osti.gov/biblio/6023582">https://www.osti.gov/biblio/6023582</a>.</div>
+  <div class="csl-entry">Brandeis L D，1913. What publicity can do[J]. Harper’s Weekly，1913-12-20：10.</div>
+  <div class="csl-entry">Canaris C-W，1990. Gesamtunwirksamkeit und Teilgültigkeit rechtsgeschäftlicher Regelungen[M].</div>
+  <div class="csl-entry">Chevallier M，2003. L’État de droit[M/OL]. 4 版. Paris：Montchrestien. <a href="https://www.decitre.fr/livres/l-etat-de-droit-9782707613714.html">https://www.decitre.fr/livres/l-etat-de-droit-9782707613714.html</a>.</div>
+  <div class="csl-entry">Dreier R，Paulson S，2003. Rechtsphilosophie Studienausgabe[M]. 2 版. Heidelberg：UTB Uni-Taschenbücher Verlag.</div>
+  <div class="csl-entry">Fischer T，2015. Absurdes Spektakel um den Tod[N]. Die Zeit，2015-09-29.</div>
+  <div class="csl-entry">Habermas J，1996. Between facts and norms: contributions to a discourse theory of law and democracy[M]. Rehg W，trans. MIT Press.</div>
+  <div class="csl-entry">Horsley J，2006. Rule of law in China: incremental progress[M]//Bergsten C F，Gill B，Lardy N R，et al. China: The balance sheet. Public Affairs Press.</div>
+  <div class="csl-entry">Joyeux-Prunel B，[2010]. L’histoire de l’art et le quantitatif[EB/OL]. [2010-03-17]. <a href="http://histoiremesure.revues.org/index3543.html">http://histoiremesure.revues.org/index3543.html</a>.</div>
+  <div class="csl-entry">Kaufmann A，1972. Bemerkungen zur Reform des § 218 StGB aus rechtsphilosophischer Sicht[M]//Baumann J. Das Abtreibungsverbot des § 218 StGB. 2 版.</div>
+  <div class="csl-entry">McDonell S，2016. When China began streaming trials online[EB/OL]. （2016-09-30）[2022-07-26]. <a href="https://www.bbc.com/news/blogs-china-blog-37515399">https://www.bbc.com/news/blogs-china-blog-37515399</a>.</div>
+  <div class="csl-entry">Meidenbauer M，[2017]. Wissenschaftliches Publizieren[EB/OL]. [2017-10-10]. <a href="https://www.clio-online.de/sites/files/clio/portal-archiv/site/lang_de/40208143/Default-2.html">https://www.clio-online.de/sites/files/clio/portal-archiv/site/lang_de/40208143/Default-2.html</a>.</div>
+  <div class="csl-entry">Poisson M，2015a. Le droit de la mer[J]. RGDIP，2015：15-47.</div>
+  <div class="csl-entry">Poisson M，2015b. Le droit de la mer[M]//Lapieuvre R. Le droit des Océans. Éditions de la mer. 12-48.</div>
+  <div class="csl-entry">Poisson M，2016a. Le droit de la mer en Méditerranée[R]. Congrès de Marseille：228-229.</div>
+  <div class="csl-entry">Poisson M，2016b. Le droit de la mer en Méditerranée：1202[R]. 2016-08.</div>
+  <div class="csl-entry">Poisson M，2016c. Le droit de la mer appliqué à la Méditerranée[D]. l’Université de Marseille.</div>
+  <div class="csl-entry">Reich C A，1964. The new property[J/OL]. Yale Law Journal，73（5）：733-787. DOI:<a href="https://doi.org/10.2307/794645">10.2307/794645</a>.</div>
+  <div class="csl-entry">Rosenthal A，1990. White House tutors Kremlin in how a presidency works[N/OL]. New York Times，1990-06-15（A1）. <a href="https://www.nytimes.com/1990/06/15/world/white-house-tutors-kremlin-in-how-a-presidency-works.html">https://www.nytimes.com/1990/06/15/world/white-house-tutors-kremlin-in-how-a-presidency-works.html</a>.</div>
+  <div class="csl-entry">Roxin C，2006. Strafrecht Allgemeiner Teil：第1卷[M]. 4 版. C. H. Beck.</div>
+  <div class="csl-entry">Schwab M，2013. [M/OL]//Münchener Kommentar BGB：第5卷. 6 版. <a href="https://beck-online.beck.de/?vpath=bibdata%2Fkomm%2FMuekoBGB_Band5%2FBGB%2Fcont%2FMuekoBGB.BGB.P817.T0.htm">https://beck-online.beck.de/?vpath=bibdata%2Fkomm%2FMuekoBGB_Band5%2FBGB%2Fcont%2FMuekoBGB.BGB.P817.T0.htm</a>.</div>
+  <div class="csl-entry">Vogel B，2017. Rechtsgüterschutz und Normgeltung[J/OL]. Zeitschrift für die gesamte Strafrechtswissenschaft，129（3）：629-649. <a href="https://www.degruyter.com/document/doi/10.1515/zstw-2017-0033/html?lang=de">https://www.degruyter.com/document/doi/10.1515/zstw-2017-0033/html?lang=de</a>. DOI:<a href="https://doi.org/10.1515/zstw-2017-0033">10.1515/zstw-2017-0033</a>.</div>
+  <div class="csl-entry">Würdinger M，2012. Über Radarwarngeräte und die Zukunft des Europäischen Privatrechts[J/OL]. Juristische Schulung（3）：234-240. <a href="https://dialnet.unirioja.es/servlet/articulo?codigo=3906259">https://dialnet.unirioja.es/servlet/articulo?codigo=3906259</a>.</div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->
+
+### APA 示例文献
+
+<!-- PLACEHOLDER FOR WEBSITE - BEFORE RESULT -->
+
+<div class="csl-bib-body maxoffset-0 second-field-align-false hangingindent-true">
+  <div class="csl-entry">Anon，1954. Brown v. Board of Education[EB/OL]//U.S.：v.347. <a href="http://www.oyez.org/cases/1940-1955/347us483">http://www.oyez.org/cases/1940-1955/347us483</a>.</div>
+  <div class="csl-entry">Anon，1964. Civil Rights Act of 1964：88-352[EB/OL]//Stat.：v.78. <a href="https://www.govinfo.gov/content/pkg/STATUE-78/pdf/STATUTE-78-Pg241.pdf">https://www.govinfo.gov/content/pkg/STATUE-78/pdf/STATUTE-78-Pg241.pdf</a>.</div>
+  <div class="csl-entry">Anon，1972. Patsy Mink Equal Opportunity in Education Act[EB/OL]//U.S.C：v.20. <a href="https://www.justice.org/crt/title-ix-education-amendments-1972">https://www.justice.org/crt/title-ix-education-amendments-1972</a>.</div>
+  <div class="csl-entry">Anon，1976. Tarasoff v. Regents of the University of California[EB/OL]//Cal.3d：v.17. <a href="https://www.casebriefs.com/blog/law/torts/tors-keyed-to-dobbs/the-duty-to-protect-from-third-persons/tarasoff-v-regents-of-university-of-california">https://www.casebriefs.com/blog/law/torts/tors-keyed-to-dobbs/the-duty-to-protect-from-third-persons/tarasoff-v-regents-of-university-of-california</a>.</div>
+  <div class="csl-entry">Anon，1981. Marking time in the land of plenty: Reflections on mental health in the United States[J/OL]. American Journal of Orthopsychiatry，51（3）：391-402. DOI:<a href="https://doi.org/10.1111/j.1939-0025.1981.tb01388.x">10.1111/j.1939-0025.1981.tb01388.x</a>.</div>
+  <div class="csl-entry">Anon，1984. Durflinger v. Artiles[EB/OL]//F.Supp.：v.563. <a href="https://openjurist.org/727/f2d/888/durflinger-v-artiles">https://openjurist.org/727/f2d/888/durflinger-v-artiles</a>.</div>
+  <div class="csl-entry">Anon，1989. United nations convention on the rights of the child[EB/OL]. （1989-11-20）. <a href="https://www.ohchr.org/en/professionalinterest/pages/crc.aspx">https://www.ohchr.org/en/professionalinterest/pages/crc.aspx</a>.</div>
+  <div class="csl-entry">Anon，1990. American With Disabilities Act of 1990[EB/OL]//U.S.C：v.42. <a href="https://www.ada.gov/pubs/adastatute08.htm">https://www.ada.gov/pubs/adastatute08.htm</a>.</div>
+  <div class="csl-entry">Anon，1991. Daubert v. Merrell Dow Pharmaceuticals, Inc.[EB/OL]//F.2d：v.951. <a href="https://openjurist.org/951/f2d/1128/william-dabert-v-merrell-dow-pharmaceuticals">https://openjurist.org/951/f2d/1128/william-dabert-v-merrell-dow-pharmaceuticals</a>.</div>
+  <div class="csl-entry">Anon，1992. Texas v. Morales[EB/OL]//S.W.2d：v.826. <a href="https://www.leagle.com/decision/19921027826sw2d20111010">https://www.leagle.com/decision/19921027826sw2d20111010</a>.</div>
+  <div class="csl-entry">Anon，2001. Burriola v. Greater Toledo YMCA[EB/OL]//F.Supp.2d：v.133. <a href="https://law.justia.com/cases/federal/district-courts/FSupp2/133/1034/2293141/">https://law.justia.com/cases/federal/district-courts/FSupp2/133/1034/2293141/</a>.</div>
+  <div class="csl-entry">Anon，2002—2008. The wire[Z]. Blown Deadline Productions; HBO.</div>
+  <div class="csl-entry">Anon，2004. The Qur’an[M]. Abdel Haleem M A S，trans. Oxford University Press.</div>
+  <div class="csl-entry">Anon，2009a. Lilly Leadbetter Fair Play Act of 2009：111-2[EB/OL]//Stat.：v.123. <a href="https://www.govinfo.gov/content/pkg/PLAW-111publ2/pdf/PLAW-111publ2.pdf">https://www.govinfo.gov/content/pkg/PLAW-111publ2/pdf/PLAW-111publ2.pdf</a>.</div>
+  <div class="csl-entry">Anon，2009b. Florida Mental Health Act[EB/OL]//Fla. Stat. <a href="http://www.leg.state.fl.us/statues/index.cfm?App_mode=Display_Statute&#38;URL=0300-0399/0394/0394.html">http://www.leg.state.fl.us/statues/index.cfm?App_mode=Display_Statute&#38;URL=0300-0399/0394/0394.html</a>.</div>
+  <div class="csl-entry">Anon，2009c. Protection of human subjects[EB/OL]//C.F.R.：v.45. <a href="https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf">https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf</a>.</div>
+  <div class="csl-entry">Anon，2013. Mental Health on Campus Improvement Act：H.R. 1100[EB/OL]. （2013）. <a href="https://www.congress.gov/bill/113th-congress/house-bill/1100">https://www.congress.gov/bill/113th-congress/house-bill/1100</a>.</div>
+  <div class="csl-entry">Anon，2014a. Strengthening the federal student loan program for borrowers: Hearing before the U.S. Senate Committee on Health, Education, Labor &#38; Pensions[EB/OL]. （2014）. <a href="https://www.help.senate.gov/hearings/strengthening-the-federal-student-load-program-for-borrowers">https://www.help.senate.gov/hearings/strengthening-the-federal-student-load-program-for-borrowers</a>.</div>
+  <div class="csl-entry">Anon，2014b. Exec. Order No. 13,676[EB/OL]//C.F.R.：v.3. <a href="https://www.govinfo.gov/content/pkg/CFR-2015-title3-vol1/pdf/CFR-2015-title3-vol1-eo13676.pdf">https://www.govinfo.gov/content/pkg/CFR-2015-title3-vol1/pdf/CFR-2015-title3-vol1-eo13676.pdf</a>.</div>
+  <div class="csl-entry">Anon，2015a. The Torah: The five books of Moses[M]. 3rd ed. The Jewish Publication Society.</div>
+  <div class="csl-entry">Anon，2015b. Obergefell v. Hodges[EB/OL]//U.S.：v.576. <a href="https://www.supremecourt.gov/opinions/14pdf/14-556_3204.pdf">https://www.supremecourt.gov/opinions/14pdf/14-556_3204.pdf</a>.</div>
+  <div class="csl-entry">Anon，2015c. Every Student Succeeds Act[EB/OL]//U.S.C：v.20. <a href="https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf">https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf</a>.</div>
+  <div class="csl-entry">Anon，2015d. H.R. Rep. No. 114-358[R/OL]. 2015. <a href="https://www.gpo.gov/fdsys/pkg/CRPT-114rpt358/pdf/CRPT-114hrpt358.pdf">https://www.gpo.gov/fdsys/pkg/CRPT-114rpt358/pdf/CRPT-114hrpt358.pdf</a>.</div>
+  <div class="csl-entry">Anon，2016a. Federal real property reform: How cutting red tape and better management count achieve billions in savings, U.S. Senate Committee on Homeland Security and Governmental Affairs[EB/OL]. （2016）. <a href="http://www.gsa.gov/portal/content/233107">http://www.gsa.gov/portal/content/233107</a>.</div>
+  <div class="csl-entry">Anon，2016b. S. Res. 438[EB/OL]//Cong. Rec.：v.162. <a href="https://www.congress.gov/congressional-record/2016/04/21/senate-section/article/S2394-2">https://www.congress.gov/congressional-record/2016/04/21/senate-section/article/S2394-2</a>.</div>
+  <div class="csl-entry">Anon，2016c. Defining and delimiting the exemptions for executive, administrative, professional, outside sales and computer employees[EB/OL]//F.R.：v.81. <a href="https://www.federalregister.gov/articles/2016/05/23/2016-11754/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and">https://www.federalregister.gov/articles/2016/05/23/2016-11754/defining-and-delimiting-the-exemptions-for-executive-administrative-professional-outside-sales-and</a>.</div>
+  <div class="csl-entry">Anon，2017. King James Bible[M/OL]. King James Bible Online. <a href="https://www.kingjamesbibleonline.org/">https://www.kingjamesbibleonline.org/</a>.</div>
+  <div class="csl-entry">Anon，2019. List of oldest companies[M/OL]//Wikipedia. <a href="https://en.wikipedia.org/w/index.php?title=List_of_oldest_companies&#38;oldid=878158136">https://en.wikipedia.org/w/index.php?title=List_of_oldest_companies&#38;oldid=878158136</a>.</div>
+  <div class="csl-entry">Anon，n.d.-a. U.S. Const. art. I, § 3[Z].</div>
+  <div class="csl-entry">Anon，n.d.-b. S.C. Const. art. XI, § 3[Z].</div>
+  <div class="csl-entry">Anon，n.d.-c. U.S. Const. amend. XIX[Z].</div>
+  <div class="csl-entry">Anon，n.d.-d. U.S. Const. amend. XVIII (repealed 1933)[Z].</div>
+  <div class="csl-entry">Anon，n.d.-e. U.S. Const. amend. I-X[Z].</div>
+  <div class="csl-entry">Anon，n.d.-f. U.N. Charter art. 1, para. 3[Z].</div>
+  <div class="csl-entry">Ahmann E，Tuttle L J，Saviet M，et al.，2018. A descriptive review of ADHD coaching research: Implications for college students[J/OL]. Journal of Postsecondary Education and Disability，31（1）：17-39. <a href="https://www.ahead.org/professional-resources/publications/jped/archived-jped/jped-volume-31">https://www.ahead.org/professional-resources/publications/jped/archived-jped/jped-volume-31</a>.</div>
+  <div class="csl-entry">Alonso-Tapia J，Nieto C，Merino-Tejedor E，et al.，2018. Situated Goals Questionnaire for University Students (SGQ-U, CMS-U)[DS/OL]. PsycTESTS（2018）. DOI:<a href="https://doi.org/10.1037/t66267-000">10.1037/t66267-000</a>.</div>
+  <div class="csl-entry">Amano N，Kondo H，2000. Lexical characteristics of Japanese language：v.7[M]. Sansei-do.</div>
+  <div class="csl-entry">American Counseling Association，2014. 2014 ACA code of ethics[R/OL]. 2014. <a href="https://www.counseling.org/knowledge-center">https://www.counseling.org/knowledge-center</a>.</div>
+  <div class="csl-entry">American Nurses Association，2015. Code of ethics for nurses with interpretive statements[R/OL]. 2015. <a href="https://www.nursingworld.org/coe-view-only">https://www.nursingworld.org/coe-view-only</a>.</div>
+  <div class="csl-entry">American Psychiatric Association，2013. Diagnostic and statistical manual of mental disorders[R/OL]. 5th ed. American Psychiatric Association. DOI:<a href="https://doi.org/10.1176/appi.books.9780890425596">10.1176/appi.books.9780890425596</a>.</div>
+  <div class="csl-entry">American Psychological Association，2017. Ethical principles of psychologists and code of conduct[R/OL]. 2017. <a href="https://www.apa.org/ethics/code/index.aspx">https://www.apa.org/ethics/code/index.aspx</a>.</div>
+  <div class="csl-entry">American Psychological Association，[2019a]. APA dictionary of psychology[M/OL]. <a href="https://dictionary.apa.org/">https://dictionary.apa.org/</a>.</div>
+  <div class="csl-entry">American Psychological Association，[2019b]. Positive transference[M/OL]//APA dictionary of psychology. <a href="https://dictionary.apa.org/positive-transference">https://dictionary.apa.org/positive-transference</a>.</div>
+  <div class="csl-entry">Anderson M，2018. Getting consistent with consequences[J]. Educational Leadership，76（1）：26-33.</div>
+  <div class="csl-entry">APA Education [@APAEducation]，2018. College students are forming mental-health Clubs—and they’re making a difference @washingtonpost [Thumbnail with link attached][EB/OL]. （2018-06-29）. <a href="https://twitter.com/apaeducation/status/1012810490530140161">https://twitter.com/apaeducation/status/1012810490530140161</a>.</div>
+  <div class="csl-entry">APA Style [@APA_Style]，[2019]. Tweets[EB/OL]. [2019-11-01]. <a href="https://twitter.com/APA_Style">https://twitter.com/APA_Style</a>.</div>
+  <div class="csl-entry">Aristotle，1994. Poetics[M/OL]. Butcher S H，trans. The Internet Classics Archive. <a href="http://classics.mit.edu/Aristotle/poetics.html">http://classics.mit.edu/Aristotle/poetics.html</a>.</div>
+  <div class="csl-entry">Australian Government Productivity Commission，New Zealand Productivity Commission，2012. Strengthening trans-Tasman economic relations[R/OL]. 2012. <a href="https://www.pc.gov.au/inquiries/completed/australia-new-zealand/report/trans-tasman.pdf">https://www.pc.gov.au/inquiries/completed/australia-new-zealand/report/trans-tasman.pdf</a>.</div>
+  <div class="csl-entry">Author A，2019. How workout buddies can help stave off loneliness[N]. The Washington Post，2019-01-15.</div>
+  <div class="csl-entry">Avramova N，2019. The secret to a long, happy, health life? Think age-positive[EB/OL]. （2019-01-03）. <a href="https://www.cnn.com/2019/01/03/health/respect-towards-elderly-leads-to-long-life-intl/index.html">https://www.cnn.com/2019/01/03/health/respect-towards-elderly-leads-to-long-life-intl/index.html</a>.</div>
+  <div class="csl-entry">Bach J S，2010. The Brandenburg concertos: Concertos BVW 1043 &#38; 1060[Z]. Decca.</div>
+  <div class="csl-entry">Badlands National Park [@BadlandsNPS]，2018. Biologists have identified more than 400 different plant species growing in @BadlandsNPS #DYK #biodoversity[EB/OL]. （2018-02-26）. <a href="https://twitter.com/BadlandsNPS/status/968196500412133379">https://twitter.com/BadlandsNPS/status/968196500412133379</a>.</div>
+  <div class="csl-entry">Baer R A，2015. Unpublished raw data on the correlations between the Five Facet Mindfulness Questionnaire and the Kentucky Inventory of Mindfulness Skills[DS]. University of Kentucky（2015）.</div>
+  <div class="csl-entry">Balsam K F，Martell C R，Jones K P，et al.，2019. Affirmative cognitive behavior therapy with sexual and gender minority people[M/OL]//Iwamasa G Y，Hays P A. Culturally responsive cognitive behavior therapy: Practice and supervision. 2nd ed. American Psychological Association：287-314. DOI:<a href="https://doi.org/10.1037/0000119-012">10.1037/0000119-012</a>.</div>
+  <div class="csl-entry">Barris K，2017. Lemons：Season 3, Episode 12[Z]//Black-ish. Wilmore Films; Artists First; Cinema Gypsy Productions; ABC Studios.</div>
+  <div class="csl-entry">Bergeson S，2019. Really cool neutral plasmas[J/OL]. Science，363（6422）：33-34. DOI:<a href="https://doi.org/10.1126/science.aau7988">10.1126/science.aau7988</a>.</div>
+  <div class="csl-entry">Beyoncé，2016. Formation[Z]//Lemonade. Parkwood; Columbia.</div>
+  <div class="csl-entry">Blackwell D L，Lucas J W，Clarke T C，2014. Summary health statistics for U.S. adults: National Health Interview Survey, 2012[R/OL]. Centers for Disease Control and Prevention. <a href="https://www.atlantic.org/images/publications/Democratic_Defense_Against_Disinformation_FINAL.pdf">https://www.atlantic.org/images/publications/Democratic_Defense_Against_Disinformation_FINAL.pdf</a>.</div>
+  <div class="csl-entry">Blair C B，2015—2020. Stress, self-regulation and psychopathology in middle childhood：5R01HD081252-04[R/OL]. Eunice Kennedy Shriver National Institute of Child Health &#38; Human Development. <a href="https://projectreporter.nih.gov/project_info_details.cfm?aid=9473071&#38;icde=40092311">https://projectreporter.nih.gov/project_info_details.cfm?aid=9473071&#38;icde=40092311</a>.</div>
+  <div class="csl-entry">Boddy J，Neumann T，Jennings S，et al.，n.d. Ethics principles[EB/OL]. <a href="http://www.ethicsguidebook.ac.uk/EthicsPrinciples">http://www.ethicsguidebook.ac.uk/EthicsPrinciples</a>.</div>
+  <div class="csl-entry">Bologna C，2018. What happens to your mind and body when you feel homesick?[EB/OL]. （2018-06-27）. <a href="https://www.huffingtonpost.com/entry/what-happens-mind-body-homesick_us_5b201ebde4b09d7a3d77eee1">https://www.huffingtonpost.com/entry/what-happens-mind-body-homesick_us_5b201ebde4b09d7a3d77eee1</a>.</div>
+  <div class="csl-entry">Borenstein M，Hedges L，Higgins J，et al.，2014. Comprehensive meta-analysis[CP/OL]. Biostat. <a href="https://www.meta-analysis.com/">https://www.meta-analysis.com/</a>.</div>
+  <div class="csl-entry">Bowie D，2016. Blackstar[Z]. Columbia.</div>
+  <div class="csl-entry">British Cardiovascular Society Working Group，2016. British Cardiovascular Society Working Group report: Out-of-hours cardiovascular care: Management of cardiac emergencies and hospital in-patients[R/OL]. British Cardiovascular Society. <a href="http://www.bcs.com/documents/BCSOOHWP_Final_Report_05092016.pdf">http://www.bcs.com/documents/BCSOOHWP_Final_Report_05092016.pdf</a>.</div>
+  <div class="csl-entry">Brodsky E，2016. The year we thought about love[Z].</div>
+  <div class="csl-entry">Bronfenbrenner U，2005. The social ecology of human development: A retrospective conclusion[M]//Bronfenbrenner U. Making human beings human: Bioecological perspectives on human development. SAGE Publications：27-40.</div>
+  <div class="csl-entry">Brown L S，2018. Feminist therapy[M/OL]. 2nd ed. American Psychological Association. DOI:<a href="https://doi.org/10.1037/0000092-000">10.1037/0000092-000</a>.</div>
+  <div class="csl-entry">Burgess R，2019. Rethinking global health: Frameworks of power[M]. Routledge.</div>
+  <div class="csl-entry">Burin D，Kilteni K，Rabuffetti M，et al.，2019. Body ownership increases the interference between observed and executed movements[J/OL]. PLOS ONE，14（1）：e0209899. DOI:<a href="https://doi.org/10.1371/journal.pone.0209899">10.1371/journal.pone.0209899</a>.</div>
+  <div class="csl-entry">Bustillos M，2013. On video games and storytelling: An interview with Tom Bissell[J/OL]. The New Yorker，2013-03-19. <a href="https://www.newyorker.com/books/page-turner/on-video-games-and-storytelling-an-interview-with-tom-bissell">https://www.newyorker.com/books/page-turner/on-video-games-and-storytelling-an-interview-with-tom-bissell</a>.</div>
+  <div class="csl-entry">Cable D，2013. The racial dot map[CM/OL]. University of Virginia：Weldon Cooper Center for Public Service. <a href="https://demographics.coopercenter.org/Racial-Dot-Map">https://demographics.coopercenter.org/Racial-Dot-Map</a>.</div>
+  <div class="csl-entry">Cain S，2012. Quiet: The power of introverts in a world that can’t stop talking[M/OL]. Random House Audio. <a href="http://bit.ly/2GOBpbl">http://bit.ly/2GOBpbl</a>.</div>
+  <div class="csl-entry">Canada Council for the Arts，2013. What we heard: Summary of key findings: 2013 Canada Council’s Inter-Arts Office Consultation[R/OL]. 2013. <a href="http://publications.gc.ca/collections/collection_2017/canadacouncil/K23-65-2013-eng.pdf">http://publications.gc.ca/collections/collection_2017/canadacouncil/K23-65-2013-eng.pdf</a>.</div>
+  <div class="csl-entry">Canan E，Vasilev J，2019. Lecture notes on resource allocation[A/OL]. 2019-05-22. <a href="https://uchilefau.academia.edu/ElseZCanan">https://uchilefau.academia.edu/ElseZCanan</a>.</div>
+  <div class="csl-entry">Carcavilla González N，2015. Auditory sensory therapy: Brain activation through music[M/OL]//Garcia Meilán J J. Guía práctica de terapias estimulativas en el Alzhéimer. Editorial Síntesis：67-86. <a href="http://www.sintesis.com/guias-profesionales-203/guia-practica-de-terapias-estimulativas-en-el-alzheimer-libro-1943.html">http://www.sintesis.com/guias-profesionales-203/guia-practica-de-terapias-estimulativas-en-el-alzheimer-libro-1943.html</a>.</div>
+  <div class="csl-entry">Cardoza D，Morris J K，Myers H F，et al.，2000. Acculturative Stress Inventory (ASI)：TC022704[DS]. ETS TestLink（2000）.</div>
+  <div class="csl-entry">Centers for Disease Control and Prevention，2018. People at high risk of developing flu-related complications[EB/OL]. （2018-01-23）. <a href="https://www.cdc.gov/flu/about/disease/high_risk.htm">https://www.cdc.gov/flu/about/disease/high_risk.htm</a>.</div>
+  <div class="csl-entry">Chaves-Morillo V，Gómez Calero C，Fernández-Muñoz J J，et al.，2018. Sensorineural anosmia: Relationship between subtype, recognition time, and age[J/OL]. Clínica y Salud，28（3）：155-161. DOI:<a href="https://doi.org/10.1016/j.clysa.2017.04.002">10.1016/j.clysa.2017.04.002</a>.</div>
+  <div class="csl-entry">Childish Gambino，2018. This is America[Z]. mcDJ; RCA.</div>
+  <div class="csl-entry">Christian B，Griffiths T，2016. Algorithms to live by: The computer science of human decisions[M/OL]. Henry Holt and Co. <a href="http://a.co/7qGBZAk">http://a.co/7qGBZAk</a>.</div>
+  <div class="csl-entry">Cuellar N G，2016. Study abroad programs[J/OL]. Journal of Transcultural Nursing，27（3）：209. DOI:<a href="https://doi.org/10.1177/1043659616638722">10.1177/1043659616638722</a>.</div>
+  <div class="csl-entry">Cutts S，2017. Happiness[EB/OL]. Vimeo. <a href="https://vimeo.com/244405542">https://vimeo.com/244405542</a>.</div>
+  <div class="csl-entry">de Beauvoir S，1960. Simone de Beauvoir discusses the art of writing[A/OL]. Studs Terkel Radio Archive; The Chicago History Museum，1960-05-04. <a href="https://studsterkel.wfmt.com/programs/simone-de-beauvoir-discusses-art-writing">https://studsterkel.wfmt.com/programs/simone-de-beauvoir-discusses-art-writing</a>.</div>
+  <div class="csl-entry">De Boer D，LaFavor T，2018. The art and significance of successfully identifying resilient individuals A person-focused approach[Z]//Perspectives on resilience: Conceptualization, measurement, and enhancement. Portland, OR, United States.</div>
+  <div class="csl-entry">De Vries R，Nieuwenhuijze M，Buitendijk S E，et al.，2013. What does it take to have a strong and independent profession of midwifery? Lessons from the Netherlands[J/OL]. Midwifery，29（10）：1122-1128. DOI:<a href="https://doi.org/10.1016/j.midw.2013.07.007">10.1016/j.midw.2013.07.007</a>.</div>
+  <div class="csl-entry">Delacroix E，1826—1827. Faust attempts to seduce Marguerite[A]. Paris, France：The Louvre，1826/1827.</div>
+  <div class="csl-entry">D’Souza A，Wiseheart M，2018. Cognitive effects of music and dance training in children：ICPSR 37080[DS/OL]. VV1. ICPSR（2018）. DOI:<a href="https://doi.org/10.3886/ICPSR37080.1">10.3886/ICPSR37080.1</a>.</div>
+  <div class="csl-entry">Epocrates，2019a. Epocrates medical references[CP/OL]. App Store. <a href="https://itunes.apple.com/us/app/epocrates/id281935788?mt=8">https://itunes.apple.com/us/app/epocrates/id281935788?mt=8</a>.</div>
+  <div class="csl-entry">Epocrates，2019b. Interaction Check: Aspirin + Sertraline[EB/OL]//Epocrates medical references. Google Play Store. <a href="https://play.google.com/store/apps/details?id=com.epocrates&#38;hl=en_US">https://play.google.com/store/apps/details?id=com.epocrates&#38;hl=en_US</a>.</div>
+  <div class="csl-entry">Fiske S T，Gilbert D T，Lindzey G，2010. Handbook of social psychology：v.1[M/OL]. 5th ed. John Wiley &#38; Sons. DOI:<a href="https://doi.org/10.1002/9780470561119">10.1002/9780470561119</a>.</div>
+  <div class="csl-entry">Fistek A，Jester E，Sonnenberg K，2017. Everybody’s got a little music in them: Using music therapy to connect, engage, and motivate[EB/OL]. （2017-07-12/15）. <a href="https://asa.confex.com/asa/2017/webprogramarchives/Session9517.html">https://asa.confex.com/asa/2017/webprogramarchives/Session9517.html</a>.</div>
+  <div class="csl-entry">Fogarty M，2016. How to diagram a sentence (absolute basics)[EB/OL]. YouTube. <a href="https://youtube.be/deiEY5Yq1ql">https://youtube.be/deiEY5Yq1ql</a>.</div>
+  <div class="csl-entry">Forman M，1975. One flew over the cuckoo’s nest[Z]. United Artists.</div>
+  <div class="csl-entry">Freud S，2010. The interpretation of dreams: The complete and definitive text[M]. Strachey J，trans. Basic Books.</div>
+  <div class="csl-entry">Fried D，Polyakova A，2018. Democratic defense against disinformation[R/OL]. Atlantic Council. <a href="https://www.atlantic.org/images/publications/Democratic_Defense_Against_Disinformation_FINAL.pdf">https://www.atlantic.org/images/publications/Democratic_Defense_Against_Disinformation_FINAL.pdf</a>.</div>
+  <div class="csl-entry">Gaiman N，2018. 100,000+ Rohingya refugees could be at serious risk during Bangladesh’s monsoon season. My fellow UNHCR Goodwill Ambassador Cate Blanchett is [Image attached][EB/OL]. （2018-03-22）. <a href="http://bit.ly/2JQxPAD">http://bit.ly/2JQxPAD</a>.</div>
+  <div class="csl-entry">GDJ，2018. Neural network deep learning prismatic[A/OL]. Openclipart，2018. <a href="https://openclipart.org/detail/309343/neural-network-deep-learning-prismatic">https://openclipart.org/detail/309343/neural-network-deep-learning-prismatic</a>.</div>
+  <div class="csl-entry">Giertz S，2018. Why you should make useless things[EB/OL]. TED Conferences. <a href="https://www.ted.com/talks/simone_giertz_why_you_should_make_useless_things">https://www.ted.com/talks/simone_giertz_why_you_should_make_useless_things</a>.</div>
+  <div class="csl-entry">Glass I，2011. Amusement park：443[EB/OL]//This American Life. WBEZ Chicago. <a href="https://www.thisamericanlife.org/radio-archives/episode/443/amusement-park">https://www.thisamericanlife.org/radio-archives/episode/443/amusement-park</a>.</div>
+  <div class="csl-entry">Gold M，1999. The complete social scientist: A Kurt Lewin reader[M/OL]. American Psychological Association. DOI:<a href="https://doi.org/10.1037/10319-000">10.1037/10319-000</a>.</div>
+  <div class="csl-entry">Goldberg J F，2018. Evaluating adverse drug effects[EB/OL]. American Psychiatric Association. <a href="https://education.psychiatry.org/Users/ProductDetails.aspx?ActivityID=6172">https://education.psychiatry.org/Users/ProductDetails.aspx?ActivityID=6172</a>.</div>
+  <div class="csl-entry">Goldin-Meadow S，2015. Gesture and cognitive development[M/OL]//Liben L S，Mueller U. Handbook of child psychology and developmental science：v.2. 7th ed. John Wiley &#38; Sons：339-380. DOI:<a href="https://doi.org/10.1002/9781118963418.childpsy209">10.1002/9781118963418.childpsy209</a>.</div>
+  <div class="csl-entry">Goldman C，2018. The complicated calibration of love, especially in adoption[N]. Chicago Tribune，2018-11-28.</div>
+  <div class="csl-entry">Google，[2020]. Google Maps directions for driving from La Paz, Bolivia, to Lima, Peru[CM/OL]. <a href="https://goo.gl/YYE3GR">https://goo.gl/YYE3GR</a>.</div>
+  <div class="csl-entry">Graham G，2019. Behaviorism[M/OL]//Zalta E N. The Stanford encyclopedia of philosophy. Summer 2019 ed. Stanford University. <a href="https://plato.stanford.edu/archives/sum2019/entries/behaviorism">https://plato.stanford.edu/archives/sum2019/entries/behaviorism</a>.</div>
+  <div class="csl-entry">Guarino B，2017. How will humanity react to alien life? Psychologists have some predictions[N/OL]. The Washington Post，2017-12-04. <a href="https://www.washingtonpost.com/news/speaking-of-science/wp/2017/12/04/how-will-humanity-react-to-alien-life-psychologists-have-some-predictions">https://www.washingtonpost.com/news/speaking-of-science/wp/2017/12/04/how-will-humanity-react-to-alien-life-psychologists-have-some-predictions</a>.</div>
+  <div class="csl-entry">Hacker Hughes J，2017. Military veteran psychological health and social care: Contemporary approaches[M]. Routledge.</div>
+  <div class="csl-entry">Harris L，2014. Instructional leadership perceptions and practices of elementary school leaders[D]. University of Virginia.</div>
+  <div class="csl-entry">Harwell M，2018. Don’t expect too much: The limited usefulness of common SES measures and a prescription for change[R/OL]. National Education Policy Center. <a href="https://nepc.colorado.edu/publication/SES">https://nepc.colorado.edu/publication/SES</a>.</div>
+  <div class="csl-entry">Heidegger M，2008. On the essence of truth[M]. Sallis J，trans.//Krell D F. Basic writings. Harper Perennial Modern Thought：111-138.</div>
+  <div class="csl-entry">Hess A，2019. Cats who take direction[N]. The New York Times，2019-01-03（C1）.</div>
+  <div class="csl-entry">Hiremath S C，Kumar S，Lu F，et al.，2016. Using metaphors to present concepts across different intellectual domains：9,367,592[P/OL]. 2016. <a href="http://patft.uspto.gov/netacgi/nph-Parser?patentnumber=9367592">http://patft.uspto.gov/netacgi/nph-Parser?patentnumber=9367592</a>.</div>
+  <div class="csl-entry">Ho H-K，2014. Teacher preparation for early childhood special education in Taiwan[PP/OL]. ERIC（2014）. <a href="https://files.eric.ed.gov/fulltext/ED545393.pdf">https://files.eric.ed.gov/fulltext/ED545393.pdf</a>.</div>
+  <div class="csl-entry">Hollander M M，2017. Resistance to authority: Methodological innovations and new lessons from the Milgram experiment：10289373[D]. University of Wisconsin–Madison.</div>
+  <div class="csl-entry">Housand B，2016. Game on! Integrating games and simulations in the classroom[A/OL]. 2016. <a href="https://www.slideshare.net/brianhousand/game-on-iagc-2016/">https://www.slideshare.net/brianhousand/game-on-iagc-2016/</a>.</div>
+  <div class="csl-entry">Huestegge S M，Raettig T，Huestegge L，2019. Are face-incongruent voices harder to process? Effects of face–voice gender incongruency on basic cognitive information processing[J/OL]. Experimental Psychology，2019. DOI:<a href="https://doi.org/10.1027/1618-3169/a000440">10.1027/1618-3169/a000440</a>.</div>
+  <div class="csl-entry">Hutcheson V H，2012. Dealing with dual differences: Social coping strategies of gifted and lesbian, gay, bisexual, transgender, and queer adolescents[D/OL]. The College of William &#38; Mary. <a href="https://digitalarchive.wm.edu/bitstream/handle/10288/16594/HutchesonVirginia2012.pdf">https://digitalarchive.wm.edu/bitstream/handle/10288/16594/HutchesonVirginia2012.pdf</a>.</div>
+  <div class="csl-entry">Jackson P，2001. The lord of the rings: The fellowship of the ring[Z/four-disc special extended ed. on DVD]. WingNut Films; The Saul Zaentz Company.</div>
+  <div class="csl-entry">Kalnay E，Kanamitsu M，Kistler R，et al.，1996. The NCEP/NCAR 40-year reanalysis project[J/OL]. Bulletin of the American Meteorological Society，77（3）：437-471. DOI:<a href="https://doi.org/fg6rf9">fg6rf9</a>.</div>
+  <div class="csl-entry">King M L Jr，1963. I have a dream[EB/OL]. American Rhetoric. <a href="https://www.americanrhetoric.com/speeches/mlkihaveadream.htm">https://www.americanrhetoric.com/speeches/mlkihaveadream.htm</a>.</div>
+  <div class="csl-entry">Klymkowsky M，2018. Can we talk scientifically about free will?[EB/OL]. （2018-09-15）. <a href="https://blogs.plos.org/scied/2018/09/15/can-we-talk-scientifically-about-free-will/">https://blogs.plos.org/scied/2018/09/15/can-we-talk-scientifically-about-free-will/</a>.</div>
+  <div class="csl-entry">KS in NJ，2019. From this article, it sounds like men are figuring something out that women have known forever. I know of many[N/OL]. The Washington Post，2019-01-15. <a href="https://wapo.st/2HDToGJ">https://wapo.st/2HDToGJ</a>.</div>
+  <div class="csl-entry">Lamar K，2017. Humble[Z]//Damn. Aftermath Entertainment; Interscope Records; Top Dawg Entertainment.</div>
+  <div class="csl-entry">Leuker C，Samartzidis L，Hertwig R，et al.，2018. When money talks: Judging risk and coercion in high-paying clinical trials[PP/OL]. PsyArXiv（2018）. DOI:<a href="https://doi.org/10.17605/OSF.IO/9P7CB">10.17605/OSF.IO/9P7CB</a>.</div>
+  <div class="csl-entry">Levenson H，2017. Accelerated experiental dynamic psychotherapy (AEDP) supervision[EB/educational DVD]. American Pychological Association. <a href="http://www.apa.org/pubs/videos/4310958.aspx">http://www.apa.org/pubs/videos/4310958.aspx</a>.</div>
+  <div class="csl-entry">Lewin K，1999. Group decision and social change[M/OL]//Gold M. The complete social scientist: A Kurt Lewin reader. American Psychological Association：265-284. DOI:<a href="https://doi.org/10.1037/10319-000">10.1037/10319-000</a>.</div>
+  <div class="csl-entry">Lichtenstein J，2013. Profile of veteran business owners: More young veterans appear to be starting businesses：1[R/OL]. U.S. Small Business Administration, Office of Advocacy. <a href="https://www.sba.org/sites/default/files/Issue%20Brief%201,%20Veteran%20Business%20Owners.pdf">https://www.sba.org/sites/default/files/Issue%20Brief%201,%20Veteran%20Business%20Owners.pdf</a>.</div>
+  <div class="csl-entry">Lilienfeld S O，2018. Archives of scientific psychology：Heterodox issues in psychology[J]. 6. 51-104.</div>
+  <div class="csl-entry">Lippincott T，Poindexter E K，2019. Emotion recognition as a function of facial cues: Implications for practice[A]. 2019.</div>
+  <div class="csl-entry">Lynch J，1995. Who shot Mr. Burns? (Part One)：Season 6, Episode 25[Z]//The Simpsons. Gracie Films; Twentieth Century Fox Film Corporation.</div>
+  <div class="csl-entry">Mack R，Spake G，2018. Citing open source images and formatting references for presentations[A/OL]. 2018. <a href="https://fnu.onelogin.com/login">https://fnu.onelogin.com/login</a>.</div>
+  <div class="csl-entry">Maddox S，Hurling J，Stewart E，et al.，2016. If mama ain’t happy, nobody’s happy: The effect of parental depression on mood dysregulation in children[Z]. New Orleans, LA, United States.</div>
+  <div class="csl-entry">Madigan S，2019. Narrative therapy[M/OL]. 2nd ed. American Psychological Association. DOI:<a href="https://doi.org/10.1037/00000131-000">10.1037/00000131-000</a>.</div>
+  <div class="csl-entry">Malle L，1987. Goodbye children[Z]. Nouvelles Éditions de Films.</div>
+  <div class="csl-entry">Martin Lillie C M，2016. Be kind to yourself: How self-compassion can improve your resiliency[EB/OL]. （2016-12-29）. <a href="https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/self-compassion-can-improve-your-resiliency/art-20267193">https://www.mayoclinic.org/healthy-lifestyle/adult-health/in-depth/self-compassion-can-improve-your-resiliency/art-20267193</a>.</div>
+  <div class="csl-entry">McCauley S M，Christiansen M H，2019. Language learning as language use: A cross-linguistic model of child language development[J/OL]. Psychological Review，126（1）：1-51. DOI:<a href="https://doi.org/10.1037/rev0000126">10.1037/rev0000126</a>.</div>
+  <div class="csl-entry">McCurry S，1985. Afghan girl[A/OL]. National Geographic，1985. <a href="https://www.nationalgeographic.com/magazine/national-geographic-magazine-50-years-of-covers/#/ngm-1985-jun-714.jpg">https://www.nationalgeographic.com/magazine/national-geographic-magazine-50-years-of-covers/#/ngm-1985-jun-714.jpg</a>.</div>
+  <div class="csl-entry">McDaniel S H，Salas E，Kazak A E，2018. American psychologist：The science of teamwork[J]. 73.</div>
+  <div class="csl-entry">Meadows D H，2008. Thinking in systems: A primer[M]. Chelsea Green Publishing.</div>
+  <div class="csl-entry">Mehrholz J，Pohl M，Platz T，et al.，2018. Electromechanical and robot-assisted arm training for improving activities of daily living, arm function, and arm muscle strength after stroke[J/OL]. Cochrane Database of Systematic Reviews，2018. DOI:<a href="https://doi.org/10.1002/14651858.CD006876.pub5">10.1002/14651858.CD006876.pub5</a>.</div>
+  <div class="csl-entry">Merriam-Webster，[2019a]. Merriam-Webster.com dictionary[M/OL]. <a href="https://www.merriam-webster.com/">https://www.merriam-webster.com/</a>.</div>
+  <div class="csl-entry">Merriam-Webster，[2019b]. Self-report[M/OL]//Merriam-Webster.com dictionary. <a href="https://www.merriam-webster.com/dictionary/self-report">https://www.merriam-webster.com/dictionary/self-report</a>.</div>
+  <div class="csl-entry">Mirabito L A，Heck N C，2016. Bringing LGBTQ youth theater into the spotlight[J/OL]. Psychology of Sexual Orientation and Gender Diversity，3（4）：499-500. DOI:<a href="https://doi.org/10.1037/sgd0000205">10.1037/sgd0000205</a>.</div>
+  <div class="csl-entry">Morey M C，2019. Physical activity and exercise in older adults[J/OL]. UpToDate，2019. <a href="https://www.uptodate.com/contents/physical-activity-and-exercise-in-older-adults">https://www.uptodate.com/contents/physical-activity-and-exercise-in-older-adults</a>.</div>
+  <div class="csl-entry">National Aeronautics and Space Administration [@nasa]，2018. I’m NASA Astronaut Scott Tingle. Ask me anything about adjusting to being back on Earth after my first spaceflight![EB/OL]. （2018-09-12）. <a href="https://www.reddit.com/r/IAmA/comments/9fagqy/im_nasa_astronaut_scott_tingle_ask_me_anything/">https://www.reddit.com/r/IAmA/comments/9fagqy/im_nasa_astronaut_scott_tingle_ask_me_anything/</a>.</div>
+  <div class="csl-entry">National Cancer Institute，2018. Facing forward: Life after cancer treatment：18-2424[R/OL]. U.S. Department of Health and Human Services, National Institutes of Health. <a href="https://www.cancer.gov/publications/patient-education/life-after-cancer-treatment.pdf">https://www.cancer.gov/publications/patient-education/life-after-cancer-treatment.pdf</a>.</div>
+  <div class="csl-entry">National Center for Education Statistics，2016. Fast response survey system (FRSS): Teacher’s use of educational technology in U.S. public schools, 2009：ICPSR 35531[DS/OL]. VV3. National Archive of Data on Arts and Culture（2016）. DOI:<a href="https://doi.org/10.3886/ICPSR335531.v3">10.3886/ICPSR335531.v3</a>.</div>
+  <div class="csl-entry">National Institute of Mental Health，2018. Suicide affects all ages, genders, races, and ethnicities. Check out these 5 Action Steps for Helping Someone in Emotional Pain[EB/OL]. （2018-11-28）. <a href="http://bit.ly/321Qstq">http://bit.ly/321Qstq</a>.</div>
+  <div class="csl-entry">National Nurses United，n.d. What employers should do to protect nurses from Zika[EB/OL]. <a href="https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika">https://www.nationalnursesunited.org/pages/what-employers-should-do-to-protect-rns-from-zika</a>.</div>
+  <div class="csl-entry">News From Science，2018. These frogs walk instead of hop. https://scimag.2KlriwH[EB/OL]. （2018-06-26）. <a href="https://www.facebook.com/ScienceNOW/videos/10155508587605108">https://www.facebook.com/ScienceNOW/videos/10155508587605108</a>.</div>
+  <div class="csl-entry">Oregan Youth Authority，2011. Recidivism outcomes[DS]. （2011）.</div>
+  <div class="csl-entry">O’Shea M，2018. Understanding proactive behavior in the workplace as a function of gender[A]. 2018.</div>
+  <div class="csl-entry">Pachur T，Scheibehenne B. Unpacking buyer-seller differences in valuation from experience: A cognitive modeling approach[J]. Psychonomic Bulletin &#38; Review.</div>
+  <div class="csl-entry">Pearson J，2018. Fat talk and its effects on state-based body image in women[EB/OL]. （2018-09-27/30）. <a href="http://bit.ly/2XGSThP">http://bit.ly/2XGSThP</a>.</div>
+  <div class="csl-entry">Perkins D，2018. <i>The good place</i> ends its remarkable second season with irrational hope, unexpected gifts, and a smile[EB/OL]. （2018-02-01）. <a href="https://www.avclub.com/the-good-place-ends-its-remarkable-second-season-with-i-1822649316">https://www.avclub.com/the-good-place-ends-its-remarkable-second-season-with-i-1822649316</a>.</div>
+  <div class="csl-entry">Pew Research Center，2018. American trends panel Wave 26[DS/OL]. （2018）. <a href="https://www.pewsocialtrends.org/dataset/american-trends-panel-wave-26/">https://www.pewsocialtrends.org/dataset/american-trends-panel-wave-26/</a>.</div>
+  <div class="csl-entry">Piaget J，1972. Intellectual evolution from adolescence to adulthood[J/OL]. Bliss J，Furth H，trans. Human Development，15（1）：1-12. DOI:<a href="https://doi.org/10.1159/00027/1225">10.1159/00027/1225</a>.</div>
+  <div class="csl-entry">Piaget J，Inhelder B，1966. The psychology of the child[M]. Quadrige.</div>
+  <div class="csl-entry">Piaget J，Inhelder B，1969. The psychology of the child[M]. Weaver H，trans. 2nd ed. Basic Books.</div>
+  <div class="csl-entry">Pridham K F，Limbo R，Schroeder M，2018. Guided participation in pediatric nursing practice: Relationship-based teaching and learning with parents, children and adolescents[M/OL]. Springer Publishing Company. <a href="http://a.co/0IAiVgt">http://a.co/0IAiVgt</a>.</div>
+  <div class="csl-entry">Project Implicit，n.d. Gender-Science IAT[EB/OL]. <a href="https://implicit.harvard.edi/implicit/takeatest.html">https://implicit.harvard.edi/implicit/takeatest.html</a>.</div>
+  <div class="csl-entry">Richardson F，1973. Brain and intelligence: The ecology of child development[M]. National Educational Press：113-123.</div>
+  <div class="csl-entry">Rinaldi J，2016. Photograph series of a boy who finds his footing after abuse by those he trusted[A/OL]. The Pulitzer Prizes，2016. <a href="https://www.pulitzer.org/winners/jessica-rinaldi">https://www.pulitzer.org/winners/jessica-rinaldi</a>.</div>
+  <div class="csl-entry">Rossman J，Palmer R，2015. Sorting through our space junk[A/OL]. World Science Festival，2015. <a href="https://www.worldsciencefestival.com/2015/11/space-junk-infographic/">https://www.worldsciencefestival.com/2015/11/space-junk-infographic/</a>.</div>
+  <div class="csl-entry">Rowling J K，2015. Harry Potter and the sorceror’s stone[M/OL]. Pottermore Publishing. <a href="http://bit.ly/2TcHchx">http://bit.ly/2TcHchx</a>.</div>
+  <div class="csl-entry">Sacchett C，Humphreys G W，1992. Calling a squirrel and squirrel but a canoe a wigwam: A category-specific deficit for artefactual objects and body parts[J/OL]. Cognitive Neuropsychology，9（1）：73-86. DOI:<a href="https://doi.org/d4vb59">d4vb59</a>.</div>
+  <div class="csl-entry">Sacchett C，Humphreys G W，2004. Calling a squirrel and squirrel but a canoe a wigwam: A category-specific deficit for artefactual objects and body parts[M]//Balota D A，Marsh E J. Cognitive psychology: Key readings in cognition. Psychology Press：100-108.</div>
+  <div class="csl-entry">Santos F，2019. Reframing refugee children’s stories[N/OL]. The New York Times，2019-01-11. <a href="https://nyt.ms/2Hlgjk3">https://nyt.ms/2Hlgjk3</a>.</div>
+  <div class="csl-entry">Schmid H-J，2017. Entrenchment and the psychology of language learning: How we reorganize and adapt linguistic knowledge[M/OL]. American Psychological Association; De Gruyter Mouton. DOI:<a href="https://doi.org/10.1037/15969-000">10.1037/15969-000</a>.</div>
+  <div class="csl-entry">Schur M，2018. Somewhere else[Z].</div>
+  <div class="csl-entry">Segaert A，Bauer A，2015. The extent and nature of veteran homelessness in Canada[R/OL]. Employment and Social Development Canada. <a href="https://www.canada.ca/en/employment-social-development/programs/communities/homelessness/publications-bulletins/veterans-report.html">https://www.canada.ca/en/employment-social-development/programs/communities/homelessness/publications-bulletins/veterans-report.html</a>.</div>
+  <div class="csl-entry">Shakespeare W，1995. Much ado about nothing[M]. Washington Square Press.</div>
+  <div class="csl-entry">Shore M F，2014. Marking time in the land of plenty: Reflections on mental health in the United States[J/OL]. American Journal of Orthopsychiatry，84（6）：611-618. DOI:<a href="https://doi.org/10.1037/h0100165">10.1037/h0100165</a>.</div>
+  <div class="csl-entry">Smithsonian’s National Zoo and Conservation Biology Institute，[2019]. Home[EB/OL]. [2019-07-22]. <a href="https://www.facebookcom/nationalzoo">https://www.facebookcom/nationalzoo</a>.</div>
+  <div class="csl-entry">SR Research，2016. Eyelink 1000 plus[CP/OL]. （2016）. <a href="https://www.sr-research.com/eyelink1000plus.html">https://www.sr-research.com/eyelink1000plus.html</a>.</div>
+  <div class="csl-entry">Stults-Kolehmainen M A，Sinha R，2015. The effects of stress on physical activity and exercise[PP/OL]. PubMed Central（2015）. <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3894304">https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3894304</a>.</div>
+  <div class="csl-entry">Tactile Labs，2015. Latero tactile display[CP/OL]. （2015）. <a href="https://www.tactilelabs.com/products/haptics/latero-tactile-display/">https://www.tactilelabs.com/products/haptics/latero-tactile-display/</a>.</div>
+  <div class="csl-entry">Tafoya N，Del Vecchio A，2005. Back to the future: An examination of the Native American Holocaust experience[M/OL]//McGoldrick M，Giordano J，Garcia-Preto N. Ethnicity and family therapy. 3rd ed. Guilford Press：55-63. <a href="http://a.co/36xRhBT">http://a.co/36xRhBT</a>.</div>
+  <div class="csl-entry">TED，2012. Brené Brown: Listening to shame[EB/OL]. YouTube. <a href="https://www.youtube.com/watch?v=psN1DORYYV0">https://www.youtube.com/watch?v=psN1DORYYV0</a>.</div>
+  <div class="csl-entry">Tellegen A，Ben-Porath Y S，2011. Minnesota Multiphasic Personality Inventory-2 Restructured Form (MMPI-2-RF): Technical Manual[R]. Pearson.</div>
+  <div class="csl-entry">The New York Public Library [@nypl]，[2019]. The raven[EB/OL]. [2019-04-16]. <a href="https://bitly.com/2FV8bu3">https://bitly.com/2FV8bu3</a>.</div>
+  <div class="csl-entry">Travis C B，White J W，2018. APA handbook of the psychology of women：v.1 History, theory, and battlegrounds[M/OL]. American Psychological Association. DOI:<a href="https://doi.org/10.1037/0000059-000">10.1037/0000059-000</a>.</div>
+  <div class="csl-entry">University of Oxford，2016. How do geckos walk on water?[EB/OL]. YouTube. <a href="https://www.youtube.com/watch?v=qm1xGfOZJc8">https://www.youtube.com/watch?v=qm1xGfOZJc8</a>.</div>
+  <div class="csl-entry">U.S. Census Bureau，[2019]. U.S. and world population clock[EB/OL]. [2019-07-03]. <a href="https://www.census.gov/popclock/">https://www.census.gov/popclock/</a>.</div>
+  <div class="csl-entry">U.S. Food and Drug Administration，2019. FDA authorizes first interoperable insulin pup intended to allow patients to customize treatment through their individual diabetes management devices[R/OL]. U.S. Food and Drug Administration. <a href="https://www.fds.gov/NewsEvents/Newsroom/PressAnnouncements/ucm631412.htm">https://www.fds.gov/NewsEvents/Newsroom/PressAnnouncements/ucm631412.htm</a>.</div>
+  <div class="csl-entry">U.S. Securities and Exchange Commission，2017. Agency financial report: Fiscal Year 2017[R/OL]. 2017. <a href="https://www.sec.gov/files/sec-2017-agency-financial-report.pdf">https://www.sec.gov/files/sec-2017-agency-financial-report.pdf</a>.</div>
+  <div class="csl-entry">van Beethoven L，2012. Symphony No. 3 in E-flat major[Z]//Beethoven: Complete Symphonies. Brilliant Classics.</div>
+  <div class="csl-entry">Vedantam S，2015. Hidden brain[EB/OL]. NPR. <a href="https://www.npr.org/series/423302056/hidden-brain">https://www.npr.org/series/423302056/hidden-brain</a>.</div>
+  <div class="csl-entry">Weinstock R，Leong G B，Silva J A，2003. Defining forensic psychiatry: Roles and responsibilities[M]//Rosner R. Principles and practise of forensic psychiatry. 2nd ed. CRC Press：7-13.</div>
+  <div class="csl-entry">Weir K，2017. Forgiveness can improve mental and physical health[J]. Monitor on Psychology，48（1）：30.</div>
+  <div class="csl-entry">White B，2018. I treasure every minute we spent together #koko [image attached][EB/OL]. （2018-06-21）. <a href="https://twitter.com/BettyMWhite/status/1009951892846227456">https://twitter.com/BettyMWhite/status/1009951892846227456</a>.</div>
+  <div class="csl-entry">Wood G，1930. American gothic[A/OL]. Chicago, IL, United States：Art Institute of Chicago，1930. <a href="https://www.artic.edu/aic/collections/artwork/6565">https://www.artic.edu/aic/collections/artwork/6565</a>.</div>
+  <div class="csl-entry">World Health Organization，2018. Questions and answers on immunization and vaccine safety[EB/OL]. （2018-03）. <a href="https://www.who.int/features/qa/84/en/">https://www.who.int/features/qa/84/en/</a>.</div>
+  <div class="csl-entry">World Health Organization，2019. International statistical classification of diseases and related health problems[R/OL]. 11th ed. World Health Organization. <a href="https://icd.who.int/">https://icd.who.int/</a>.</div>
+  <div class="csl-entry">Yoo J，Miyamoto Y，Rigotti A，et al.，2016. Linking positive affect to blood lipids: A cultural perspective[A]. 2016.</div>
+  <div class="csl-entry">Yousafzai M，2016. We are displaced: My journey and stories from refugee girls around the world[M].</div>
+  <div class="csl-entry">Zalta E N，2019. The Stanford encyclopedia of philosophy[M/OL]. Summer 2019 ed. Stanford University. <a href="https://plato.stanford.edu/archives/sum2019/">https://plato.stanford.edu/archives/sum2019/</a>.</div>
+  <div class="csl-entry">Zeitz MOCAA [@zeitzmocaa]，2018. Grade 6 learners from Parkfields Primary School in Hanover Park visited the museum for a tour and workshop hosted by[EB/OL]. （2018-11-26）. <a href="https://www.instagram.com/p/BqpHpjFBs3b">https://www.instagram.com/p/BqpHpjFBs3b</a>.</div>
+</div>
+
+<!-- PLACEHOLDER FOR WEBSITE - AFTER RESULT -->

--- a/src/GB-T-7714—2025（著者-出版年，双语，页码在括号内）/metadata.json
+++ b/src/GB-T-7714—2025（著者-出版年，双语，页码在括号内）/metadata.json
@@ -1,0 +1,30 @@
+{
+  "dir": "GB-T-7714—2025（著者-出版年，双语，页码在括号内）",
+  "file": "GB-T-7714—2025（著者-出版年，双语，页码在括号内）.csl",
+  "style_class": "in-text",
+  "title": "GB/T 7714—2025（著者-出版年，双语，页码在括号内）",
+  "id": "https://zotero-chinese.com/styles/GB-T-7714—2025（著者-出版年，双语，页码在括号内）",
+  "link_self": "https://zotero-chinese.com/styles/GB-T-7714—2025（著者-出版年，双语，页码在括号内）",
+  "link_template": "https://zotero-chinese.com/styles/GB-T-7714—2025（著者-出版年，双语）",
+  "link_documentation": "https://std.samr.gov.cn/gb/search/gbDetailed?id=4507EFE13D37CB6AE06397BE0A0A601F",
+  "author": [
+    {
+      "name": "Zeping Lee"
+    }
+  ],
+  "contributor": [],
+  "citation_format": "author-date",
+  "field": "generic-base",
+  "summary": "GB/T 7714—2025 信息与文献 参考文献著录规则（2026-07-01实施）。引注页码显示在括号内。",
+  "updated": "2026-07-31T16:06:19+08:00",
+  "citations": "（张三，2008，42）<br>\n张三 （2008，42）<br>\n（Jason，2008，42）<br>\nJason （2008，42）<br>\n",
+  "bibliography": "<div class=\"csl-bib-body maxoffset-0 second-field-align-false hangingindent-true\">\n  <div class=\"csl-entry\">张三，2008. 引注测试 2.1:1[M].</div>\n  <div class=\"csl-entry\">Jason J，2008. Citation test 2.1:2[M].</div>\n</div>",
+  "tags": [
+    "姓名小写",
+    "有标题",
+    "期刊全称",
+    "有URL",
+    "有DOI",
+    "无英文翻译"
+  ]
+}


### PR DESCRIPTION
## 新增样式 PR

请按照 [`CONTRIBUTING.md`](https://github.com/zotero-chinese/styles/blob/main/CONTRIBUTING.md) 的要求填写文件。

- 样式的官网链接：<https://openstd.samr.gov.cn/bzgk/std/newGbInfo?hcno=C6CE52E55AC09B9C79A20AEA77CEDD14>

- 样式的发布日期：2025-12-02

- 请上传一份格式规范文件：

  GB/T 7714—2025《信息与文献 参考文献著录规则》。

  官方标准信息平台注明该标准涉及版权保护，不提供标准全文阅读，因此未附标准全文；
  本样式是在原有的csl文件制作的，只增加了括号内页码的功能。
